### PR TITLE
Add CI jobs with Go 1.11 and removed older versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,12 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-1.7
-      - test-1.8
-      - test-1.9
       - test-1.10
+      - test-1.11
 jobs:
-  test-1.7:
+  test-1.10:
     docker:
-      - image: 'circleci/golang:1.7'
+      - image: 'circleci/golang:1.10'
     working_directory: /go/src/github.com/wmnsk/gopcua
     steps: &ref_0
       - checkout
@@ -19,18 +17,8 @@ jobs:
       - run: go get -u golang.org/x/lint/golint
       - run: golint ./...
       - run: go test -v ./...
-  test-1.8:
+  test-1.11:
     docker:
-      - image: 'circleci/golang:1.8'
-    working_directory: /go/src/github.com/wmnsk/gopcua
-    steps: *ref_0
-  test-1.9:
-    docker:
-      - image: 'circleci/golang:1.9'
-    working_directory: /go/src/github.com/wmnsk/gopcua
-    steps: *ref_0
-  test-1.10:
-    docker:
-      - image: 'circleci/golang:1.10'
+      - image: 'circleci/golang:1.11'
     working_directory: /go/src/github.com/wmnsk/gopcua
     steps: *ref_0


### PR DESCRIPTION
* Added CircleCI job with Go 1.11
* Removed older versions: 1.07, 1.08, 1.09

Now jobs in CCI is 1.10 and 1.11 only.
As Golang officially supports only two latest versions(and don't wait for four CCI jobs to finish), I decided to remove tests with older versions.
https://golang.org/doc/devel/release.html#policy
