### PR TITLE
Correct buffer size field order in Hello

### DIFF
--- a/uacp/hello.go
+++ b/uacp/hello.go
@@ -16,15 +16,15 @@ import (
 type Hello struct {
 	*Header
 	Version        uint32
-	SendBufSize    uint32
 	ReceiveBufSize uint32
+	SendBufSize    uint32
 	MaxMessageSize uint32
 	MaxChunkCount  uint32
 	EndPointURL    *datatypes.String
 }
 
 // NewHello creates a new OPC UA Hello.
-func NewHello(ver, sndBuf, rcvBuf, maxMsg uint32, endpoint string) *Hello {
+func NewHello(ver, rcvBuf, sndBuf, maxMsg uint32, endpoint string) *Hello {
 	h := &Hello{
 		Header: NewHeader(
 			MessageTypeHello,
@@ -32,8 +32,8 @@ func NewHello(ver, sndBuf, rcvBuf, maxMsg uint32, endpoint string) *Hello {
 			nil,
 		),
 		Version:        ver,
-		SendBufSize:    sndBuf,
 		ReceiveBufSize: rcvBuf,
+		SendBufSize:    sndBuf,
 		MaxMessageSize: maxMsg,
 		MaxChunkCount:  0,
 		EndPointURL:    datatypes.NewString(endpoint),
@@ -67,8 +67,8 @@ func (h *Hello) DecodeFromBytes(b []byte) error {
 	b = h.Header.Payload
 
 	h.Version = binary.LittleEndian.Uint32(b[:4])
-	h.SendBufSize = binary.LittleEndian.Uint32(b[4:8])
-	h.ReceiveBufSize = binary.LittleEndian.Uint32(b[8:12])
+	h.ReceiveBufSize = binary.LittleEndian.Uint32(b[4:8])
+	h.SendBufSize = binary.LittleEndian.Uint32(b[8:12])
 	h.MaxMessageSize = binary.LittleEndian.Uint32(b[12:16])
 	h.MaxChunkCount = binary.LittleEndian.Uint32(b[16:20])
 
@@ -94,8 +94,8 @@ func (h *Hello) SerializeTo(b []byte) error {
 	h.Header.Payload = make([]byte, h.Len()-8)
 
 	binary.LittleEndian.PutUint32(h.Header.Payload[:4], h.Version)
-	binary.LittleEndian.PutUint32(h.Header.Payload[4:8], h.SendBufSize)
-	binary.LittleEndian.PutUint32(h.Header.Payload[8:12], h.ReceiveBufSize)
+	binary.LittleEndian.PutUint32(h.Header.Payload[4:8], h.ReceiveBufSize)
+	binary.LittleEndian.PutUint32(h.Header.Payload[8:12], h.SendBufSize)
 	binary.LittleEndian.PutUint32(h.Header.Payload[12:16], h.MaxMessageSize)
 	binary.LittleEndian.PutUint32(h.Header.Payload[16:20], h.MaxChunkCount)
 

--- a/uacp/hello_test.go
+++ b/uacp/hello_test.go
@@ -18,8 +18,8 @@ var testHelloBytes = [][]byte{
 		0x46, 0x00, 0x00, 0x00,
 		// Version: 0
 		0x00, 0x00, 0x00, 0x00,
-		// ReceiveBufSize: 65535
-		0xff, 0xff, 0x00, 0x00,
+		// ReceiveBufSize: 65280
+		0x00, 0xff, 0x00, 0x00,
 		// SendBufSize: 65535
 		0xff, 0xff, 0x00, 0x00,
 		// MaxMessageSize: 4000
@@ -53,10 +53,10 @@ func TestDecodeHello(t *testing.T) {
 		t.Errorf("MessageSize doesn't match. Want: %d, Got: %d", 70, h.MessageSize)
 	case h.Version != 0:
 		t.Errorf("Version doesn't match. Want: %d, Got: %d", 0, h.Version)
+	case h.ReceiveBufSize != 65280:
+		t.Errorf("ReceiveBufSize doesn't match. Want: %d, Got: %d", 65280, h.ReceiveBufSize)
 	case h.SendBufSize != 65535:
 		t.Errorf("SendBufSize doesn't match. Want: %d, Got: %d", 65535, h.SendBufSize)
-	case h.ReceiveBufSize != 65535:
-		t.Errorf("ReceiveBufSize doesn't match. Want: %d, Got: %d", 65535, h.ReceiveBufSize)
 	case h.MaxMessageSize != 4000:
 		t.Errorf("MaxMessageSize doesn't match. Want: %d, Got: %d", 4000, h.MaxMessageSize)
 	case h.MaxChunkCount != 0:
@@ -69,10 +69,10 @@ func TestDecodeHello(t *testing.T) {
 
 func TestSerializeHello(t *testing.T) {
 	h := NewHello(
-		0,      //Version
-		0xffff, // SendBufSize
-		0xffff, // ReceiveBufSize
-		4000,   // MaxMessageSize
+		0,     //Version
+		65280, // ReceiveBufSize
+		65535, // SendBufSize
+		4000,  // MaxMessageSize
 		"opc.tcp://wow.its.easy:11111/UA/Server", // EndPointURL
 	)
 

--- a/uacp/uacp_test.go
+++ b/uacp/uacp_test.go
@@ -5,8 +5,9 @@
 package uacp
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestDecode(t *testing.T) {
@@ -104,10 +105,10 @@ func TestSerialize(t *testing.T) {
 	t.Run("HEL", func(t *testing.T) {
 		t.Parallel()
 		h := NewHello(
-			0,      //Version
-			0xffff, // SendBufSize
-			0xffff, // ReceiveBufSize
-			4000,   // MaxMessageSize
+			0,     //Version
+			65280, // ReceiveBufSize
+			65535, // SendBufSize
+			4000,  // MaxMessageSize
 			"opc.tcp://wow.its.easy:11111/UA/Server", // EndPointURL
 		)
 
@@ -116,8 +117,8 @@ func TestSerialize(t *testing.T) {
 			t.Fatalf("Failed to serialize Hello: %s", err)
 		}
 
-		if !reflect.DeepEqual(serialized, testHelloBytes[0]) {
-			t.Errorf("Unexpectedly serialized:\nWant: %x\nGot:  %x", testHelloBytes[0], serialized)
+		if diff := cmp.Diff(serialized, testHelloBytes[0]); diff != "" {
+			t.Error(diff)
 		}
 	})
 }


### PR DESCRIPTION
I found the order of `SendBufferSize` and `ReceiveBufferSize` was wrong.

* Corrected the order in `hello.go`
* Improved `hello_test.go` to use different value in `SendBufferSize` and `ReceiveBufferSize`, to make it easier to notice.
