### PR TITLE
Add custom errors

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,71 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// New returns an error that formats as the given text.
+// This function just wraps the errors.New from Golang standard errors library.
+func New(text string) error {
+	return errors.New(text)
+}
+
+// ErrTooShortToDecode indicates the length of user input is too short to be decoded.
+type ErrTooShortToDecode struct {
+	Type interface{}
+	Msg  string
+}
+
+// Error returns the type of receiver of decoder method and some additional message.
+func (e *ErrTooShortToDecode) Error() string {
+	return fmt.Sprintf("too short to decode as %T: %s", e.Type, e.Msg)
+}
+
+// ErrInvalidLength indicates the value in Length field is invalid.
+type ErrInvalidLength struct {
+	Type interface{}
+	Msg  string
+}
+
+// Error returns the type of receiver and some additional message.
+func (e *ErrInvalidLength) Error() string {
+	return fmt.Sprintf("got invalid Length in %T: %s", e.Type, e.Msg)
+}
+
+// ErrUnsupported indicates the value in Version field is invalid.
+type ErrUnsupported struct {
+	Type interface{}
+	Msg  string
+}
+
+// Error returns the type of receiver and some additional message.
+func (e *ErrUnsupported) Error() string {
+	return fmt.Sprintf("unsupported %T: %s", e.Type, e.Msg)
+}
+
+// ErrInvalidType indicates the value in Type/Code field is invalid.
+type ErrInvalidType struct {
+	Type   interface{}
+	Action string
+	Msg    string
+}
+
+// Error returns the type of receiver and some additional message.
+func (e *ErrInvalidType) Error() string {
+	return fmt.Sprintf("cannot %s as %T: %s", e.Action, e.Type, e.Msg)
+}
+
+// ErrReceiverNil indicates the receiver is nil.
+type ErrReceiverNil struct {
+	Type interface{}
+}
+
+// Error returns the type of receiver.
+func (e *ErrReceiverNil) Error() string {
+	return fmt.Sprintf("Receiver %T is nil", e.Type)
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,23 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// XXX - Implement!
+package errors
+
+import "testing"
+
+func raiseErrTooShortToDecode() error {
+	return &ErrTooShortToDecode{
+		Type: "",
+		Msg:  "too short to decode",
+	}
+}
+
+func TestErrors(t *testing.T) {
+	err := raiseErrTooShortToDecode()
+
+	if _, ok := err.(*ErrTooShortToDecode); !ok {
+		t.Fatalf("Failed to assert type: %T", err)
+	}
+}


### PR DESCRIPTION
To handle errors used in decoder/encoder functions in each protocol in common, added custom error definitions.
This also wraps `errors.New()` in Golang's standard `errors` package to keep imports simple,

