### PR TITLE
uacp: set SendBufferSize in HEL message

### DIFF
--- a/uacp/client.go
+++ b/uacp/client.go
@@ -44,6 +44,7 @@ func dial(ctx context.Context, endpoint string, interval time.Duration, maxRetry
 		lenChan:     make(chan int),
 		errChan:     make(chan error),
 		rcvBuf:      make([]byte, 0xffff),
+		sndBuf:      make([]byte, 0xffff),
 		rep:         endpoint,
 	}
 	conn.lowerConn, err = net.Dial(network, raddr.String())


### PR DESCRIPTION
The UACP handshake fails when connecting to the open62541 server
and a SendBufferSize of 0. The server never responds with an ACK.
Setting the SendBufferSize fixes this.