### PR TITLE
Add datatype Uint32Array

### DIFF
--- a/datatypes/uint32.go
+++ b/datatypes/uint32.go
@@ -1,0 +1,87 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package datatypes
+
+import "encoding/binary"
+
+// Uint32Array represents the array of Uint32 type of data.
+type Uint32Array struct {
+	ArraySize int32
+	Values    []uint32
+}
+
+// NewUint32Array creates a new NewUint32Array from multiple uint32 values.
+func NewUint32Array(vals []uint32) *Uint32Array {
+	if vals == nil {
+		u := &Uint32Array{
+			ArraySize: 0,
+		}
+		return u
+	}
+
+	u := &Uint32Array{
+		ArraySize: int32(len(vals)),
+	}
+	for _, v := range vals {
+		u.Values = append(u.Values, v)
+	}
+
+	return u
+}
+
+// DecodeUint32Array decodes given bytes into Uint32Array.
+func DecodeUint32Array(b []byte) (*Uint32Array, error) {
+	s := &Uint32Array{}
+	if err := s.DecodeFromBytes(b); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// DecodeFromBytes decodes given bytes into Uint32Array.
+// TODO: add validation to avoid crash.
+func (u *Uint32Array) DecodeFromBytes(b []byte) error {
+	u.ArraySize = int32(binary.LittleEndian.Uint32(b[:4]))
+	if u.ArraySize <= 0 {
+		return nil
+	}
+
+	var offset = 4
+	for i := 1; i <= int(u.ArraySize); i++ {
+		u.Values = append(u.Values, binary.LittleEndian.Uint32(b[offset:offset+4]))
+		offset += 4
+	}
+
+	return nil
+}
+
+// Serialize serializes Uint32Array into bytes.
+func (u *Uint32Array) Serialize() ([]byte, error) {
+	b := make([]byte, u.Len())
+	if err := u.SerializeTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// SerializeTo serializes Uint32Array into bytes.
+func (u *Uint32Array) SerializeTo(b []byte) error {
+	var offset = 4
+	binary.LittleEndian.PutUint32(b[:4], uint32(u.ArraySize))
+
+	for _, v := range u.Values {
+		binary.LittleEndian.PutUint32(b[offset:offset+4], v)
+		offset += 4
+	}
+
+	return nil
+}
+
+// Len returns the actual length in int.
+func (u *Uint32Array) Len() int {
+	return 4 + (len(u.Values) * 4)
+}

--- a/datatypes/uint32_test.go
+++ b/datatypes/uint32_test.go
@@ -1,0 +1,122 @@
+// Copyright 2018 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package datatypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDecodeUint32Array(t *testing.T) {
+	cases := []struct {
+		input []byte
+		want  *Uint32Array
+	}{
+		{ // No contents
+			[]byte{
+				0x00, 0x00, 0x00, 0x00,
+			},
+			NewUint32Array(nil),
+		},
+		{ // 1 value
+			[]byte{
+				0x01, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00,
+			},
+			NewUint32Array([]uint32{1}),
+		},
+		{ // 4 values
+			[]byte{
+				0x04, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00,
+				0x02, 0x00, 0x00, 0x00,
+				0x03, 0x00, 0x00, 0x00,
+				0x04, 0x00, 0x00, 0x00,
+			},
+			NewUint32Array([]uint32{1, 2, 3, 4}),
+		},
+	}
+
+	for i, c := range cases {
+		got, err := DecodeUint32Array(c.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(got, c.want); diff != "" {
+			t.Errorf("case #%d failed\n%s", i, diff)
+		}
+	}
+}
+
+func TestSerializeUint32Array(t *testing.T) {
+	cases := []struct {
+		input *Uint32Array
+		want  []byte
+	}{
+		{ // No contents
+			NewUint32Array(nil),
+			[]byte{
+				0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{ // 1 value
+			NewUint32Array([]uint32{1}),
+			[]byte{
+				0x01, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00,
+			},
+		},
+		{ // 4 values
+			NewUint32Array([]uint32{1, 2, 3, 4}),
+			[]byte{
+				0x04, 0x00, 0x00, 0x00,
+				0x01, 0x00, 0x00, 0x00,
+				0x02, 0x00, 0x00, 0x00,
+				0x03, 0x00, 0x00, 0x00,
+				0x04, 0x00, 0x00, 0x00,
+			},
+		},
+	}
+
+	for i, c := range cases {
+		got, err := c.input.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(got, c.want); diff != "" {
+			t.Errorf("case #%d failed\n%s", i, diff)
+		}
+	}
+}
+
+func TestUint32ArrayLen(t *testing.T) {
+	cases := []struct {
+		input *Uint32Array
+		want  int
+	}{
+		{ // No contents
+			NewUint32Array(nil),
+			4,
+		},
+		{ // 1 value
+			NewUint32Array([]uint32{1}),
+			8,
+		},
+		{ // 4 values
+			NewUint32Array([]uint32{1, 2, 3, 4}),
+			20,
+		},
+	}
+
+	for i, c := range cases {
+		got := c.input.Len()
+		if diff := cmp.Diff(got, c.want); diff != "" {
+			t.Errorf("case #%d failed\n%s", i, diff)
+		}
+	}
+}


### PR DESCRIPTION
New datatype: Uint32Array
This is used for example in `Results` in ActivateSessionResponse.

* Add `Uint32Array` structure
* Add methods like other datatypes have
* Add tests in table-driven manner