### PR TITLE
add data type extension object

### DIFF
--- a/datatypes/extension-object.go
+++ b/datatypes/extension-object.go
@@ -1,0 +1,95 @@
+package datatypes
+
+// ExtensionObject is encoded as sequence of bytes prefixed by the NodeId of its DataTypeEncoding
+// and the number of bytes encoded.
+//
+// Specification: Part 6, 5.2.2.15
+type ExtensionObject struct {
+	TypeID       *ExpandedNodeID
+	EncodingMask byte
+	Body         *ByteString
+}
+
+// DecodeExtensionObject decodes given bytes into ExtensionObject.
+func DecodeExtensionObject(b []byte) (*ExtensionObject, error) {
+	e := &ExtensionObject{}
+	if err := e.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// DecodeFromBytes decodes given bytes into ExtensionObject.
+func (e *ExtensionObject) DecodeFromBytes(b []byte) error {
+	// type id
+	nodeID, err := DecodeExpandedNodeID(b)
+	if err != nil {
+		return err
+	}
+	e.TypeID = nodeID
+	offset := e.TypeID.Len()
+
+	// encoding mask
+	e.EncodingMask = b[offset]
+	offset += 1
+
+	// body
+	e.Body = &ByteString{}
+	if err := e.Body.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Serialize serializes ExtensionObject into bytes.
+func (e *ExtensionObject) Serialize() ([]byte, error) {
+	b := make([]byte, e.Len())
+	if err := e.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes ExtensionObject into bytes.
+func (e *ExtensionObject) SerializeTo(b []byte) error {
+	offset := 0
+
+	// type id
+	if e.TypeID != nil {
+		if err := e.TypeID.SerializeTo(b); err != nil {
+			return err
+		}
+		offset += e.TypeID.Len()
+	}
+
+	// encoding mask
+	b[offset] = e.EncodingMask
+	offset += 1
+
+	// body
+	if e.Body != nil {
+		if err := e.Body.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Len returns the actual length of ExtensionObject in int.
+func (e *ExtensionObject) Len() int {
+	// encoding mask byte
+	length := 1
+
+	if e.TypeID != nil {
+		length += e.TypeID.Len()
+	}
+
+	if e.Body != nil {
+		length += e.Body.Len()
+	}
+
+	return length
+}

--- a/datatypes/extension-object_test.go
+++ b/datatypes/extension-object_test.go
@@ -1,0 +1,143 @@
+package datatypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDecodeExtensionObject(t *testing.T) {
+	b := []byte{
+		0x01, 0x00, 0x41, 0x01, 0x01, 0x0d, 0x00, 0x00,
+		0x00, 0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f,
+		0x6e, 0x79, 0x6d, 0x6f, 0x75, 0x73,
+	}
+	e, err := DecodeExtensionObject(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := &ExtensionObject{
+		TypeID: &ExpandedNodeID{
+			NodeID: &FourByteNodeID{
+				EncodingMask: 0x01,
+				Namespace:    0,
+				Identifier:   321,
+			},
+		},
+		EncodingMask: 0x01,
+		Body: NewByteString([]byte{
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e,
+			0x79, 0x6d, 0x6f, 0x75, 0x73,
+		}),
+	}
+	if diff := cmp.Diff(e, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestExtensionObjectDecodeFromBytes(t *testing.T) {
+	b := []byte{
+		0x01, 0x00, 0x41, 0x01, 0x01, 0x0d, 0x00, 0x00,
+		0x00, 0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f,
+		0x6e, 0x79, 0x6d, 0x6f, 0x75, 0x73,
+	}
+	e := &ExtensionObject{}
+	if err := e.DecodeFromBytes(b); err != nil {
+		t.Fatal(err)
+	}
+	expected := &ExtensionObject{
+		TypeID: &ExpandedNodeID{
+			NodeID: &FourByteNodeID{
+				EncodingMask: 0x01,
+				Namespace:    0,
+				Identifier:   321,
+			},
+		},
+		EncodingMask: 0x01,
+		Body: NewByteString([]byte{
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e,
+			0x79, 0x6d, 0x6f, 0x75, 0x73,
+		}),
+	}
+	if diff := cmp.Diff(e, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestExtensionObjectSerialize(t *testing.T) {
+	e := &ExtensionObject{
+		TypeID: &ExpandedNodeID{
+			NodeID: &FourByteNodeID{
+				EncodingMask: 0x01,
+				Namespace:    0,
+				Identifier:   321,
+			},
+		},
+		EncodingMask: 0x01,
+		Body: NewByteString([]byte{
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e,
+			0x79, 0x6d, 0x6f, 0x75, 0x73,
+		}),
+	}
+	b, err := e.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{
+		0x01, 0x00, 0x41, 0x01, 0x01, 0x0d, 0x00, 0x00,
+		0x00, 0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f,
+		0x6e, 0x79, 0x6d, 0x6f, 0x75, 0x73,
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestExtensionObjectSerializeTo(t *testing.T) {
+	e := &ExtensionObject{
+		TypeID: &ExpandedNodeID{
+			NodeID: &FourByteNodeID{
+				EncodingMask: 0x01,
+				Namespace:    0,
+				Identifier:   321,
+			},
+		},
+		EncodingMask: 0x01,
+		Body: NewByteString([]byte{
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e,
+			0x79, 0x6d, 0x6f, 0x75, 0x73,
+		}),
+	}
+	b := make([]byte, e.Len())
+	if err := e.SerializeTo(b); err != nil {
+		t.Fatal(err)
+	}
+	expected := []byte{
+		0x01, 0x00, 0x41, 0x01, 0x01, 0x0d, 0x00, 0x00,
+		0x00, 0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f,
+		0x6e, 0x79, 0x6d, 0x6f, 0x75, 0x73,
+	}
+	if diff := cmp.Diff(b, expected); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestExtensionObjectLen(t *testing.T) {
+	e := &ExtensionObject{
+		TypeID: &ExpandedNodeID{
+			NodeID: &FourByteNodeID{
+				EncodingMask: 0x01,
+				Namespace:    0,
+				Identifier:   321,
+			},
+		},
+		EncodingMask: 0x01,
+		Body: NewByteString([]byte{
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e,
+			0x79, 0x6d, 0x6f, 0x75, 0x73,
+		}),
+	}
+	if e.Len() != 22 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 12, e.Len())
+	}
+}


### PR DESCRIPTION
Here is the next type `ExtensionObject`.

I need this for the `ActivateSessionRequest`. It has a field `UserIdentityToken` and its type is `ExtensionObject`.