### PR TITLE
Add constructors for custom errors

### DIFF
--- a/datatypes/bytestring.go
+++ b/datatypes/bytestring.go
@@ -50,7 +50,7 @@ func DecodeByteString(b []byte) (*ByteString, error) {
 // DecodeFromBytes decodes given bytes into OPC UA ByteString.
 func (s *ByteString) DecodeFromBytes(b []byte) error {
 	if len(b) < 4 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 4 bytes"}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 4 bytes")
 	}
 
 	s.Length = int32(binary.LittleEndian.Uint32(b[:4]))
@@ -75,7 +75,7 @@ func (s *ByteString) Serialize() ([]byte, error) {
 // SerializeTo serializes ByteString into bytes.
 func (s *ByteString) SerializeTo(b []byte) error {
 	if len(b) < s.Len() {
-		return &errors.ErrInvalidLength{s, "bytes should be longer"}
+		return errors.NewErrInvalidLength(s, "bytes should be longer")
 	}
 
 	binary.LittleEndian.PutUint32(b[:4], uint32(s.Length))

--- a/datatypes/guid.go
+++ b/datatypes/guid.go
@@ -58,7 +58,7 @@ func DecodeGUID(b []byte) (*GUID, error) {
 // DecodeFromBytes decodes given bytes into GUID.
 func (g *GUID) DecodeFromBytes(b []byte) error {
 	if len(b) < 16 {
-		return &errors.ErrTooShortToDecode{g, "should be 16 bytes"}
+		return errors.NewErrTooShortToDecode(g, "should be 16 bytes")
 	}
 
 	g.Data1 = binary.LittleEndian.Uint32(b[:4])

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -54,11 +54,7 @@ func DecodeNodeID(b []byte) (NodeID, error) {
 	case TypeOpaque:
 		n = &OpaqueNodeID{}
 	default:
-		return nil, &errors.ErrInvalidType{
-			Type:   encodingMask,
-			Action: "decode",
-			Msg:    "got undefined type",
-		}
+		return nil, errors.NewErrInvalidType(encodingMask, "decode", "got undefined type")
 	}
 
 	if err := n.DecodeFromBytes(b); err != nil {
@@ -89,7 +85,7 @@ func NewTwoByteNodeID(val byte) *TwoByteNodeID {
 // DecodeFromBytes decodes given bytes into TwoByteNodeID.
 func (t *TwoByteNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 2 {
-		return &errors.ErrTooShortToDecode{t, "should be 2 bytes"}
+		return errors.NewErrTooShortToDecode(t, "should be 2 bytes")
 	}
 
 	t.EncodingMask = b[0]
@@ -164,7 +160,7 @@ func NewFourByteNodeID(idx uint8, val uint16) *FourByteNodeID {
 // DecodeFromBytes decodes given bytes into FourByteNodeID.
 func (f *FourByteNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 4 {
-		return &errors.ErrTooShortToDecode{f, "should be 4 bytes"}
+		return errors.NewErrTooShortToDecode(f, "should be 4 bytes")
 	}
 
 	f.EncodingMask = b[0]
@@ -241,7 +237,7 @@ func NewNumericNodeID(idx uint16, val uint32) *NumericNodeID {
 // DecodeFromBytes decodes given bytes into NumericNodeID.
 func (n *NumericNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 7 {
-		return &errors.ErrTooShortToDecode{n, "should be 7 bytes"}
+		return errors.NewErrTooShortToDecode(n, "should be 7 bytes")
 	}
 
 	n.EncodingMask = b[0]
@@ -319,7 +315,7 @@ func NewStringNodeID(idx uint16, val string) *StringNodeID {
 // DecodeFromBytes decodes given bytes into StringNodeID.
 func (s *StringNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 7 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 7 bytes"}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 7 bytes")
 	}
 
 	s.EncodingMask = b[0]
@@ -403,7 +399,7 @@ func NewGUIDNodeID(idx uint16, val string) *GUIDNodeID {
 // DecodeFromBytes decodes given bytes into GUIDNodeID.
 func (g *GUIDNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 19 {
-		return &errors.ErrTooShortToDecode{g, "should be 19 bytes"}
+		return errors.NewErrTooShortToDecode(g, "should be 19 bytes")
 	}
 
 	g.EncodingMask = b[0]
@@ -484,7 +480,7 @@ func NewOpaqueNodeID(idx uint16, val []byte) *OpaqueNodeID {
 // DecodeFromBytes decodes given bytes into OpaqueNodeID.
 func (o *OpaqueNodeID) DecodeFromBytes(b []byte) error {
 	if len(b) < 7 {
-		return &errors.ErrTooShortToDecode{o, "should be longer than 7 bytes"}
+		return errors.NewErrTooShortToDecode(o, "should be longer than 7 bytes")
 	}
 
 	o.EncodingMask = b[0]

--- a/datatypes/string.go
+++ b/datatypes/string.go
@@ -47,7 +47,7 @@ func DecodeString(b []byte) (*String, error) {
 // DecodeFromBytes decodes given bytes into OPC UA String.
 func (s *String) DecodeFromBytes(b []byte) error {
 	if len(b) < 4 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 4 bytes"}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 4 bytes")
 	}
 
 	s.Length = int32(binary.LittleEndian.Uint32(b[:4]))
@@ -71,7 +71,7 @@ func (s *String) Serialize() ([]byte, error) {
 // SerializeTo serializes String into bytes.
 func (s *String) SerializeTo(b []byte) error {
 	if len(b) < s.Len() {
-		return &errors.ErrInvalidLength{s, "bytes should be longer"}
+		return errors.NewErrInvalidLength(s, "bytes should be longer")
 	}
 
 	binary.LittleEndian.PutUint32(b[:4], uint32(s.Length))

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,47 +17,82 @@ func New(text string) error {
 
 // ErrTooShortToDecode indicates the length of user input is too short to be decoded.
 type ErrTooShortToDecode struct {
-	Type interface{}
-	Msg  string
+	Type    interface{}
+	Message string
+}
+
+// NewErrTooShortToDecode creates a ErrTooShortToDecode.
+func NewErrTooShortToDecode(decodedType interface{}, msg string) *ErrTooShortToDecode {
+	return &ErrTooShortToDecode{
+		Type:    decodedType,
+		Message: msg,
+	}
 }
 
 // Error returns the type of receiver of decoder method and some additional message.
 func (e *ErrTooShortToDecode) Error() string {
-	return fmt.Sprintf("too short to decode as %T: %s", e.Type, e.Msg)
+	return fmt.Sprintf("too short to decode as %T: %s", e.Type, e.Message)
 }
 
 // ErrInvalidLength indicates the value in Length field is invalid.
 type ErrInvalidLength struct {
-	Type interface{}
-	Msg  string
+	Type    interface{}
+	Message string
+}
+
+// NewErrInvalidLength creates a ErrInvalidLength.
+func NewErrInvalidLength(rcvType interface{}, msg string) *ErrInvalidLength {
+	return &ErrInvalidLength{
+		Type:    rcvType,
+		Message: msg,
+	}
 }
 
 // Error returns the type of receiver and some additional message.
 func (e *ErrInvalidLength) Error() string {
-	return fmt.Sprintf("got invalid Length in %T: %s", e.Type, e.Msg)
+	return fmt.Sprintf("got invalid Length in %T: %s", e.Type, e.Message)
 }
 
 // ErrUnsupported indicates the value in Version field is invalid.
 type ErrUnsupported struct {
-	Type interface{}
-	Msg  string
+	Type    interface{}
+	Message string
+}
+
+// NewErrUnsupported creates a ErrUnsupported.
+func NewErrUnsupported(unsupportedType interface{}, msg string) *ErrUnsupported {
+	return &ErrUnsupported{
+		Type:    unsupportedType,
+		Message: msg,
+	}
 }
 
 // Error returns the type of receiver and some additional message.
 func (e *ErrUnsupported) Error() string {
-	return fmt.Sprintf("unsupported %T: %s", e.Type, e.Msg)
+	return fmt.Sprintf("unsupported %T: %s", e.Type, e.Message)
 }
 
 // ErrInvalidType indicates the value in Type/Code field is invalid.
 type ErrInvalidType struct {
-	Type   interface{}
-	Action string
-	Msg    string
+	Type    interface{}
+	Action  string
+	Message string
+}
+
+// NewErrInvalidType creates a ErrInvalidType.
+//
+// The parameter action is the action taken when this error is raised(e.g., "decode").
+func NewErrInvalidType(invalidType interface{}, action, msg string) *ErrInvalidType {
+	return &ErrInvalidType{
+		Type:    invalidType,
+		Action:  action,
+		Message: msg,
+	}
 }
 
 // Error returns the type of receiver and some additional message.
 func (e *ErrInvalidType) Error() string {
-	return fmt.Sprintf("cannot %s as %T: %s", e.Action, e.Type, e.Msg)
+	return fmt.Sprintf("cannot %s as %T: %s", e.Action, e.Type, e.Message)
 }
 
 // ErrReceiverNil indicates the receiver is nil.
@@ -65,7 +100,14 @@ type ErrReceiverNil struct {
 	Type interface{}
 }
 
+// NewErrReceiverNil creates a ErrReceiverNil.
+func NewErrReceiverNil(rcvType interface{}) *ErrReceiverNil {
+	return &ErrReceiverNil{
+		Type: rcvType,
+	}
+}
+
 // Error returns the type of receiver.
 func (e *ErrReceiverNil) Error() string {
-	return fmt.Sprintf("Receiver %T is nil", e.Type)
+	return fmt.Sprintf("Receiver %T is nil.", e.Type)
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,19 +5,121 @@
 // XXX - Implement!
 package errors
 
-import "testing"
+import (
+	"testing"
 
-func raiseErrTooShortToDecode() error {
-	return &ErrTooShortToDecode{
-		Type: "",
-		Msg:  "too short to decode",
-	}
+	"github.com/google/go-cmp/cmp"
+)
+
+var dummy string
+
+func TestNewErrors(t *testing.T) {
+	t.Run("ErrTooShortToDecode", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrTooShortToDecode(dummy, "should be XXX.")
+		expected := &ErrTooShortToDecode{
+			Type:    dummy,
+			Message: "should be XXX.",
+		}
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrInvalidLength", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrInvalidLength(dummy, "should be XXX.")
+		expected := &ErrInvalidLength{
+			Type:    dummy,
+			Message: "should be XXX.",
+		}
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrUnsupported", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrUnsupported(dummy, "XXX is not supported yet.")
+		expected := &ErrUnsupported{
+			Type:    dummy,
+			Message: "XXX is not supported yet.",
+		}
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrInvalidType", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrInvalidType(dummy, "decode", "something's wrong.")
+		expected := &ErrInvalidType{
+			Type:    dummy,
+			Action:  "decode",
+			Message: "something's wrong.",
+		}
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrReceiverNil", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrReceiverNil(dummy)
+		expected := &ErrReceiverNil{
+			Type: dummy,
+		}
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
 }
 
-func TestErrors(t *testing.T) {
-	err := raiseErrTooShortToDecode()
+func TestError(t *testing.T) {
+	t.Run("ErrTooShortToDecode", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrTooShortToDecode(dummy, "should be XXX.").Error()
+		expected := "too short to decode as string: should be XXX."
 
-	if _, ok := err.(*ErrTooShortToDecode); !ok {
-		t.Fatalf("Failed to assert type: %T", err)
-	}
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrInvalidLength", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrInvalidLength(dummy, "should be XXX.").Error()
+		expected := "got invalid Length in string: should be XXX."
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrUnsupported", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrUnsupported(dummy, "XXX is not supported yet.").Error()
+		expected := "unsupported string: XXX is not supported yet."
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrInvalidType", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrInvalidType(dummy, "decode", "something's wrong.").Error()
+		expected := "cannot decode as string: something's wrong."
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("ErrReceiverNil", func(t *testing.T) {
+		t.Parallel()
+		e := NewErrReceiverNil(dummy).Error()
+		expected := "Receiver string is nil."
+
+		if diff := cmp.Diff(e, expected); diff != "" {
+			t.Error(diff)
+		}
+	})
 }

--- a/services/channel-security-token.go
+++ b/services/channel-security-token.go
@@ -45,7 +45,7 @@ func DecodeChannelSecurityToken(b []byte) (*ChannelSecurityToken, error) {
 // DecodeFromBytes decodes given bytes into ChannelSecurityToken.
 func (c *ChannelSecurityToken) DecodeFromBytes(b []byte) error {
 	if len(b) < 20 {
-		return &errors.ErrTooShortToDecode{c, "should be longer than 20 bytes"}
+		return errors.NewErrTooShortToDecode(c, "should be longer than 20 bytes")
 	}
 
 	c.ChannelID = binary.LittleEndian.Uint32(b[0:4])

--- a/services/create-session-request.go
+++ b/services/create-session-request.go
@@ -69,7 +69,7 @@ func DecodeCreateSessionRequest(b []byte) (*CreateSessionRequest, error) {
 // DecodeFromBytes decodes given bytes into CreateSessionRequest.
 func (c *CreateSessionRequest) DecodeFromBytes(b []byte) error {
 	if len(b) < 120 {
-		return &errors.ErrTooShortToDecode{c, "should be longer than 120 bytes."}
+		return errors.NewErrTooShortToDecode(c, "should be longer than 120 bytes.")
 	}
 
 	var offset = 0

--- a/services/create-session-response.go
+++ b/services/create-session-response.go
@@ -68,7 +68,7 @@ func DecodeCreateSessionResponse(b []byte) (*CreateSessionResponse, error) {
 // DecodeFromBytes decodes given bytes into CreateSessionResponse.
 func (c *CreateSessionResponse) DecodeFromBytes(b []byte) error {
 	if len(b) < 120 {
-		return &errors.ErrTooShortToDecode{c, "should be longer than 120 bytes."}
+		return errors.NewErrTooShortToDecode(c, "should be longer than 120 bytes.")
 	}
 
 	var offset = 0

--- a/services/endpoint-description.go
+++ b/services/endpoint-description.go
@@ -53,7 +53,7 @@ func DecodeEndpointDescription(b []byte) (*EndpointDescription, error) {
 // DecodeFromBytes decodes given bytes into EndpointDescription.
 func (e *EndpointDescription) DecodeFromBytes(b []byte) error {
 	if len(b) < 6 {
-		return &errors.ErrTooShortToDecode{e, "should be longer than 6 bytes."}
+		return errors.NewErrTooShortToDecode(e, "should be longer than 6 bytes.")
 	}
 
 	var offset = 0
@@ -234,7 +234,7 @@ func DecodeEndpointDescriptionArray(b []byte) (*EndpointDescriptionArray, error)
 // DecodeFromBytes decodes given bytes into EndpointDescriptionArray.
 func (e *EndpointDescriptionArray) DecodeFromBytes(b []byte) error {
 	if len(b) < 4 {
-		return &errors.ErrTooShortToDecode{e, "should be longer than 4 bytes."}
+		return errors.NewErrTooShortToDecode(e, "should be longer than 4 bytes.")
 	}
 
 	e.ArraySize = int32(binary.LittleEndian.Uint32(b[:4]))

--- a/services/get-endpoints-request.go
+++ b/services/get-endpoints-request.go
@@ -72,7 +72,7 @@ func DecodeGetEndpointsRequest(b []byte) (*GetEndpointsRequest, error) {
 // DecodeFromBytes decodes given bytes into GetEndpointsRequest.
 func (g *GetEndpointsRequest) DecodeFromBytes(b []byte) error {
 	if len(b) < 16 {
-		return &errors.ErrTooShortToDecode{g, "should be longer than 16 bytes"}
+		return errors.NewErrTooShortToDecode(g, "should be longer than 16 bytes")
 	}
 
 	var offset = 0

--- a/services/get-endpoints-response.go
+++ b/services/get-endpoints-response.go
@@ -63,7 +63,7 @@ func DecodeGetEndpointsResponse(b []byte) (*GetEndpointsResponse, error) {
 // DecodeFromBytes decodes given bytes into GetEndpointsResponse.
 func (g *GetEndpointsResponse) DecodeFromBytes(b []byte) error {
 	if len(b) < 16 {
-		return &errors.ErrTooShortToDecode{g, "should be longer than 16 bytes"}
+		return errors.NewErrTooShortToDecode(g, "should be longer than 16 bytes")
 	}
 
 	var offset = 0

--- a/services/open-secure-channel-request.go
+++ b/services/open-secure-channel-request.go
@@ -95,7 +95,7 @@ func DecodeOpenSecureChannelRequest(b []byte) (*OpenSecureChannelRequest, error)
 // DecodeFromBytes decodes given bytes into OpenSecureChannelRequest.
 func (o *OpenSecureChannelRequest) DecodeFromBytes(b []byte) error {
 	if len(b) < 16 {
-		return &errors.ErrTooShortToDecode{o, "should be longer than 16 bytes"}
+		return errors.NewErrTooShortToDecode(o, "should be longer than 16 bytes")
 	}
 
 	var offset = 0

--- a/services/open-secure-channel-response.go
+++ b/services/open-secure-channel-response.go
@@ -63,7 +63,7 @@ func DecodeOpenSecureChannelResponse(b []byte) (*OpenSecureChannelResponse, erro
 // DecodeFromBytes decodes given bytes into OpenSecureChannelResponse.
 func (o *OpenSecureChannelResponse) DecodeFromBytes(b []byte) error {
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{o, "should be longer than 16 bytes"}
+		return errors.NewErrTooShortToDecode(o, "should be longer than 16 bytes")
 	}
 
 	var offset = 0

--- a/services/service.go
+++ b/services/service.go
@@ -35,11 +35,11 @@ func Decode(b []byte) (Service, error) {
 
 	typeID, err := datatypes.DecodeExpandedNodeID(b)
 	if err != nil {
-		return nil, &errors.ErrUnsupported{typeID, "cannot decode TypeID."}
+		return nil, errors.NewErrUnsupported(typeID, "cannot decode TypeID.")
 	}
 	n, ok := typeID.NodeID.(*datatypes.FourByteNodeID)
 	if !ok {
-		return nil, &errors.ErrUnsupported{typeID.NodeID, "should be FourByteNodeID."}
+		return nil, errors.NewErrUnsupported(typeID.NodeID, "should be FourByteNodeID.")
 	}
 
 	switch n.Identifier {
@@ -56,7 +56,7 @@ func Decode(b []byte) (Service, error) {
 	case ServiceTypeCreateSessionResponse:
 		s = &CreateSessionResponse{}
 	default:
-		return nil, &errors.ErrUnsupported{n.Identifier, "unsupported or not implemented yet."}
+		return nil, errors.NewErrUnsupported(n.Identifier, "unsupported or not implemented yet.")
 	}
 
 	if err := s.DecodeFromBytes(b); err != nil {

--- a/services/signature-data.go
+++ b/services/signature-data.go
@@ -40,7 +40,7 @@ func DecodeSignatureData(b []byte) (*SignatureData, error) {
 // DecodeFromBytes decodes given bytes into SignatureData.
 func (s *SignatureData) DecodeFromBytes(b []byte) error {
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 8 bytes."}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 8 bytes.")
 	}
 	var offset = 0
 	s.Algorithm = &datatypes.String{}

--- a/services/signed-software-certificate.go
+++ b/services/signed-software-certificate.go
@@ -41,7 +41,7 @@ func DecodeSignedSoftwareCertificate(b []byte) (*SignedSoftwareCertificate, erro
 // DecodeFromBytes decodes given bytes into SignedSoftwareCertificate.
 func (s *SignedSoftwareCertificate) DecodeFromBytes(b []byte) error {
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 8 bytes."}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 8 bytes.")
 	}
 	var offset = 0
 	s.CertificateData = &datatypes.ByteString{}

--- a/uacp/acknowledge.go
+++ b/uacp/acknowledge.go
@@ -54,7 +54,7 @@ func DecodeAcknowledge(b []byte) (*Acknowledge, error) {
 func (a *Acknowledge) DecodeFromBytes(b []byte) error {
 	var err error
 	if len(b) < 20 {
-		return &errors.ErrTooShortToDecode{a, "should be longer than 20 bytes"}
+		return errors.NewErrTooShortToDecode(a, "should be longer than 20 bytes")
 	}
 
 	a.Header, err = DecodeHeader(b)
@@ -85,7 +85,7 @@ func (a *Acknowledge) Serialize() ([]byte, error) {
 // TODO: add error handling.
 func (a *Acknowledge) SerializeTo(b []byte) error {
 	if a == nil {
-		return &errors.ErrReceiverNil{a}
+		return errors.NewErrReceiverNil(a)
 	}
 	a.Header.Payload = make([]byte, a.Len()-8)
 

--- a/uacp/error.go
+++ b/uacp/error.go
@@ -79,7 +79,7 @@ func DecodeError(b []byte) (*Error, error) {
 func (e *Error) DecodeFromBytes(b []byte) error {
 	var err error
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{e, "should be longer than 8 bytes"}
+		return errors.NewErrTooShortToDecode(e, "should be longer than 8 bytes")
 	}
 
 	e.Header, err = DecodeHeader(b)
@@ -106,7 +106,7 @@ func (e *Error) Serialize() ([]byte, error) {
 // TODO: add error handling.
 func (e *Error) SerializeTo(b []byte) error {
 	if e == nil {
-		return &errors.ErrReceiverNil{e}
+		return errors.NewErrReceiverNil(e)
 	}
 	e.Header.Payload = make([]byte, e.Len()-8)
 

--- a/uacp/generic.go
+++ b/uacp/generic.go
@@ -44,7 +44,7 @@ func DecodeGeneric(b []byte) (*Generic, error) {
 func (g *Generic) DecodeFromBytes(b []byte) error {
 	var err error
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{g, "should be longer than 8 bytes"}
+		return errors.NewErrTooShortToDecode(g, "should be longer than 8 bytes")
 	}
 
 	g.Header, err = DecodeHeader(b)

--- a/uacp/header.go
+++ b/uacp/header.go
@@ -66,7 +66,7 @@ func DecodeHeader(b []byte) (*Header, error) {
 // DecodeFromBytes decodes given bytes into OPC UA Header.
 func (h *Header) DecodeFromBytes(b []byte) error {
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{h, "should be longer than 8 bytes"}
+		return errors.NewErrTooShortToDecode(h, "should be longer than 8 bytes")
 	}
 
 	h.MessageType = utils.Uint24To32(b[:3])
@@ -90,7 +90,7 @@ func (h *Header) Serialize() ([]byte, error) {
 // TODO: add error handling.
 func (h *Header) SerializeTo(b []byte) error {
 	if h == nil {
-		return &errors.ErrReceiverNil{h}
+		return errors.NewErrReceiverNil(h)
 	}
 	copy(b[:3], utils.Uint32To24(h.MessageType))
 	b[3] = h.ChunkType

--- a/uacp/hello.go
+++ b/uacp/hello.go
@@ -57,7 +57,7 @@ func DecodeHello(b []byte) (*Hello, error) {
 func (h *Hello) DecodeFromBytes(b []byte) error {
 	var err error
 	if len(b) < 24 {
-		return &errors.ErrTooShortToDecode{h, "should be longer than 24 bytes"}
+		return errors.NewErrTooShortToDecode(h, "should be longer than 24 bytes")
 	}
 
 	h.Header, err = DecodeHeader(b)
@@ -89,7 +89,7 @@ func (h *Hello) Serialize() ([]byte, error) {
 // SerializeTo serializes OPC UA Hello into given bytes.
 func (h *Hello) SerializeTo(b []byte) error {
 	if h == nil {
-		return &errors.ErrReceiverNil{h}
+		return errors.NewErrReceiverNil(h)
 	}
 	h.Header.Payload = make([]byte, h.Len()-8)
 

--- a/uacp/reverse-hello.go
+++ b/uacp/reverse-hello.go
@@ -48,7 +48,7 @@ func DecodeReverseHello(b []byte) (*ReverseHello, error) {
 func (r *ReverseHello) DecodeFromBytes(b []byte) error {
 	var err error
 	if len(b) < 8 {
-		return &errors.ErrTooShortToDecode{r, "should be longer than 8 bytes"}
+		return errors.NewErrTooShortToDecode(r, "should be longer than 8 bytes")
 	}
 
 	r.Header, err = DecodeHeader(b)
@@ -81,7 +81,7 @@ func (r *ReverseHello) Serialize() ([]byte, error) {
 // SerializeTo serializes OPC UA ReverseHello into given bytes.
 func (r *ReverseHello) SerializeTo(b []byte) error {
 	if r == nil {
-		return &errors.ErrReceiverNil{r}
+		return errors.NewErrReceiverNil(r)
 	}
 	r.Header.Payload = make([]byte, r.Len()-8)
 

--- a/uasc/asymmetric-security-header.go
+++ b/uasc/asymmetric-security-header.go
@@ -45,7 +45,7 @@ func DecodeAsymmetricSecurityHeader(b []byte) (*AsymmetricSecurityHeader, error)
 func (a *AsymmetricSecurityHeader) DecodeFromBytes(b []byte) error {
 	l := len(b)
 	if l < 12 {
-		return &errors.ErrTooShortToDecode{a, "should be longer than 12 bytes"}
+		return errors.NewErrTooShortToDecode(a, "should be longer than 12 bytes")
 	}
 
 	var offset = 0

--- a/uasc/message-header.go
+++ b/uasc/message-header.go
@@ -61,7 +61,7 @@ func DecodeHeader(b []byte) (*Header, error) {
 // DecodeFromBytes decodes given bytes into OPC UA Secure Conversation Header.
 func (h *Header) DecodeFromBytes(b []byte) error {
 	if len(b) < 12 {
-		return &errors.ErrTooShortToDecode{h, "should be longer than 12 bytes"}
+		return errors.NewErrTooShortToDecode(h, "should be longer than 12 bytes")
 	}
 
 	h.MessageType = utils.Uint24To32(b[:3])

--- a/uasc/message.go
+++ b/uasc/message.go
@@ -106,7 +106,7 @@ func Decode(b []byte) (*Message, error) {
 // DecodeFromBytes decodes given bytes into OPC UA Secure Conversation message.
 func (m *Message) DecodeFromBytes(b []byte) error {
 	if len(b) < 16 {
-		return &errors.ErrTooShortToDecode{m, "should be longer than 16 bytes"}
+		return errors.NewErrTooShortToDecode(m, "should be longer than 16 bytes")
 	}
 
 	m.Header = &Header{}
@@ -120,7 +120,7 @@ func (m *Message) DecodeFromBytes(b []byte) error {
 	case MessageTypeMessage:
 		return m.decodeMSGFromBytes(m.Header.Payload)
 	default:
-		return &errors.ErrInvalidType{m, "decode", "should be one of OPN, MSG, CLO"}
+		return errors.NewErrInvalidType(m, "decode", "should be one of OPN, MSG, CLO")
 	}
 }
 
@@ -188,7 +188,7 @@ func (m *Message) SerializeTo(b []byte) error {
 	case MessageTypeMessage:
 		return m.serializeMSGTo(b[offset:])
 	default:
-		return &errors.ErrInvalidType{m, "serialize", "should be one of OPN, MSG, CLO"}
+		return errors.NewErrInvalidType(m, "serialize", "should be one of OPN, MSG, CLO")
 	}
 }
 

--- a/uasc/sequence-header.go
+++ b/uasc/sequence-header.go
@@ -45,7 +45,7 @@ func DecodeSequenceHeader(b []byte) (*SequenceHeader, error) {
 func (s *SequenceHeader) DecodeFromBytes(b []byte) error {
 	l := len(b)
 	if l < 8 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 8 bytes"}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 8 bytes")
 	}
 	s.SequenceNumber = binary.LittleEndian.Uint32(b[:4])
 	s.RequestID = binary.LittleEndian.Uint32(b[4:8])

--- a/uasc/symmetric-security-header.go
+++ b/uasc/symmetric-security-header.go
@@ -43,7 +43,7 @@ func DecodeSymmetricSecurityHeader(b []byte) (*SymmetricSecurityHeader, error) {
 func (s *SymmetricSecurityHeader) DecodeFromBytes(b []byte) error {
 	l := len(b)
 	if l < 4 {
-		return &errors.ErrTooShortToDecode{s, "should be longer than 4 bytes"}
+		return errors.NewErrTooShortToDecode(s, "should be longer than 4 bytes")
 	}
 	s.TokenID = binary.LittleEndian.Uint32(b[:4])
 	s.Payload = b[4:]


### PR DESCRIPTION
* Added constructors for custom errors defined in `error.go`
* Added tests for custom errors
* Revised the way it is called from protocol decoder/serializers
