### PR TITLE
Implement CloseSecureChannelRequest/Response

### DIFF
--- a/examples/sender/sender.go
+++ b/examples/sender/sender.go
@@ -57,6 +57,7 @@ func main() {
 		6000000, nil,
 	)
 	o.SetDiagAll()
+
 	// Prepare TCP connection
 	raddr, err := net.ResolveTCPAddr("tcp", *ip+":"+*port)
 	if err != nil {
@@ -143,6 +144,20 @@ func main() {
 			log.Printf("Something went wrong: %s", err)
 		}
 		log.Printf("Received: %s\nRaw: %x", gres, buf[:m])
+
+		c := services.NewCloseSecureChannelRequest(
+			time.Now(), 0, 1, 0, 0, "", cfg.SecureChannelID,
+		)
+		c.SetDiagAll()
+		clo, err := uasc.New(c, cfg).Serialize()
+		if err != nil {
+			log.Fatalf("Failed to serialize CloseSecureChannelRequest: %s", err)
+		}
+
+		if _, err := conn.Write(clo); err != nil {
+			log.Fatalf("Failed to write CloseSecureChannel: %s", err)
+		}
+		log.Printf("Successfully sent CloseSecureChannel: %x", gep)
 
 	case uacp.MessageTypeError:
 		log.Fatalf("Received Error, closing: %s", cp)

--- a/services/close-secure-channel-request.go
+++ b/services/close-secure-channel-request.go
@@ -1,0 +1,140 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package services
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/wmnsk/gopcua/datatypes"
+	"github.com/wmnsk/gopcua/errors"
+)
+
+// CloseSecureChannelRequest represents an CloseSecureChannelRequest.
+// This Service is used to terminate a SecureChannel.
+//
+// Specification: Part 4, 5.5.2.3
+type CloseSecureChannelRequest struct {
+	TypeID *datatypes.ExpandedNodeID
+	*RequestHeader
+	SecureChannelID uint32
+}
+
+// NewCloseSecureChannelRequest creates an CloseSecureChannelRequest.
+func NewCloseSecureChannelRequest(ts time.Time, authToken uint8, handle, diag, timeout uint32, auditID string, chanID uint32) *CloseSecureChannelRequest {
+	o := &CloseSecureChannelRequest{
+		TypeID: datatypes.NewExpandedNodeID(
+			false, false,
+			datatypes.NewFourByteNodeID(
+				0, ServiceTypeCloseSecureChannelRequest,
+			),
+			"", 0,
+		),
+		RequestHeader: NewRequestHeader(
+			datatypes.NewTwoByteNodeID(authToken),
+			ts,
+			handle,
+			diag,
+			timeout,
+			auditID,
+			NewAdditionalHeader(
+				datatypes.NewExpandedNodeID(
+					false, false,
+					datatypes.NewTwoByteNodeID(0),
+					"", 0,
+				),
+				0x00,
+			),
+			nil,
+		),
+		SecureChannelID: chanID,
+	}
+
+	return o
+}
+
+// DecodeCloseSecureChannelRequest decodes given bytes into CloseSecureChannelRequest.
+func DecodeCloseSecureChannelRequest(b []byte) (*CloseSecureChannelRequest, error) {
+	o := &CloseSecureChannelRequest{}
+	if err := o.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+// DecodeFromBytes decodes given bytes into CloseSecureChannelRequest.
+func (o *CloseSecureChannelRequest) DecodeFromBytes(b []byte) error {
+	if len(b) < 16 {
+		return errors.NewErrTooShortToDecode(o, "should be longer than 16 bytes")
+	}
+
+	var offset = 0
+	o.TypeID = &datatypes.ExpandedNodeID{}
+	if err := o.TypeID.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+	offset += o.TypeID.Len()
+
+	o.RequestHeader = &RequestHeader{}
+	if err := o.RequestHeader.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+	offset += o.RequestHeader.Len() - len(o.RequestHeader.Payload)
+
+	o.SecureChannelID = binary.LittleEndian.Uint32(b[offset : offset+4])
+
+	return nil
+}
+
+// Serialize serializes CloseSecureChannelRequest into bytes.
+func (o *CloseSecureChannelRequest) Serialize() ([]byte, error) {
+	b := make([]byte, o.Len())
+	if err := o.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes CloseSecureChannelRequest into bytes.
+func (o *CloseSecureChannelRequest) SerializeTo(b []byte) error {
+	var offset = 0
+	if o.TypeID != nil {
+		if err := o.TypeID.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += o.TypeID.Len()
+	}
+
+	if o.RequestHeader != nil {
+		if err := o.RequestHeader.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += o.RequestHeader.Len() - len(o.Payload)
+	}
+
+	binary.LittleEndian.PutUint32(b[offset:offset+4], o.SecureChannelID)
+
+	return nil
+}
+
+// Len returns the actual length of CloseSecureChannelRequest.
+func (o *CloseSecureChannelRequest) Len() int {
+	var l = 4
+	if o.TypeID != nil {
+		l += o.TypeID.Len()
+	}
+	if o.RequestHeader != nil {
+		l += (o.RequestHeader.Len() - len(o.Payload))
+	}
+
+	return l
+}
+
+// ServiceType returns type of Service in uint16.
+func (o *CloseSecureChannelRequest) ServiceType() uint16 {
+	return ServiceTypeCloseSecureChannelRequest
+}

--- a/services/close-secure-channel-response.go
+++ b/services/close-secure-channel-response.go
@@ -1,0 +1,122 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package services
+
+import (
+	"time"
+
+	"github.com/wmnsk/gopcua/datatypes"
+	"github.com/wmnsk/gopcua/errors"
+)
+
+// CloseSecureChannelResponse represents an CloseSecureChannelResponse.
+// This Service is used to terminate a SecureChannel.
+//
+// Specification: Part 4, 5.5.2.3
+type CloseSecureChannelResponse struct {
+	TypeID *datatypes.ExpandedNodeID
+	*ResponseHeader
+}
+
+// NewCloseSecureChannelResponse creates an CloseSecureChannelResponse.
+func NewCloseSecureChannelResponse(timestamp time.Time, handle, code uint32, diag *DiagnosticInfo, strs []string) *CloseSecureChannelResponse {
+	o := &CloseSecureChannelResponse{
+		TypeID: datatypes.NewExpandedNodeID(
+			false, false,
+			datatypes.NewFourByteNodeID(
+				0, ServiceTypeCloseSecureChannelResponse,
+			),
+			"", 0,
+		),
+		ResponseHeader: NewResponseHeader(
+			timestamp, handle, code, diag, strs,
+			NewAdditionalHeader(
+				datatypes.NewExpandedNodeID(
+					false, false,
+					datatypes.NewTwoByteNodeID(0),
+					"", 0,
+				),
+				0x00,
+			), nil,
+		),
+	}
+
+	return o
+}
+
+// DecodeCloseSecureChannelResponse decodes given bytes into CloseSecureChannelResponse.
+func DecodeCloseSecureChannelResponse(b []byte) (*CloseSecureChannelResponse, error) {
+	o := &CloseSecureChannelResponse{}
+	if err := o.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+// DecodeFromBytes decodes given bytes into CloseSecureChannelResponse.
+func (o *CloseSecureChannelResponse) DecodeFromBytes(b []byte) error {
+	if len(b) < 8 {
+		return errors.NewErrTooShortToDecode(o, "should be longer than 16 bytes")
+	}
+
+	var offset = 0
+	o.TypeID = &datatypes.ExpandedNodeID{}
+	if err := o.TypeID.DecodeFromBytes(b[offset:]); err != nil {
+		return err
+	}
+	offset += o.TypeID.Len()
+
+	o.ResponseHeader = &ResponseHeader{}
+	return o.ResponseHeader.DecodeFromBytes(b[offset:])
+}
+
+// Serialize serializes CloseSecureChannelResponse into bytes.
+func (o *CloseSecureChannelResponse) Serialize() ([]byte, error) {
+	b := make([]byte, o.Len())
+	if err := o.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes CloseSecureChannelResponse into bytes.
+func (o *CloseSecureChannelResponse) SerializeTo(b []byte) error {
+	var offset = 0
+	if o.TypeID != nil {
+		if err := o.TypeID.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += o.TypeID.Len()
+	}
+
+	if o.ResponseHeader != nil {
+		if err := o.ResponseHeader.SerializeTo(b[offset:]); err != nil {
+			return err
+		}
+		offset += o.ResponseHeader.Len() - len(o.Payload)
+	}
+
+	return nil
+}
+
+// Len returns the actual length of CloseSecureChannelResponse.
+func (o *CloseSecureChannelResponse) Len() int {
+	var l = 0
+	if o.TypeID != nil {
+		l += o.TypeID.Len()
+	}
+	if o.ResponseHeader != nil {
+		l += (o.ResponseHeader.Len() - len(o.Payload))
+	}
+
+	return l
+}
+
+// ServiceType returns type of Service in uint16.
+func (o *CloseSecureChannelResponse) ServiceType() uint16 {
+	return ServiceTypeCloseSecureChannelResponse
+}

--- a/services/service.go
+++ b/services/service.go
@@ -11,12 +11,14 @@ import (
 
 // ServiceType definitions.
 const (
-	ServiceTypeGetEndpointsRequest       uint16 = 428
-	ServiceTypeGetEndpointsResponse             = 431
-	ServiceTypeOpenSecureChannelRequest         = 446
-	ServiceTypeOpenSecureChannelResponse        = 449
-	ServiceTypeCreateSessionRequest             = 461
-	ServiceTypeCreateSessionResponse            = 464
+	ServiceTypeGetEndpointsRequest        uint16 = 428
+	ServiceTypeGetEndpointsResponse              = 431
+	ServiceTypeOpenSecureChannelRequest          = 446
+	ServiceTypeOpenSecureChannelResponse         = 449
+	ServiceTypeCloseSecureChannelRequest         = 452
+	ServiceTypeCloseSecureChannelResponse        = 455
+	ServiceTypeCreateSessionRequest              = 461
+	ServiceTypeCreateSessionResponse             = 464
 )
 
 // Service is an interface to handle any kind of OPC UA Services.
@@ -47,6 +49,10 @@ func Decode(b []byte) (Service, error) {
 		s = &OpenSecureChannelRequest{}
 	case ServiceTypeOpenSecureChannelResponse:
 		s = &OpenSecureChannelResponse{}
+	case ServiceTypeCloseSecureChannelRequest:
+		s = &CloseSecureChannelRequest{}
+	case ServiceTypeCloseSecureChannelResponse:
+		s = &CloseSecureChannelResponse{}
 	case ServiceTypeGetEndpointsRequest:
 		s = &GetEndpointsRequest{}
 	case ServiceTypeGetEndpointsResponse:

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -346,7 +346,27 @@ var testServiceBytes = [][]byte{
 		// MaxRequestMessageSize
 		0xfe, 0xff, 0x00, 0x00,
 	},
-	{},
+	{ // CloseSecureChannelRequest
+		// TypeID
+		0x01, 0x00, 0xc4, 0x01,
+		// RequestHeader
+		0x00, 0x00, 0x00, 0x98, 0x67, 0xdd, 0xfd, 0x30,
+		0xd4, 0x01, 0x01, 0x00, 0x00, 0x00, 0xff, 0x03,
+		0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00,
+		// SecureChannelID
+		0x01, 0x00, 0x00, 0x00,
+	},
+	{ // CloseSecureChannelResponse
+		// TypeID
+		0x01, 0x00, 0xc7, 0x01,
+		// ResponseHeader
+		0x00, 0x98, 0x67, 0xdd, 0xfd, 0x30, 0xd4, 0x01,
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+		0x00, 0x66, 0x6f, 0x6f, 0x03, 0x00, 0x00, 0x00,
+		0x62, 0x61, 0x72, 0x00, 0x00, 0x00,
+	},
 }
 
 func TestDecode(t *testing.T) {
@@ -533,6 +553,44 @@ func TestDecode(t *testing.T) {
 			t.Errorf("MaxRequestMessageSize doesn't match. Want: %d, Got: %d", 65534, cs.MaxRequestMessageSize)
 		}
 		t.Log(cs.String())
+	})
+	t.Run("close-sec-chan-req", func(t *testing.T) {
+		t.Parallel()
+		c, err := Decode(testServiceBytes[6])
+		if err != nil {
+			t.Fatalf("Failed to decode Service: %s", err)
+		}
+
+		csc, ok := c.(*CloseSecureChannelRequest)
+		if !ok {
+			t.Fatalf("Failed to assert type.")
+		}
+
+		switch {
+		case c.ServiceType() != ServiceTypeCloseSecureChannelRequest:
+			t.Errorf("ServiceType doesn't Match. Want: %d, Got: %d", ServiceTypeCloseSecureChannelRequest, c.ServiceType())
+		case csc.SecureChannelID != 1:
+			t.Errorf("SecureChannelID doesn't Match. Want: %d, Got: %d", 1, csc.SecureChannelID)
+		}
+		t.Log(c.String())
+	})
+	t.Run("close-sec-chan-res", func(t *testing.T) {
+		t.Parallel()
+		c, err := Decode(testServiceBytes[7])
+		if err != nil {
+			t.Fatalf("Failed to decode Service: %s", err)
+		}
+
+		_, ok := c.(*CloseSecureChannelResponse)
+		if !ok {
+			t.Fatalf("Failed to assert type.")
+		}
+
+		switch {
+		case c.ServiceType() != ServiceTypeCloseSecureChannelResponse:
+			t.Errorf("ServiceType doesn't Match. Want: %d, Got: %d", ServiceTypeCloseSecureChannelResponse, c.ServiceType())
+		}
+		t.Log(c.String())
 	})
 }
 
@@ -765,6 +823,50 @@ func TestSerializeServices(t *testing.T) {
 
 		for i, s := range serialized {
 			x := testServiceBytes[5][i]
+			if s != x {
+				t.Errorf("Bytes doesn't match. Want: %#x, Got: %#x at %dth", x, s, i)
+			}
+		}
+		t.Logf("%x", serialized)
+	})
+	t.Run("close-sec-chan-req", func(t *testing.T) {
+		t.Parallel()
+		o := NewCloseSecureChannelRequest(
+			time.Date(2018, time.August, 10, 23, 0, 0, 0, time.UTC),
+			0, 1, 0, 0, "", 1,
+		)
+		o.SetDiagAll()
+
+		serialized, err := o.Serialize()
+		if err != nil {
+			t.Fatalf("Failed to serialize Service: %s", err)
+		}
+
+		for i, s := range serialized {
+			x := testServiceBytes[6][i]
+			if s != x {
+				t.Errorf("Bytes doesn't match. Want: %#x, Got: %#x at %dth", x, s, i)
+			}
+		}
+		t.Logf("%x", serialized)
+	})
+	t.Run("close-sec-chan-res", func(t *testing.T) {
+		t.Parallel()
+		o := NewCloseSecureChannelResponse(
+			time.Date(2018, time.August, 10, 23, 0, 0, 0, time.UTC),
+			1,
+			0x00000000,
+			NewNullDiagnosticInfo(),
+			[]string{"foo", "bar"},
+		)
+
+		serialized, err := o.Serialize()
+		if err != nil {
+			t.Fatalf("Failed to serialize Service: %s", err)
+		}
+
+		for i, s := range serialized {
+			x := testServiceBytes[7][i]
 			if s != x {
 				t.Errorf("Bytes doesn't match. Want: %#x, Got: %#x at %dth", x, s, i)
 			}


### PR DESCRIPTION
* Added `CloseSecureChannelRequest` and `CloseSecureChannelResponse` and their tests
* Added `ServiceTypeCloseSecureChannelRequest`, `ServiceTypeCloseSecureChannelResponse` in `service.go`
* Added lines to send `CloseSecureChannelRequest` in `examples/sender/sender.go`

Note: Tests should be revised, as it's becoming too big in `service_test.go`, and not efficient.
