### PR TITLE
Implement UACP Client

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 // Command client provides a connection establishment of OPC UA Secure Conversation.
+//
+// XXX - Currently this command just initiates the connection(UACP) to the specified endpoint
+// and print the address of remote endpoint.
 package main
 
 import (
@@ -15,12 +18,12 @@ import (
 func main() {
 	var (
 		endpoint = flag.String("endpoint", "opc.tcp://example.com/foo/bar", "OPC UA Endpoint URL")
+		bufsize  = flag.Int("bufsize", 0xffff, "Receive Buffer Size")
 	)
 	flag.Parse()
 
-	cfg := uacp.NewClientConfig(*endpoint, 0xffff)
-
-	conn, err := uacp.Dial(cfg, nil)
+	cpClient := uacp.NewClient(*endpoint, uint32(*bufsize))
+	conn, err := cpClient.Dial(nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -1,0 +1,29 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// Command client provides a connection establishment of OPC UA Secure Conversation.
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/wmnsk/gopcua/uacp"
+)
+
+func main() {
+	var (
+		endpoint = flag.String("endpoint", "opc.tcp://example.com/foo/bar", "OPC UA Endpoint URL")
+	)
+	flag.Parse()
+
+	cfg := uacp.NewClientConfig(*endpoint, 0xffff)
+
+	conn, err := uacp.Dial(cfg, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("%T, %v", conn, conn.RemoteAddr())
+}

--- a/uacp/client.go
+++ b/uacp/client.go
@@ -1,0 +1,103 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package uacp
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/wmnsk/gopcua/errors"
+)
+
+// ClientConfig is the configuration that OPC UA Connection Protocol client should have.
+type ClientConfig struct {
+	Endpoint          string
+	SendBufferSize    uint32
+	ReceiveBufferSize uint32
+}
+
+// NewClientConfig creates a new ClientConfig with minimum mandatory parameters.
+func NewClientConfig(endpoint string, rcvBufSize uint32) *ClientConfig {
+	return &ClientConfig{
+		Endpoint:          endpoint,
+		ReceiveBufferSize: rcvBufSize,
+		SendBufferSize:    0,
+	}
+}
+
+// Dial acts like Dial for OPC UA network.
+//
+// Currently the endpoint can only be specified in "opc.tcp://<addr[:port]>" format.
+// If port is missing, ":4840" is automatically chosen.
+// If laddr is nil, a local address is automatically chosen.
+func Dial(cfg *ClientConfig, laddr *net.TCPAddr) (*Conn, error) {
+	network, raddr, err := resolveEndpoint(cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := &Conn{}
+	conn.tcpConn, err = net.DialTCP(network, laddr, raddr)
+	if err != nil {
+		return nil, err
+	}
+	conn.rcvBuf = make([]byte, int(cfg.ReceiveBufferSize))
+	if err := conn.Hello(cfg); err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// Hello sends UACP Hello message and checks the reponse.
+//
+// Note: This is exported for those who wants to debug, but might be made private in the future.
+func (c *Conn) Hello(cfg *ClientConfig) error {
+	hel, err := NewHello(0, cfg.SendBufferSize, cfg.ReceiveBufferSize, 0, cfg.Endpoint).Serialize()
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.tcpConn.Write(hel); err != nil {
+		return err
+	}
+
+	n, err := c.tcpConn.Read(c.rcvBuf)
+	if err != nil {
+		return err
+	}
+
+	message, err := Decode(c.rcvBuf[:n])
+	if err != nil {
+		return err
+	}
+
+	switch msg := message.(type) {
+	case *Acknowledge:
+		cfg.SendBufferSize = msg.ReceiveBufSize
+		return nil
+	case *Error:
+		return fmt.Errorf("received Error. Reason: %s", msg.Reason.Get())
+	default:
+		return errors.NewErrInvalidType(msg, "initiating UACP", ".")
+	}
+}
+
+func resolveEndpoint(ep string) (network string, raddr *net.TCPAddr, err error) {
+	elems := strings.Split(ep, "/")
+	if elems[0] != "opc.tcp:" {
+		return "", nil, errors.NewErrUnsupported(elems[0], "should be in \"opc.tcp://<addr:port>\" format.")
+	}
+
+	addr := elems[2]
+	if !strings.Contains(addr, ":") {
+		addr += ":4840"
+	}
+
+	network = "tcp"
+	raddr, err = net.ResolveTCPAddr("tcp", addr)
+	return
+}

--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -1,0 +1,83 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package uacp
+
+import (
+	"net"
+	"time"
+)
+
+// Conn is an implementation of the net.Conn interface for OPC UA Connection Protocol.
+type Conn struct {
+	tcpConn  *net.TCPConn
+	endpoint string
+	sndBuf   []byte
+	rcvBuf   []byte
+}
+
+// Read reads data from the connection.
+// Read can be made to time out and return an Error with Timeout() == true
+// after a fixed time limit; see SetDeadline and SetReadDeadline.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	return c.tcpConn.Read(b)
+}
+
+// Write writes data to the connection.
+// Write can be made to time out and return an Error with Timeout() == true
+// after a fixed time limit; see SetDeadline and SetWriteDeadline.
+func (c *Conn) Write(b []byte) (n int, err error) {
+	return c.tcpConn.Write(b)
+}
+
+// Close closes the connection.
+// Any blocked Read or Write operations will be unblocked and return errors.
+func (c *Conn) Close() error {
+	return c.tcpConn.Close()
+}
+
+// LocalAddr returns the local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.tcpConn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.tcpConn.RemoteAddr()
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail with a timeout (see type Error) instead of
+// blocking. The deadline applies to all future and pending
+// I/O, not just the immediately following call to Read or
+// Write. After a deadline has been exceeded, the connection
+// can be refreshed by setting a deadline in the future.
+//
+// An idle timeout can be implemented by repeatedly extending
+// the deadline after successful Read or Write calls.
+//
+// A zero value for t means I/O operations will not time out.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.tcpConn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.tcpConn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.tcpConn.SetWriteDeadline(t)
+}


### PR DESCRIPTION
* Added `Conn` structure in UACP, with the methods that required to implement `net.Conn` interface.
* Added `ClientConfig` structure.
* Implemented `Dial()` function and some other methods.
* Added `client.go` in example.

This is still WIP - Methods implemented on `Conn` should be improved.
