### PR TITLE
add data type read value id

### DIFF
--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -325,7 +325,7 @@ func (s *StringNodeID) DecodeFromBytes(b []byte) error {
 	s.EncodingMask = b[0]
 	s.Namespace = binary.LittleEndian.Uint16(b[1:3])
 	s.Length = binary.LittleEndian.Uint32(b[3:7])
-	s.Identifier = b[7:]
+	s.Identifier = b[7 : 7+s.Length]
 	return nil
 }
 
@@ -344,7 +344,7 @@ func (s *StringNodeID) SerializeTo(b []byte) error {
 	b[0] = s.EncodingMask
 	binary.LittleEndian.PutUint16(b[1:3], s.Namespace)
 	binary.LittleEndian.PutUint32(b[3:7], s.Length)
-	copy(b[7:7+int(s.Length)], s.Identifier)
+	copy(b[7:7+s.Length], s.Identifier)
 
 	return nil
 }
@@ -490,7 +490,7 @@ func (o *OpaqueNodeID) DecodeFromBytes(b []byte) error {
 	o.EncodingMask = b[0]
 	o.Namespace = binary.LittleEndian.Uint16(b[1:3])
 	o.Length = binary.LittleEndian.Uint32(b[3:7])
-	o.Identifier = b[7 : 7+int(o.Length)]
+	o.Identifier = b[7 : 7+o.Length]
 
 	return nil
 }
@@ -510,7 +510,7 @@ func (o *OpaqueNodeID) SerializeTo(b []byte) error {
 	b[0] = o.EncodingMask
 	binary.LittleEndian.PutUint16(b[1:3], o.Namespace)
 	binary.LittleEndian.PutUint32(b[3:7], o.Length)
-	copy(b[7:7+int(o.Length)], o.Identifier)
+	copy(b[7:7+o.Length], o.Identifier)
 
 	return nil
 }

--- a/datatypes/qualified-name.go
+++ b/datatypes/qualified-name.go
@@ -13,18 +13,22 @@ type QualifiedName struct {
 
 // NewQualifiedName creates a new QualifiedName.
 func NewQualifiedName(index uint16, name string) *QualifiedName {
-	value := []byte(name)
-	length := -1
-
-	if len(value) != 0 {
-		length = len(value)
+	if len(name) == 0 {
+		q := &QualifiedName{
+			NamespaceIndex: index,
+			Name: &String{
+				Length: -1,
+			},
+		}
+		return q
 	}
 
+	value := []byte(name)
 	q := &QualifiedName{
 		NamespaceIndex: index,
 		Name: &String{
 			Value:  value,
-			Length: int32(length),
+			Length: int32(len(value)),
 		},
 	}
 	return q

--- a/datatypes/qualified-name_test.go
+++ b/datatypes/qualified-name_test.go
@@ -28,7 +28,6 @@ func TestNewQualifiedNameEmptyName(t *testing.T) {
 	expected := &QualifiedName{
 		NamespaceIndex: 1,
 		Name: &String{
-			Value:  []byte{},
 			Length: -1,
 		},
 	}

--- a/datatypes/read-value-id.go
+++ b/datatypes/read-value-id.go
@@ -1,0 +1,213 @@
+package datatypes
+
+import "encoding/binary"
+
+// IntegerID is a UInt32 that is used as an identifier, such as a handle.
+// All values, except for 0, are valid.
+//
+// Specification: Part 4, 7.14
+type IntegerID uint32
+
+// Identifiers assigned to Attributes.
+//
+// Specification: Part 6, A.1
+const (
+	IntegerIDNodeID IntegerID = iota + 1
+	IntegerIDNodeClass
+	IntegerIDBrowseName
+	IntegerIDDisplayName
+	IntegerIDDescription
+	IntegerIDWriteMask
+	IntegerIDUserWriteMask
+	IntegerIDIsAbstract
+	IntegerIDSymmetric
+	IntegerIDInverseName
+	IntegerIDContainsNoLoops
+	IntegerIDEventNotifier
+	IntegerIDValue
+	IntegerIDDataType
+	IntegerIDValueRank
+	IntegerIDArrayDimensions
+	IntegerIDAccessLevel
+	IntegerIDUserAccessLevel
+	IntegerIDMinimumSamplingInterval
+	IntegerIDHistorizing
+	IntegerIDExecutable
+	IntegerIDUserExecutable
+	IntegerIDDataTypeDefinition
+	IntegerIDRolePermissions
+	IntegerIDUserRolePermissions
+	IntegerIDAccessRestrictions
+	IntegerIDAccessLevelEx
+)
+
+// ReadValueID is an identifier for an item to read or to monitor.
+//
+// Specification: Part 4, 7.24
+type ReadValueID struct {
+	NodeID
+	AttributeID  IntegerID
+	IndexRange   *String
+	DataEncoding *QualifiedName
+}
+
+// DecodeReadValueID decodes given bytes into ReadValueID.
+func DecodeReadValueID(b []byte) (*ReadValueID, error) {
+	r := &ReadValueID{}
+	if err := r.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// DecodeFromBytes decodes given bytes into OPC UA ReadValueID.
+func (r *ReadValueID) DecodeFromBytes(b []byte) error {
+	nodeID, err := DecodeNodeID(b)
+	if err != nil {
+		return err
+	}
+	r.NodeID = nodeID
+	offset := r.NodeID.Len()
+
+	// attribute id
+	r.AttributeID = IntegerID(binary.LittleEndian.Uint32(b[offset:]))
+	offset += 4
+
+	// index range
+	r.IndexRange = &String{}
+	if err := r.IndexRange.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+	offset += r.IndexRange.Len()
+
+	// data encoding
+	r.DataEncoding = &QualifiedName{}
+	if err := r.DataEncoding.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Serialize serializes ReadValueID into bytes.
+func (r *ReadValueID) Serialize() ([]byte, error) {
+	b := make([]byte, r.Len())
+	if err := r.SerializeTo(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// SerializeTo serializes ReadValueID into bytes.
+func (r *ReadValueID) SerializeTo(b []byte) error {
+	// node id
+	if err := r.NodeID.SerializeTo(b); err != nil {
+		return err
+	}
+	offset := r.NodeID.Len()
+
+	// attribute id
+	binary.LittleEndian.PutUint32(b[offset:offset+4], uint32(r.AttributeID))
+	offset += 4
+
+	// index range
+	if err := r.IndexRange.SerializeTo(b[offset:]); err != nil {
+		return err
+	}
+	offset += r.IndexRange.Len()
+
+	// data encoding
+	return r.DataEncoding.SerializeTo(b[offset:])
+}
+
+// Len returns the actual length of ReadValueID in int.
+func (r *ReadValueID) Len() int {
+	return r.NodeID.Len() + 4 + r.IndexRange.Len() + r.DataEncoding.Len()
+}
+
+// ReadValueIDArray represents an array of ReadValueIDs.
+// It does not correspond to a certain type from the specification
+// but makes encoding and decoding easier.
+type ReadValueIDArray struct {
+	ArraySize    int32
+	ReadValueIDs []*ReadValueID
+}
+
+// NewReadValueIDArray creates a new ReadValueIDArray from multiple ReadValueIDs.
+func NewReadValueIDArray(ids []*ReadValueID) *ReadValueIDArray {
+	if ids == nil {
+		r := &ReadValueIDArray{
+			ArraySize: 0,
+		}
+		return r
+	}
+
+	r := &ReadValueIDArray{
+		ArraySize:    int32(len(ids)),
+		ReadValueIDs: ids,
+	}
+
+	return r
+}
+
+// DecodeReadValueIDArray decodes given bytes into ReadValueIDArray.
+func DecodeReadValueIDArray(b []byte) (*ReadValueIDArray, error) {
+	r := &ReadValueIDArray{}
+	if err := r.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// DecodeFromBytes decodes given bytes into ReadValueIDArray.
+func (r *ReadValueIDArray) DecodeFromBytes(b []byte) error {
+	r.ArraySize = int32(binary.LittleEndian.Uint32(b[:4]))
+	if r.ArraySize <= 0 {
+		return nil
+	}
+
+	offset := 4
+	for i := 1; i <= int(r.ArraySize); i++ {
+		id, err := DecodeReadValueID(b[offset:])
+		if err != nil {
+			return err
+		}
+		r.ReadValueIDs = append(r.ReadValueIDs, id)
+		offset += id.Len()
+	}
+
+	return nil
+}
+
+// Serialize serializes ReadValueIDArray into bytes.
+func (r *ReadValueIDArray) Serialize() ([]byte, error) {
+	b := make([]byte, r.Len())
+	if err := r.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes ReadValueIDArray into bytes.
+func (r *ReadValueIDArray) SerializeTo(b []byte) error {
+	var offset = 4
+	binary.LittleEndian.PutUint32(b[:4], uint32(r.ArraySize))
+
+	for _, id := range r.ReadValueIDs {
+		if err := id.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += id.Len()
+	}
+
+	return nil
+}
+
+// Len returns the actual length in int.
+func (r *ReadValueIDArray) Len() int {
+	l := 4
+	for _, id := range r.ReadValueIDs {
+		l += id.Len()
+	}
+	return l
+}

--- a/datatypes/read-value-id.go
+++ b/datatypes/read-value-id.go
@@ -99,29 +99,54 @@ func (r *ReadValueID) Serialize() ([]byte, error) {
 
 // SerializeTo serializes ReadValueID into bytes.
 func (r *ReadValueID) SerializeTo(b []byte) error {
+	offset := 0
+
 	// node id
-	if err := r.NodeID.SerializeTo(b); err != nil {
-		return err
+	if r.NodeID != nil {
+		if err := r.NodeID.SerializeTo(b); err != nil {
+			return err
+		}
+		offset += r.NodeID.Len()
 	}
-	offset := r.NodeID.Len()
 
 	// attribute id
 	binary.LittleEndian.PutUint32(b[offset:offset+4], uint32(r.AttributeID))
 	offset += 4
 
 	// index range
-	if err := r.IndexRange.SerializeTo(b[offset:]); err != nil {
-		return err
+	if r.IndexRange != nil {
+		if err := r.IndexRange.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += r.IndexRange.Len()
 	}
-	offset += r.IndexRange.Len()
 
 	// data encoding
-	return r.DataEncoding.SerializeTo(b[offset:])
+	if r.DataEncoding != nil {
+		return r.DataEncoding.SerializeTo(b[offset:])
+	}
+
+	return nil
 }
 
 // Len returns the actual length of ReadValueID in int.
 func (r *ReadValueID) Len() int {
-	return r.NodeID.Len() + 4 + r.IndexRange.Len() + r.DataEncoding.Len()
+	// attribute id
+	length := 4
+
+	if r.NodeID != nil {
+		length += r.NodeID.Len()
+	}
+
+	if r.IndexRange != nil {
+		length += r.IndexRange.Len()
+	}
+
+	if r.DataEncoding != nil {
+		length += r.DataEncoding.Len()
+	}
+
+	return length
 }
 
 // ReadValueIDArray represents an array of ReadValueIDs.

--- a/datatypes/read-value-id_test.go
+++ b/datatypes/read-value-id_test.go
@@ -1,0 +1,362 @@
+package datatypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDecodeReadValueID(t *testing.T) {
+	// sample qualified name from wireshark
+	b := []byte{
+		0x01, 0x00, 0xd0, 0x08, 0x0d, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff,
+		0xff, 0xff,
+	}
+
+	r, err := DecodeReadValueID(b)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := &ReadValueID{
+		NodeID:       NewFourByteNodeID(0, 2256),
+		AttributeID:  IntegerIDValue,
+		IndexRange:   NewString(""),
+		DataEncoding: NewQualifiedName(0, ""),
+	}
+	if diff := cmp.Diff(r, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDDecodeFromBytes(t *testing.T) {
+	r := &ReadValueID{}
+	// sample qualified name from wireshark
+	b := []byte{
+		0x01, 0x00, 0xd0, 0x08, 0x0d, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff,
+		0xff, 0xff,
+	}
+	if err := r.DecodeFromBytes(b); err != nil {
+		t.Error(err)
+	}
+	expected := &ReadValueID{
+		NodeID:       NewFourByteNodeID(0, 2256),
+		AttributeID:  IntegerIDValue,
+		IndexRange:   NewString(""),
+		DataEncoding: NewQualifiedName(0, ""),
+	}
+	if diff := cmp.Diff(r, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDSerialize(t *testing.T) {
+	expected := []byte{
+		0x01, 0x00, 0xd0, 0x08, 0x0d, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff,
+		0xff, 0xff,
+	}
+	r := &ReadValueID{
+		NodeID:       NewFourByteNodeID(0, 2256),
+		AttributeID:  IntegerIDValue,
+		IndexRange:   NewString(""),
+		DataEncoding: NewQualifiedName(0, ""),
+	}
+	b, err := r.Serialize()
+	if err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDSerializeTo(t *testing.T) {
+	expected := []byte{
+		0x01, 0x00, 0xd0, 0x08, 0x0d, 0x00, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff,
+		0xff, 0xff,
+	}
+	r := &ReadValueID{
+		NodeID:       NewFourByteNodeID(0, 2256),
+		AttributeID:  IntegerIDValue,
+		IndexRange:   NewString(""),
+		DataEncoding: NewQualifiedName(0, ""),
+	}
+	b := make([]byte, r.Len())
+	if err := r.SerializeTo(b); err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDLen(t *testing.T) {
+	r := &ReadValueID{
+		NodeID:       NewFourByteNodeID(0, 2256),
+		AttributeID:  IntegerIDValue,
+		IndexRange:   NewString(""),
+		DataEncoding: NewQualifiedName(0, ""),
+	}
+	if r.Len() != 18 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 18, r.Len())
+	}
+}
+
+func TestNewReadValueIDArray(t *testing.T) {
+	ids := []*ReadValueID{
+		&ReadValueID{
+			NodeID:       NewFourByteNodeID(0, 2256),
+			AttributeID:  IntegerIDValue,
+			IndexRange:   NewString(""),
+			DataEncoding: NewQualifiedName(0, ""),
+		},
+		&ReadValueID{
+			NodeID:       NewNumericNodeID(0, 2256),
+			AttributeID:  IntegerIDDataType,
+			IndexRange:   NewString("5:7"),
+			DataEncoding: NewQualifiedName(1, "something"),
+		},
+	}
+	arr := NewReadValueIDArray(ids)
+	expected := &ReadValueIDArray{
+		ArraySize:    2,
+		ReadValueIDs: ids,
+	}
+	if diff := cmp.Diff(arr, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestNewReadValueIDArrayNil(t *testing.T) {
+	arr := NewReadValueIDArray(nil)
+	expected := &ReadValueIDArray{
+		ArraySize: 0,
+	}
+	if diff := cmp.Diff(arr, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestDecodeReadValueIDArray(t *testing.T) {
+	in := []byte{
+		0x03, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x02, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x03, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x04, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff,
+	}
+	arr, err := DecodeReadValueIDArray(in)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := &ReadValueIDArray{
+		ArraySize: 3,
+		ReadValueIDs: []*ReadValueID{
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDNodeClass,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDBrowseName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDDisplayName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+		},
+	}
+	if diff := cmp.Diff(arr, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDArrayDecodeFromBytes(t *testing.T) {
+	arr := &ReadValueIDArray{}
+	in := []byte{
+		0x03, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x02, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x03, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x04, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff,
+	}
+	if err := arr.DecodeFromBytes(in); err != nil {
+		t.Error(err)
+	}
+	expected := &ReadValueIDArray{
+		ArraySize: 3,
+		ReadValueIDs: []*ReadValueID{
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDNodeClass,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDBrowseName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDDisplayName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+		},
+	}
+	if diff := cmp.Diff(arr, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDArraySerialize(t *testing.T) {
+	expected := []byte{
+		0x03, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x02, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x03, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x04, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff,
+	}
+	arr := &ReadValueIDArray{
+		ArraySize: 3,
+		ReadValueIDs: []*ReadValueID{
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDNodeClass,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDBrowseName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDDisplayName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+		},
+	}
+	b, err := arr.Serialize()
+	if err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDArraySerializeTo(t *testing.T) {
+	expected := []byte{
+		0x03, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x02, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x03, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff, 0x03, 0x01, 0x00, 0x0b,
+		0x00, 0x00, 0x00, 0x54, 0x65, 0x6d, 0x70, 0x65,
+		0x72, 0x61, 0x74, 0x75, 0x72, 0x65, 0x04, 0x00,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0xff, 0xff, 0xff, 0xff,
+	}
+	arr := &ReadValueIDArray{
+		ArraySize: 3,
+		ReadValueIDs: []*ReadValueID{
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDNodeClass,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDBrowseName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDDisplayName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+		},
+	}
+	b := make([]byte, arr.Len())
+	if err := arr.SerializeTo(b); err != nil {
+		t.Error(err)
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestReadValueIDArrayLen(t *testing.T) {
+	arr := &ReadValueIDArray{
+		ArraySize: 3,
+		ReadValueIDs: []*ReadValueID{
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDNodeClass,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDBrowseName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+			{
+				NodeID:       NewStringNodeID(1, "Temperature"),
+				AttributeID:  IntegerIDDisplayName,
+				IndexRange:   NewString(""),
+				DataEncoding: NewQualifiedName(0, ""),
+			},
+		},
+	}
+	if arr.Len() != 100 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 100, arr.Len())
+	}
+}


### PR DESCRIPTION
Here is the next data type `ReadValueID`. Since `ReadRequest` needs an array of `ReadValueID` I also added the type `ReadValueIDArray`. Very similar to your `StringArray`.

I also fixed some minor issues in `StringNodeID` and `QualifiedName`.

Thanks for accepting to use `go-cmp`.