### PR TITLE
Correct buffer size field order in Ack and add some GoDoc

### DIFF
--- a/uacp/acknowledge.go
+++ b/uacp/acknowledge.go
@@ -12,17 +12,19 @@ import (
 )
 
 // Acknowledge represents a OPC UA Acknowledge.
+//
+// Specification: Part6, 7.1.2.4
 type Acknowledge struct {
 	*Header
 	Version        uint32
-	SendBufSize    uint32
 	ReceiveBufSize uint32
+	SendBufSize    uint32
 	MaxMessageSize uint32
 	MaxChunkCount  uint32
 }
 
 // NewAcknowledge creates a new OPC UA Acknowledge.
-func NewAcknowledge(ver, sndBuf, rcvBuf, maxMsg uint32) *Acknowledge {
+func NewAcknowledge(ver, rcvBuf, sndBuf, maxMsg uint32) *Acknowledge {
 	a := &Acknowledge{
 		Header: NewHeader(
 			MessageTypeAcknowledge,
@@ -30,8 +32,8 @@ func NewAcknowledge(ver, sndBuf, rcvBuf, maxMsg uint32) *Acknowledge {
 			nil,
 		),
 		Version:        ver,
-		SendBufSize:    sndBuf,
 		ReceiveBufSize: rcvBuf,
+		SendBufSize:    sndBuf,
 		MaxMessageSize: maxMsg,
 		MaxChunkCount:  0,
 	}
@@ -64,8 +66,8 @@ func (a *Acknowledge) DecodeFromBytes(b []byte) error {
 	b = a.Header.Payload
 
 	a.Version = binary.LittleEndian.Uint32(b[:4])
-	a.SendBufSize = binary.LittleEndian.Uint32(b[4:8])
-	a.ReceiveBufSize = binary.LittleEndian.Uint32(b[8:12])
+	a.ReceiveBufSize = binary.LittleEndian.Uint32(b[4:8])
+	a.SendBufSize = binary.LittleEndian.Uint32(b[8:12])
 	a.MaxMessageSize = binary.LittleEndian.Uint32(b[12:16])
 	a.MaxChunkCount = binary.LittleEndian.Uint32(b[16:20])
 
@@ -90,8 +92,8 @@ func (a *Acknowledge) SerializeTo(b []byte) error {
 	a.Header.Payload = make([]byte, a.Len()-8)
 
 	binary.LittleEndian.PutUint32(a.Header.Payload[:4], a.Version)
-	binary.LittleEndian.PutUint32(a.Header.Payload[4:8], a.SendBufSize)
-	binary.LittleEndian.PutUint32(a.Header.Payload[8:12], a.ReceiveBufSize)
+	binary.LittleEndian.PutUint32(a.Header.Payload[4:8], a.ReceiveBufSize)
+	binary.LittleEndian.PutUint32(a.Header.Payload[8:12], a.SendBufSize)
 	binary.LittleEndian.PutUint32(a.Header.Payload[12:16], a.MaxMessageSize)
 	binary.LittleEndian.PutUint32(a.Header.Payload[16:20], a.MaxChunkCount)
 
@@ -112,11 +114,11 @@ func (a *Acknowledge) SetLength() {
 // String returns Acknowledge in string.
 func (a *Acknowledge) String() string {
 	return fmt.Sprintf(
-		"Header: %v, Version: %d, SendBufSize: %d, ReceiveBufSize: %d, MaxMessageSize: %d, MaxChunkCount: %d",
+		"Header: %v, Version: %d, ReceiveBufSize: %d, SendBufSize: %d, MaxMessageSize: %d, MaxChunkCount: %d",
 		a.Header,
 		a.Version,
-		a.SendBufSize,
 		a.ReceiveBufSize,
+		a.SendBufSize,
 		a.MaxMessageSize,
 		a.MaxChunkCount,
 	)

--- a/uacp/acknowledge_test.go
+++ b/uacp/acknowledge_test.go
@@ -18,8 +18,8 @@ var testAcknowledgeBytes = [][]byte{
 		0x1c, 0x00, 0x00, 0x00,
 		// Version: 0
 		0x00, 0x00, 0x00, 0x00,
-		// ReceiveBufSize: 65535
-		0xff, 0xff, 0x00, 0x00,
+		// ReceiveBufSize: 65280
+		0x00, 0xff, 0x00, 0x00,
 		// SendBufSize: 65535
 		0xff, 0xff, 0x00, 0x00,
 		// MaxMessageSize: 4000
@@ -46,10 +46,10 @@ func TestDecodeAcknowledge(t *testing.T) {
 		t.Errorf("MessageSize doesn't match. Want: %d, Got: %d", 28, a.MessageSize)
 	case a.Version != 0:
 		t.Errorf("Version doesn't match. Want: %d, Got: %d", 0, a.Version)
+	case a.ReceiveBufSize != 65280:
+		t.Errorf("ReceiveBufSize doesn't match. Want: %d, Got: %d", 65280, a.ReceiveBufSize)
 	case a.SendBufSize != 65535:
 		t.Errorf("SendBufSize doesn't match. Want: %d, Got: %d", 65535, a.SendBufSize)
-	case a.ReceiveBufSize != 65535:
-		t.Errorf("ReceiveBufSize doesn't match. Want: %d, Got: %d", 65535, a.ReceiveBufSize)
 	case a.MaxMessageSize != 4000:
 		t.Errorf("MaxMessageSize doesn't match. Want: %d, Got: %d", 4000, a.MaxMessageSize)
 	case a.MaxChunkCount != 0:
@@ -60,10 +60,10 @@ func TestDecodeAcknowledge(t *testing.T) {
 
 func TestSerializeAcknowledge(t *testing.T) {
 	a := NewAcknowledge(
-		0,      //Version
-		0xffff, // SendBufSize
-		0xffff, // ReceiveBufSize
-		4000,   // MaxMessageSize
+		0,     //Version
+		65280, // ReceiveBufSize
+		65535, // SendBufSize
+		4000,  // MaxMessageSize
 	)
 
 	serialized, err := a.Serialize()

--- a/uacp/doc.go
+++ b/uacp/doc.go
@@ -3,6 +3,13 @@
 // found in the LICENSE file.
 
 /*
-Package uacp provides encoding/decoding feature for OPC UA Connection Protocol.
+Package uacp provides encoding/decoding and connection handling for OPC UA Connection Protocol.
+
+To establish the connection as a client, create Client with NewClient() and call Dial() method.
+
+To wait for the client to connect to, create Server with NewServer() and call Listen() and Accept() methods.
+
+The connection(=returned object *Conn) can be used to read, write, print addresses, etc.
+in the same way as other kind of Conn which implements net.Conn interface.
 */
 package uacp

--- a/uacp/error.go
+++ b/uacp/error.go
@@ -43,6 +43,8 @@ const (
 )
 
 // Error represents a OPC UA Error.
+//
+// Specification: Part6, 7.1.2.5
 type Error struct {
 	*Header
 	Error  uint32

--- a/uacp/hello.go
+++ b/uacp/hello.go
@@ -13,6 +13,8 @@ import (
 )
 
 // Hello represents a OPC UA Hello.
+//
+// Specification: Part6, 7.1.2.3
 type Hello struct {
 	*Header
 	Version        uint32
@@ -122,11 +124,11 @@ func (h *Hello) SetLength() {
 // String returns Hello in string.
 func (h *Hello) String() string {
 	return fmt.Sprintf(
-		"Header: %v, Version: %d, SendBufSize: %d, ReceiveBufSize: %d, MaxMessageSize: %d, MaxChunkCount: %d, EndPointURL: %s",
+		"Header: %v, Version: %d, ReceiveBufSize: %d, SendBufSize: %d, MaxMessageSize: %d, MaxChunkCount: %d, EndPointURL: %s",
 		h.Header,
 		h.Version,
-		h.SendBufSize,
 		h.ReceiveBufSize,
+		h.SendBufSize,
 		h.MaxMessageSize,
 		h.MaxChunkCount,
 		h.EndPointURL.Get(),

--- a/uacp/reverse-hello.go
+++ b/uacp/reverse-hello.go
@@ -12,6 +12,8 @@ import (
 )
 
 // ReverseHello represents a OPC UA ReverseHello.
+//
+// Specification: Part6, 7.1.2.6
 type ReverseHello struct {
 	*Header
 	ServerURI   *datatypes.String


### PR DESCRIPTION
* Correct `acknowledge.go` and `acknowledge_test.go` to address the same issue as Hello had (PR #34)
* Add specification references in all UACP messages
* Add some lines in doc.go
