### PR TITLE
Changed the way to handle value in ExtensionObject

### DIFF
--- a/datatypes/user-identity-token.go
+++ b/datatypes/user-identity-token.go
@@ -8,6 +8,11 @@ import (
 	"github.com/wmnsk/gopcua/id"
 )
 
+// UserIdentityToken is an interface to handle all types of UserIdentityToken types as one type.
+type UserIdentityToken interface {
+	ExtensionObjectValue
+}
+
 // AnonymousIdentityToken is used to indicate that the Client has no user credentials.
 //
 // Specification: Part4, 7.36.5
@@ -68,9 +73,14 @@ func (a *AnonymousIdentityToken) Len() int {
 	return l
 }
 
-// Type returns PolicyID in int.
+// Type returns type of token defined in NodeIds.csv in int.
 func (a *AnonymousIdentityToken) Type() int {
 	return id.AnonymousIdentityToken_Encoding_DefaultBinary
+}
+
+// ID returns PolicyID in string.
+func (a *AnonymousIdentityToken) ID() string {
+	return a.PolicyID.Get()
 }
 
 // UserNameIdentityToken is used to pass simple username/password credentials to the Server.
@@ -210,9 +220,14 @@ func (u *UserNameIdentityToken) Len() int {
 	return l
 }
 
-// Type returns PolicyID in int.
+// Type returns type of token defined in NodeIds.csv in int.
 func (u *UserNameIdentityToken) Type() int {
 	return id.UserNameIdentityToken_Encoding_DefaultBinary
+}
+
+// ID returns PolicyID in string.
+func (u *UserNameIdentityToken) ID() string {
+	return u.PolicyID.Get()
 }
 
 // X509IdentityToken is used to pass an X.509 v3 Certificate which is issued by the user.
@@ -300,9 +315,14 @@ func (x *X509IdentityToken) Len() int {
 	return l
 }
 
-// Type returns PolicyID in int.
+// Type returns type of token defined in NodeIds.csv in int.
 func (x *X509IdentityToken) Type() int {
 	return id.X509IdentityToken_Encoding_DefaultBinary
+}
+
+// ID returns PolicyID in string.
+func (x *X509IdentityToken) ID() string {
+	return x.PolicyID.Get()
 }
 
 // IssuedIdentityToken is used to pass SecurityTokens issued by an external Authorization
@@ -424,7 +444,12 @@ func (i *IssuedIdentityToken) Len() int {
 	return l
 }
 
-// Type returns PolicyID in int.
+// Type returns type of token defined in NodeIds.csv in int.
 func (i *IssuedIdentityToken) Type() int {
 	return id.IssuedIdentityToken_Encoding_DefaultBinary
+}
+
+// ID returns PolicyID in string.
+func (i *IssuedIdentityToken) ID() string {
+	return i.PolicyID.Get()
 }

--- a/services/activate-session-request.go
+++ b/services/activate-session-request.go
@@ -31,7 +31,7 @@ type ActivateSessionRequest struct {
 }
 
 // NewActivateSessionRequest creates a new ActivateSessionRequest.
-func NewActivateSessionRequest(reqHeader *RequestHeader, sig *SignatureData, certs []*SignedSoftwareCertificate, locales []string, userToken *datatypes.ExtensionObject, tokenSig *SignatureData) *ActivateSessionRequest {
+func NewActivateSessionRequest(reqHeader *RequestHeader, sig *SignatureData, certs []*SignedSoftwareCertificate, locales []string, userToken datatypes.UserIdentityToken, tokenSig *SignatureData) *ActivateSessionRequest {
 	return &ActivateSessionRequest{
 		TypeID: datatypes.NewExpandedNodeID(
 			false, false,
@@ -44,7 +44,7 @@ func NewActivateSessionRequest(reqHeader *RequestHeader, sig *SignatureData, cer
 		ClientSignature:            sig,
 		ClientSoftwareCertificates: NewSignedSoftwareCertificateArray(certs),
 		LocaleIDs:                  datatypes.NewStringArray(locales),
-		UserIdentityToken:          userToken,
+		UserIdentityToken:          datatypes.NewExtensionObject(0x01, userToken),
 		UserTokenSignature:         tokenSig,
 	}
 }

--- a/services/activate-session-request_test.go
+++ b/services/activate-session-request_test.go
@@ -29,13 +29,7 @@ var activateSessionRequestCases = []struct {
 				1, 0, 0, "", NewNullAdditionalHeader(), nil,
 			),
 			NewSignatureData("", nil), nil, nil,
-			datatypes.NewExtensionObject(
-				&datatypes.ExpandedNodeID{
-					NodeID: datatypes.NewFourByteNodeID(0, 321),
-				},
-				0x01,
-				[]byte("0"),
-			),
+			datatypes.NewAnonymousIdentityToken("anonymous"),
 			NewSignatureData("", nil),
 		),
 		[]byte{
@@ -69,8 +63,10 @@ var activateSessionRequestCases = []struct {
 			0x01, 0x00, 0x41, 0x01,
 			// EncodingMask
 			0x01,
+			// Length
+			0x0d, 0x00, 0x00, 0x00,
 			// AnonymousIdentityToken
-			0x05, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30,
+			0x09, 0x00, 0x00, 0x00, 0x61, 0x6e, 0x6f, 0x6e, 0x79, 0x6d, 0x6f, 0x75, 0x73,
 			// UserTokenSignature
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 		},


### PR DESCRIPTION
Now `ExtensionObject` can handle the value depending on its type. Only `UserIdentityToken`(one of `AnonymousIdentityToken`, `UserNameIdentityToken`, `X509IdentityToken`, `IssuedIdentityToken`) is supported in the current implementation.