### PR TITLE
Corrected README clone path and various spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See example directory for sample codes.
 ### Run
 
 ```shell-session
-git clone git@github.com:wmnsk/gopcua.git
+git clone https://github.com/wmnsk/gopcua.git
 cd examples/sender
 go run sender.go --ip <dst IP> --port <dst Port> --url "opc.tcp://endpoint.example/gopcua/server"
 ```

--- a/datatypes/bytestring_test.go
+++ b/datatypes/bytestring_test.go
@@ -36,7 +36,7 @@ func TestSerializeByteString(t *testing.T) {
 
 	serialized, err := b.Serialize()
 	if err != nil {
-		t.Fatalf("Failed to serizlize ByteString: %s", err)
+		t.Fatalf("Failed to serialize ByteString: %s", err)
 	}
 
 	for i, s := range serialized {

--- a/datatypes/localized-text.go
+++ b/datatypes/localized-text.go
@@ -135,7 +135,7 @@ func (l *LocalizedText) Len() int {
 	return ll
 }
 
-// String retunrs LocalizedText in string.
+// String returns LocalizedText in string.
 func (l *LocalizedText) String() string {
 	return fmt.Sprintf("%x, %s, %s", l.EncodingMask, l.Locale, l.Text)
 }

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -200,7 +200,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize TwoByteNodeID: %s", err)
+			t.Fatalf("Failed to serialize TwoByteNodeID: %s", err)
 		}
 
 		for i, s := range serialized {
@@ -217,7 +217,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize FourByteNodeID: %s", err)
+			t.Fatalf("Failed to serialize FourByteNodeID: %s", err)
 		}
 
 		for i, s := range serialized {
@@ -234,7 +234,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize NumericNodeID: %s", err)
+			t.Fatalf("Failed to serialize NumericNodeID: %s", err)
 		}
 
 		for i, s := range serialized {
@@ -251,7 +251,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize StringNodeID: %s", err)
+			t.Fatalf("Failed to serialize StringNodeID: %s", err)
 		}
 
 		for i, s := range serialized {
@@ -268,7 +268,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize GUIDNodeID: %s", err)
+			t.Fatalf("Failed to serialize GUIDNodeID: %s", err)
 		}
 
 		for i, s := range serialized {
@@ -285,7 +285,7 @@ func TestSerializeNodeID(t *testing.T) {
 
 		serialized, err := n.Serialize()
 		if err != nil {
-			t.Fatalf("Failed to serizlize OpaqueNodeID: %s", err)
+			t.Fatalf("Failed to serialize OpaqueNodeID: %s", err)
 		}
 
 		for i, s := range serialized {

--- a/examples/sender/sender.go
+++ b/examples/sender/sender.go
@@ -91,7 +91,7 @@ func main() {
 	case uacp.MessageTypeAcknowledge:
 		log.Printf("Received Acknowledge: %s", cp)
 
-		// Send OpenSecureChannelRequest and wait for Resposne to come
+		// Send OpenSecureChannelRequest and wait for Response to come
 		opn, err := uasc.New(o, cfg).Serialize()
 		if err != nil {
 			log.Fatalf("Failed to serialize OpenSecureChannel: %s", err)
@@ -122,7 +122,7 @@ func main() {
 		cfg.SecureChannelID = osc.SecurityToken.ChannelID
 		cfg.SecurityTokenID = osc.SecurityToken.TokenID
 
-		// Send GetEndpointsRequest and wait for Resposne to come
+		// Send GetEndpointsRequest and wait for Response to come
 		gep, err := uasc.New(g, cfg).Serialize()
 		if err != nil {
 			log.Fatalf("Failed to serialize GetEndpointsRequest: %s", err)

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /*
-Command server provides a connection establishement of OPC UA Secure Conversation as a server.
+Command server provides a connection establishment of OPC UA Secure Conversation as a server.
 
 XXX - Currently this command just handles the UACP connection from any client.
 */

--- a/services/application-description_test.go
+++ b/services/application-description_test.go
@@ -57,7 +57,7 @@ func TestSerializeApplicationDescription(t *testing.T) {
 
 	serialized, err := a.Serialize()
 	if err != nil {
-		t.Fatalf("Failed to serizlize ApplicationDescription: %s", err)
+		t.Fatalf("Failed to serialize ApplicationDescription: %s", err)
 	}
 
 	for i, s := range serialized {

--- a/services/endpoint-description.go
+++ b/services/endpoint-description.go
@@ -26,8 +26,8 @@ type EndpointDescription struct {
 	SecurityLevel       uint8
 }
 
-// NewEndpointDesctiption creates a new NewEndpointDesctiption.
-func NewEndpointDesctiption(url string, server *ApplicationDescription, cert []byte, secMode uint32, secURI string, tokens *UserTokenPolicyArray, transportURI string, secLevel uint8) *EndpointDescription {
+// NewEndpointDescription creates a new NewEndpointDescription.
+func NewEndpointDescription(url string, server *ApplicationDescription, cert []byte, secMode uint32, secURI string, tokens *UserTokenPolicyArray, transportURI string, secLevel uint8) *EndpointDescription {
 	return &EndpointDescription{
 		EndpointURL:         datatypes.NewString(url),
 		Server:              server,
@@ -208,7 +208,7 @@ type EndpointDescriptionArray struct {
 	EndpointDescriptions []*EndpointDescription
 }
 
-// NewEndpointDescriptionArray creates an NewEndpointDescriptionArray from multiple EndpointDesctiption.
+// NewEndpointDescriptionArray creates an NewEndpointDescriptionArray from multiple EndpointDescription.
 func NewEndpointDescriptionArray(descs []*EndpointDescription) *EndpointDescriptionArray {
 	e := &EndpointDescriptionArray{
 		ArraySize: int32(len(descs)),

--- a/services/endpoint-description_test.go
+++ b/services/endpoint-description_test.go
@@ -234,7 +234,7 @@ func TestSerializeEndpointDescription(t *testing.T) {
 	t.Run("single", func(t *testing.T) {
 		t.Parallel()
 
-		e := NewEndpointDesctiption(
+		e := NewEndpointDescription(
 			"ep-url",
 			NewApplicationDescription(
 				"app-uri", "prod-uri", "app-name", AppTypeServer,
@@ -277,7 +277,7 @@ func TestSerializeEndpointDescription(t *testing.T) {
 
 		e := NewEndpointDescriptionArray(
 			[]*EndpointDescription{
-				NewEndpointDesctiption(
+				NewEndpointDescription(
 					"ep-url",
 					NewApplicationDescription(
 						"app-uri", "prod-uri", "app-name", AppTypeServer,
@@ -301,7 +301,7 @@ func TestSerializeEndpointDescription(t *testing.T) {
 					"trans-uri",
 					0,
 				),
-				NewEndpointDesctiption(
+				NewEndpointDescription(
 					"ep-url",
 					NewApplicationDescription(
 						"app-uri", "prod-uri", "app-name", AppTypeServer,

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -750,7 +750,7 @@ func TestSerializeServices(t *testing.T) {
 			1, 0x00000000,
 			NewNullDiagnosticInfo(),
 			[]string{},
-			NewEndpointDesctiption(
+			NewEndpointDescription(
 				"ep-url",
 				NewApplicationDescription(
 					"app-uri", "prod-uri", "app-name", AppTypeServer,
@@ -774,7 +774,7 @@ func TestSerializeServices(t *testing.T) {
 				"trans-uri",
 				0,
 			),
-			NewEndpointDesctiption(
+			NewEndpointDescription(
 				"ep-url",
 				NewApplicationDescription(
 					"app-uri", "prod-uri", "app-name", AppTypeServer,
@@ -845,7 +845,7 @@ func TestSerializeServices(t *testing.T) {
 				0xa6, 0x43, 0xf8, 0x77, 0x7b, 0xc6, 0x2f, 0xc8,
 			},
 			6000000, nil, nil, "", nil, 65534,
-			NewEndpointDesctiption(
+			NewEndpointDescription(
 				"ep-url",
 				NewApplicationDescription(
 					"app-uri", "prod-uri", "app-name", AppTypeServer,
@@ -869,7 +869,7 @@ func TestSerializeServices(t *testing.T) {
 				"trans-uri",
 				0,
 			),
-			NewEndpointDesctiption(
+			NewEndpointDescription(
 				"ep-url",
 				NewApplicationDescription(
 					"app-uri", "prod-uri", "app-name", AppTypeServer,

--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -34,7 +34,7 @@ type Conn struct {
 // In other words, the data is passed when it is NOT one of Hello, Acknowledge, Error, ReverseHello.
 func (c *Conn) Read(b []byte) (n int, err error) {
 	if !(c.state == cliStateEstablished || c.state == srvStateEstablished) {
-		return 0, ErrConnNotEstablised
+		return 0, ErrConnNotEstablished
 	}
 	for {
 		select {
@@ -52,7 +52,7 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 // after a fixed time limit; see SetDeadline and SetWriteDeadline.
 func (c *Conn) Write(b []byte) (n int, err error) {
 	if !(c.state == cliStateEstablished || c.state == srvStateEstablished) {
-		return 0, ErrConnNotEstablised
+		return 0, ErrConnNotEstablished
 	}
 	select {
 	case e := <-c.errChan:
@@ -387,10 +387,10 @@ func (c *Conn) handleMsgReverseHello(r *ReverseHello) {
 // UACP-specific error definitions.
 // XXX - to be integrated in errors package.
 var (
-	ErrInvalidState      = errors.New("invalid state")
-	ErrInvalidEndpoint   = errors.New("invalid EndpointURL")
-	ErrUnexpectedMessage = errors.New("got unexpected message")
-	ErrTimeout           = errors.New("timed out")
-	ErrReceivedError     = errors.New("received Error message")
-	ErrConnNotEstablised = errors.New("connection not established")
+	ErrInvalidState       = errors.New("invalid state")
+	ErrInvalidEndpoint    = errors.New("invalid EndpointURL")
+	ErrUnexpectedMessage  = errors.New("got unexpected message")
+	ErrTimeout            = errors.New("timed out")
+	ErrReceivedError      = errors.New("received Error message")
+	ErrConnNotEstablished = errors.New("connection not established")
 )

--- a/uasc/secure-channel.go
+++ b/uasc/secure-channel.go
@@ -53,7 +53,7 @@ func (s *SecureChannel) Read(b []byte) (n int, err error) {
 }
 
 // ReadService reads the payload(=Service) from the connection.
-// Which means the UASC Headers are ommitted.
+// Which means the UASC Headers are omitted.
 func (s *SecureChannel) ReadService(b []byte) (n int, err error) {
 	if !(s.state == cliStateSecureChannelOpened || s.state == srvStateSecureChannelOpened) {
 		return 0, ErrSecureChannelNotOpened
@@ -93,7 +93,7 @@ func (s *SecureChannel) Write(b []byte) (n int, err error) {
 // WriteService writes data to the connection.
 // Unlike Write(), given b in WriteService() should only be serialized service.Service,
 // while the UASC header is automatically set by the package.
-// This enables writing arbitary Service even if the service is not implemented in the package.
+// This enables writing arbitrary Service even if the service is not implemented in the package.
 func (s *SecureChannel) WriteService(b []byte) (n int, err error) {
 	if !(s.state == cliStateSecureChannelOpened || s.state == srvStateSecureChannelOpened) {
 		return 0, ErrSecureChannelNotOpened


### PR DESCRIPTION
Adjusted the README clone path to the public https path instead of ssh
Corrected various spelling mistakes within the code base.