### PR TITLE
add data type qualified name

### DIFF
--- a/datatypes/qualified-name.go
+++ b/datatypes/qualified-name.go
@@ -1,0 +1,69 @@
+package datatypes
+
+import "encoding/binary"
+
+// QualifiedName contains a qualified name. It is, for example, used as BrowseName.
+// The name part of the QualifiedName is restricted to 512 characters.
+//
+// Specification: Part 3, 8.3
+type QualifiedName struct {
+	NamespaceIndex uint16
+	Name           *String
+}
+
+// NewQualifiedName creates a new QualifiedName.
+func NewQualifiedName(index uint16, name string) *QualifiedName {
+	value := []byte(name)
+	length := -1
+
+	if len(value) != 0 {
+		length = len(value)
+	}
+
+	q := &QualifiedName{
+		NamespaceIndex: index,
+		Name: &String{
+			Value:  value,
+			Length: int32(length),
+		},
+	}
+	return q
+}
+
+// DecodeQualifiedName decodes given bytes into QualifiedName.
+func DecodeQualifiedName(b []byte) (*QualifiedName, error) {
+	q := &QualifiedName{}
+	if err := q.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+
+	return q, nil
+}
+
+// DecodeFromBytes decodes given bytes into OPC UA QualifiedName.
+func (q *QualifiedName) DecodeFromBytes(b []byte) error {
+	q.NamespaceIndex = binary.LittleEndian.Uint16(b[:2])
+	q.Name = &String{}
+	return q.Name.DecodeFromBytes(b[2:])
+}
+
+// Serialize serializes QualifiedName into bytes.
+func (q *QualifiedName) Serialize() ([]byte, error) {
+	b := make([]byte, q.Len())
+	if err := q.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes QualifiedName into bytes.
+func (q *QualifiedName) SerializeTo(b []byte) error {
+	binary.LittleEndian.PutUint16(b[:2], q.NamespaceIndex)
+	return q.Name.SerializeTo(b[2:])
+}
+
+// Len returns the actual length of QualifiedName in int.
+func (q *QualifiedName) Len() int {
+	return 2 + q.Name.Len()
+}

--- a/datatypes/qualified-name_test.go
+++ b/datatypes/qualified-name_test.go
@@ -1,0 +1,119 @@
+package datatypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// test string "foobar"
+var foobar = []byte{0x01, 0x00, 0x06, 0x00, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72}
+
+func TestNewQualifiedName(t *testing.T) {
+	q := NewQualifiedName(1, "foo")
+	expected := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foo"),
+			Length: 3,
+		},
+	}
+	if diff := cmp.Diff(q, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestNewQualifiedNameEmptyName(t *testing.T) {
+	q := NewQualifiedName(1, "")
+	expected := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte{},
+			Length: -1,
+		},
+	}
+	if diff := cmp.Diff(q, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestDecodeQualifiedName(t *testing.T) {
+	q, err := DecodeQualifiedName(foobar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foobar"),
+			Length: 6,
+		},
+	}
+	if diff := cmp.Diff(q, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestQualifiedNameDecodeFromBytes(t *testing.T) {
+	q := &QualifiedName{}
+	if err := q.DecodeFromBytes(foobar); err != nil {
+		t.Fatal(err)
+	}
+	expected := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foobar"),
+			Length: 6,
+		},
+	}
+	if diff := cmp.Diff(q, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestQualifiedNameSerialize(t *testing.T) {
+	q := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foobar"),
+			Length: 6,
+		},
+	}
+	b, err := q.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(b, foobar); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestQualifiedNameSerializeTo(t *testing.T) {
+	q := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foobar"),
+			Length: 6,
+		},
+	}
+	b := make([]byte, q.Len())
+	if err := q.SerializeTo(b); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(b, foobar); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestQualifiedNameLen(t *testing.T) {
+	q := &QualifiedName{
+		NamespaceIndex: 1,
+		Name: &String{
+			Value:  []byte("foobar"),
+			Length: 6,
+		},
+	}
+	if q.Len() != 12 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 12, q.Len())
+	}
+}


### PR DESCRIPTION
I'm currently working on the `ReadRequest` service. It needs the type `ReadValueID`. This type needs the `QualifiedName` type.

Here is the first PR implementing the `QualifiedName` type. I tried to implement the same methods like you did with other types.

Let me know if you want anything changed / added / fixed.