### PR TITLE
Add datatype boolean and revised extension-object

### DIFF
--- a/datatypes/boolean.go
+++ b/datatypes/boolean.go
@@ -1,0 +1,69 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package datatypes
+
+// Boolean represents the datatype Boolean.
+//
+// Specification: Part 3, 8.8
+type Boolean struct {
+	Value uint8
+}
+
+// NewBoolean creates a new Boolean datatype.
+// If given true, this returns the Boolean(=uint8) value 0x01. Otherwise the value is 0x00,
+func NewBoolean(b bool) *Boolean {
+	if b {
+		return &Boolean{Value: 0x01}
+	}
+	return &Boolean{Value: 0x00}
+}
+
+// DecodeBoolean decodes given bytes into Boolean.
+func DecodeBoolean(b []byte) (*Boolean, error) {
+	bo := &Boolean{}
+	if err := bo.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+
+	return bo, nil
+}
+
+// DecodeFromBytes decodes given bytes into Boolean.
+func (bo *Boolean) DecodeFromBytes(b []byte) error {
+	// TODO: Add validation.
+	bo.Value = b[0]
+	return nil
+}
+
+// Serialize serializes Boolean into bytes.
+func (bo *Boolean) Serialize() ([]byte, error) {
+	b := make([]byte, bo.Len())
+	if err := bo.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes Boolean into bytes.
+func (bo *Boolean) SerializeTo(b []byte) error {
+	b[0] = bo.Value
+	return nil
+}
+
+// Len returns the actual length of Boolean.
+func (bo *Boolean) Len() int {
+	return 1
+}
+
+// String returns the value of Boolean in string.
+//
+// The returned value would be "FALSE" if the Boolean is 0x00. Otherwise "TRUE".
+func (bo *Boolean) String() string {
+	if bo.Value == 0x00 {
+		return "FALSE"
+	}
+	return "TRUE"
+}

--- a/datatypes/boolean_test.go
+++ b/datatypes/boolean_test.go
@@ -1,0 +1,163 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package datatypes
+
+import (
+	"log"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	testBooleanTrue  = []byte{0x01}
+	testBooleanFalse = []byte{0x00}
+)
+
+func TestDecodeBoolean(t *testing.T) {
+	t.Run("TRUE", func(t *testing.T) {
+		t.Parallel()
+
+		bo, err := DecodeBoolean(testBooleanTrue)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := &Boolean{Value: 0x01}
+		log.Printf("%d, %d", bo, expected)
+		if diff := cmp.Diff(bo, expected); diff != "" {
+			t.Error(bo)
+		}
+	})
+	t.Run("FALSE", func(t *testing.T) {
+		t.Parallel()
+
+		bo, err := DecodeBoolean(testBooleanFalse)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := &Boolean{Value: 0x00}
+		log.Printf("%d, %d", bo, expected)
+		if diff := cmp.Diff(bo, expected); diff != "" {
+			t.Error(bo)
+		}
+	})
+}
+
+func TestBooleanDecodeFromBytes(t *testing.T) {
+	t.Run("TRUE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{}
+		if err := bo.DecodeFromBytes(testBooleanTrue); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := &Boolean{Value: 0x01}
+		log.Printf("%d, %d", bo, expected)
+		if diff := cmp.Diff(bo, expected); diff != "" {
+			t.Error(bo)
+		}
+	})
+	t.Run("FALSE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{}
+		if err := bo.DecodeFromBytes(testBooleanFalse); err != nil {
+			t.Fatal(err)
+		}
+
+		expected := &Boolean{Value: 0x00}
+		log.Printf("%d, %d", bo, expected)
+		if diff := cmp.Diff(bo, expected); diff != "" {
+			t.Error(bo)
+		}
+	})
+}
+
+func TestBooleanSerialize(t *testing.T) {
+	t.Run("TRUE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x01}
+		b, err := bo.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(b, testBooleanTrue); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("FALSE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x00}
+		b, err := bo.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(b, testBooleanFalse); diff != "" {
+			t.Error(diff)
+		}
+	})
+}
+
+func TestBooleanSerializeTo(t *testing.T) {
+	t.Run("TRUE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x01}
+		b := make([]byte, bo.Len())
+		if err := bo.SerializeTo(b); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(b, testBooleanTrue); diff != "" {
+			t.Error(diff)
+		}
+	})
+	t.Run("FALSE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x00}
+		b := make([]byte, bo.Len())
+		if err := bo.SerializeTo(b); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(b, testBooleanFalse); diff != "" {
+			t.Error(diff)
+		}
+	})
+}
+
+func TestBooleanLen(t *testing.T) {
+	bo := &Boolean{Value: 0x01}
+	if bo.Len() != 1 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 1, bo.Len())
+	}
+}
+
+func TestBooleanString(t *testing.T) {
+	t.Run("TRUE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x01}
+		if bo.String() != "TRUE" {
+			t.Errorf("Len doesn't match. Want: %s, Got: %s", "TRUE", bo.String())
+		}
+	})
+	t.Run("FALSE", func(t *testing.T) {
+		t.Parallel()
+
+		bo := &Boolean{Value: 0x00}
+		if bo.String() != "FALSE" {
+			t.Errorf("Len doesn't match. Want: %s, Got: %s", "FALSE", bo.String())
+		}
+	})
+}

--- a/datatypes/extension-object.go
+++ b/datatypes/extension-object.go
@@ -1,3 +1,7 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
 package datatypes
 
 // ExtensionObject is encoded as sequence of bytes prefixed by the NodeId of its DataTypeEncoding

--- a/datatypes/extension-object_test.go
+++ b/datatypes/extension-object_test.go
@@ -141,7 +141,7 @@ func TestExtensionObjectLen(t *testing.T) {
 			0x79, 0x6d, 0x6f, 0x75, 0x73,
 		}),
 	}
-	if e.Len() != 12 {
-		t.Errorf("Len doesn't match. Want: %d, Got: %d", 12, e.Len())
+	if e.Len() != 22 {
+		t.Errorf("Len doesn't match. Want: %d, Got: %d", 22, e.Len())
 	}
 }

--- a/datatypes/extension-object_test.go
+++ b/datatypes/extension-object_test.go
@@ -1,3 +1,7 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
 package datatypes
 
 import (
@@ -137,7 +141,7 @@ func TestExtensionObjectLen(t *testing.T) {
 			0x79, 0x6d, 0x6f, 0x75, 0x73,
 		}),
 	}
-	if e.Len() != 22 {
+	if e.Len() != 12 {
 		t.Errorf("Len doesn't match. Want: %d, Got: %d", 12, e.Len())
 	}
 }


### PR DESCRIPTION
* Added `Boolean` in datatypes.
  * This datatype is just an uint8 value, but implemented with structure to make it easier to handle in the same way as other datatypes
* Revised `extension-object.go` and `extension-object_test.go`.
  * Add copyrights on the top lines of the files
  * Corrected the value in `TestExtensionObjectLen`

