### PR TITLE
Implemented GetIdentifier() method in NodeIDs

### DIFF
--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -33,7 +33,7 @@ type NodeID interface {
 	EncodingMaskValue() uint8
 	SetURIFlag()
 	SetIndexFlag()
-	GetIdentifier() ([]byte, error)
+	GetIdentifier() []byte
 }
 
 // DecodeNodeID decodes given bytes into NodeID, depending on the Encoding Mask.
@@ -133,12 +133,8 @@ func (t *TwoByteNodeID) SetIndexFlag() {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (t *TwoByteNodeID) GetIdentifier() ([]byte, error) {
-	if t == nil {
-		return nil, errors.NewErrReceiverNil(t)
-	}
-
-	return []byte{t.Identifier}, nil
+func (t *TwoByteNodeID) GetIdentifier() []byte {
+	return []byte{t.Identifier}
 }
 
 // String returns the values in TwoByteNodeID in string.
@@ -219,14 +215,11 @@ func (f *FourByteNodeID) SetIndexFlag() {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (f *FourByteNodeID) GetIdentifier() ([]byte, error) {
-	if f == nil {
-		return nil, errors.NewErrReceiverNil(f)
-	}
-
+func (f *FourByteNodeID) GetIdentifier() []byte {
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, f.Identifier)
-	return b, nil
+
+	return b
 }
 
 // String returns the values in FourByteNodeID in string.
@@ -307,14 +300,11 @@ func (n *NumericNodeID) SetIndexFlag() {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (n *NumericNodeID) GetIdentifier() ([]byte, error) {
-	if n == nil {
-		return nil, errors.NewErrReceiverNil(n)
-	}
-
+func (n *NumericNodeID) GetIdentifier() []byte {
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, n.Identifier)
-	return b, nil
+
+	return b
 }
 
 // String returns the values in NumericNodeID in string.
@@ -403,12 +393,8 @@ func (s *StringNodeID) Value() string {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (s *StringNodeID) GetIdentifier() ([]byte, error) {
-	if s == nil {
-		return nil, errors.NewErrReceiverNil(s)
-	}
-
-	return s.Identifier, nil
+func (s *StringNodeID) GetIdentifier() []byte {
+	return s.Identifier
 }
 
 // String returns the values in StringNodeID in string.
@@ -492,12 +478,11 @@ func (g *GUIDNodeID) Value() string {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (g *GUIDNodeID) GetIdentifier() ([]byte, error) {
-	if g == nil {
-		return nil, errors.NewErrReceiverNil(g)
-	}
+// This method returns nil when the GUID in Identifier field is invalid.
+func (g *GUIDNodeID) GetIdentifier() []byte {
+	b, _ := g.Identifier.Serialize()
 
-	return g.Identifier.Serialize()
+	return b
 }
 
 // String returns the values in GUIDNodeID in string.
@@ -582,12 +567,8 @@ func (o *OpaqueNodeID) SetIndexFlag() {
 }
 
 // GetIdentifier returns value in Identifier field in bytes.
-func (o *OpaqueNodeID) GetIdentifier() ([]byte, error) {
-	if o == nil {
-		return nil, errors.NewErrReceiverNil(o)
-	}
-
-	return o.Identifier, nil
+func (o *OpaqueNodeID) GetIdentifier() []byte {
+	return o.Identifier
 }
 
 // String returns the values in OpaqueNodeID in string.

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -33,6 +33,7 @@ type NodeID interface {
 	EncodingMaskValue() uint8
 	SetURIFlag()
 	SetIndexFlag()
+	GetIdentifier() ([]byte, error)
 }
 
 // DecodeNodeID decodes given bytes into NodeID, depending on the Encoding Mask.
@@ -131,6 +132,15 @@ func (t *TwoByteNodeID) SetIndexFlag() {
 	t.EncodingMask |= 0x40
 }
 
+// GetIdentifier returns value in Identifier field in bytes.
+func (t *TwoByteNodeID) GetIdentifier() ([]byte, error) {
+	if t == nil {
+		return nil, errors.NewErrReceiverNil(t)
+	}
+
+	return []byte{t.Identifier}, nil
+}
+
 // String returns the values in TwoByteNodeID in string.
 func (t *TwoByteNodeID) String() string {
 	return fmt.Sprintf("%x, %d", t.EncodingMask, t.Identifier)
@@ -208,6 +218,17 @@ func (f *FourByteNodeID) SetIndexFlag() {
 	f.EncodingMask |= 0x40
 }
 
+// GetIdentifier returns value in Identifier field in bytes.
+func (f *FourByteNodeID) GetIdentifier() ([]byte, error) {
+	if f == nil {
+		return nil, errors.NewErrReceiverNil(f)
+	}
+
+	b := make([]byte, 2)
+	binary.LittleEndian.PutUint16(b, f.Identifier)
+	return b, nil
+}
+
 // String returns the values in FourByteNodeID in string.
 func (f *FourByteNodeID) String() string {
 	return fmt.Sprintf("%x, %d, %d", f.EncodingMask, f.Namespace, f.Identifier)
@@ -283,6 +304,17 @@ func (n *NumericNodeID) SetURIFlag() {
 // SetIndexFlag sets NamespaceURI flag in EncodingMask.
 func (n *NumericNodeID) SetIndexFlag() {
 	n.EncodingMask |= 0x40
+}
+
+// GetIdentifier returns value in Identifier field in bytes.
+func (n *NumericNodeID) GetIdentifier() ([]byte, error) {
+	if n == nil {
+		return nil, errors.NewErrReceiverNil(n)
+	}
+
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, n.Identifier)
+	return b, nil
 }
 
 // String returns the values in NumericNodeID in string.
@@ -370,6 +402,15 @@ func (s *StringNodeID) Value() string {
 	return string(s.Identifier)
 }
 
+// GetIdentifier returns value in Identifier field in bytes.
+func (s *StringNodeID) GetIdentifier() ([]byte, error) {
+	if s == nil {
+		return nil, errors.NewErrReceiverNil(s)
+	}
+
+	return s.Identifier, nil
+}
+
 // String returns the values in StringNodeID in string.
 func (s *StringNodeID) String() string {
 	return fmt.Sprintf("%x, %d, %d, %d", s.EncodingMask, s.Namespace, s.Length, s.Identifier)
@@ -448,6 +489,15 @@ func (g *GUIDNodeID) SetIndexFlag() {
 // Value returns Identifier in string.
 func (g *GUIDNodeID) Value() string {
 	return g.Identifier.String()
+}
+
+// GetIdentifier returns value in Identifier field in bytes.
+func (g *GUIDNodeID) GetIdentifier() ([]byte, error) {
+	if g == nil {
+		return nil, errors.NewErrReceiverNil(g)
+	}
+
+	return g.Identifier.Serialize()
 }
 
 // String returns the values in GUIDNodeID in string.
@@ -529,6 +579,15 @@ func (o *OpaqueNodeID) SetURIFlag() {
 // SetIndexFlag sets NamespaceURI flag in EncodingMask.
 func (o *OpaqueNodeID) SetIndexFlag() {
 	o.EncodingMask |= 0x40
+}
+
+// GetIdentifier returns value in Identifier field in bytes.
+func (o *OpaqueNodeID) GetIdentifier() ([]byte, error) {
+	if o == nil {
+		return nil, errors.NewErrReceiverNil(o)
+	}
+
+	return o.Identifier, nil
 }
 
 // String returns the values in OpaqueNodeID in string.

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -47,11 +47,7 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*TwoByteNodeID", n)
 		}
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		switch {
 		case two.EncodingMask != TypeTwoByte:
@@ -75,11 +71,7 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*FourByteNodeID", n)
 		}
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		switch {
 		case four.EncodingMask != TypeFourByte:
@@ -105,11 +97,7 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*NumericNodeID", n)
 		}
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		switch {
 		case num.EncodingMask != TypeNumeric:
@@ -135,11 +123,7 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*StringNodeID", n)
 		}
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		switch {
 		case str.EncodingMask != TypeString:
@@ -164,11 +148,7 @@ func TestDecodeNodeID(t *testing.T) {
 
 		guid, ok := n.(*GUIDNodeID)
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		if !ok {
 			t.Fatalf("Failed to assert type. Want: %s, Got: %T", "*GUIDNodeID", n)
@@ -198,11 +178,7 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*OpaqueNodeID", n)
 		}
 
-		identifier, err := n.GetIdentifier()
-		if err != nil {
-			t.Errorf("Failed to get identifier: %s", err)
-		}
-		identStr := hex.EncodeToString(identifier)
+		identStr := hex.EncodeToString(n.GetIdentifier())
 
 		switch {
 		case opq.EncodingMask != TypeOpaque:

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -47,11 +47,19 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*TwoByteNodeID", n)
 		}
 
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		switch {
 		case two.EncodingMask != TypeTwoByte:
 			t.Errorf("EncodingMask doesn't match. Want: %d, Got: %d", TypeTwoByte, two.EncodingMask)
 		case two.Identifier != 0xff:
 			t.Errorf("Identifier doesn't match. Want: %x, Got: %x", 0xff, two.Identifier)
+		case identStr != "ff":
+			t.Errorf("GetIdentifier doesn't match. Want: %s, Got: %s", "ff", identStr)
 		}
 		t.Log(two.String())
 	})
@@ -67,6 +75,12 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*FourByteNodeID", n)
 		}
 
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		switch {
 		case four.EncodingMask != TypeFourByte:
 			t.Errorf("EncodingMask doesn't match. Want: %d, Got: %d", TypeFourByte, four.EncodingMask)
@@ -74,6 +88,8 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Namespace doesn't match. Want: %x, Got: %x", 0, four.Namespace)
 		case four.Identifier != 0xcafe:
 			t.Errorf("Identifier doesn't match. Want: %x, Got: %x", 0xcafe, four.Identifier)
+		case identStr != "feca":
+			t.Errorf("GetIdentifier doesn't match. Want: %s, Got: %s", "feca", identStr)
 		}
 		t.Log(four.String())
 	})
@@ -89,6 +105,12 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*NumericNodeID", n)
 		}
 
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		switch {
 		case num.EncodingMask != TypeNumeric:
 			t.Errorf("EncodingMask doesn't match. Want: %d, Got: %d", TypeNumeric, num.EncodingMask)
@@ -96,6 +118,8 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Namespace doesn't match. Want: %x, Got: %x", 10, num.Namespace)
 		case num.Identifier != 0xdeadbeef:
 			t.Errorf("Identifier doesn't match. Want: %x, Got: %x", 0xdeadbeef, num.Identifier)
+		case identStr != "efbeadde":
+			t.Errorf("GetIdentifier doesn't match. Want: %s, Got: %s", "efbeadde", identStr)
 		}
 		t.Log(num.String())
 	})
@@ -111,6 +135,12 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*StringNodeID", n)
 		}
 
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		switch {
 		case str.EncodingMask != TypeString:
 			t.Errorf("EncodingMask doesn't match. Want: %d, Got: %d", TypeString, str.EncodingMask)
@@ -120,6 +150,8 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Length doesn't match. Want: %x, Got: %x", 6, str.Length)
 		case str.Value() != "foobar":
 			t.Errorf("Identifier doesn't match. Want: %s, Got: %s", "foobar", str.Value())
+		case identStr != "666f6f626172":
+			t.Errorf("GetIdentifier doesn't match. Want: %s, Got: %s", "666f6f626172", identStr)
 		}
 		t.Log(str.String())
 	})
@@ -131,6 +163,13 @@ func TestDecodeNodeID(t *testing.T) {
 		}
 
 		guid, ok := n.(*GUIDNodeID)
+
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		if !ok {
 			t.Fatalf("Failed to assert type. Want: %s, Got: %T", "*GUIDNodeID", n)
 		}
@@ -142,6 +181,8 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Namespace doesn't match. Want: %x, Got: %x", 4660, guid.Namespace)
 		case guid.Value() != "AAAABBBB-CCDD-EEFF-0101-0123456789AB":
 			t.Errorf("Identifier doesn't match. Want: %s, Got: %s", "AAAABBBB-CCDD-EEFF-0101-0123456789AB", guid.Value())
+		case identStr != "bbbbaaaaddccffeeab89674523010101":
+			t.Errorf("GetIdentifier doesn't match. Want: %s, Got: %s", "bbbbaaaaddccffeeab89674523010101", identStr)
 		}
 		t.Log(guid.String())
 	})
@@ -157,7 +198,12 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Failed to assert type. Want: %s, Got: %T", "*OpaqueNodeID", n)
 		}
 
-		dummyStr := hex.EncodeToString(opq.Identifier)
+		identifier, err := n.GetIdentifier()
+		if err != nil {
+			t.Errorf("Failed to get identifier: %s", err)
+		}
+		identStr := hex.EncodeToString(identifier)
+
 		switch {
 		case opq.EncodingMask != TypeOpaque:
 			t.Errorf("EncodingMask doesn't match. Want: %d, Got: %d", TypeOpaque, opq.EncodingMask)
@@ -165,8 +211,8 @@ func TestDecodeNodeID(t *testing.T) {
 			t.Errorf("Namespace doesn't match. Want: %x, Got: %x", 32768, opq.Namespace)
 		case opq.Length != 4:
 			t.Errorf("Length doesn't match. Want: %x, Got: %x", 4, opq.Length)
-		case dummyStr != "deadbeef":
-			t.Errorf("Identifier doesn't match. Want: %s, Got: %s", "deadbeef", dummyStr)
+		case identStr != "deadbeef":
+			t.Errorf("Identifier doesn't match. Want: %s, Got: %s", "deadbeef", identStr)
 		}
 		t.Log(opq.String())
 	})


### PR DESCRIPTION
This is to address issue #27.

`GetIdentifier()` method returns the value in `Identifier` field in []byte, regardless of the original field type of `Identifier`.
