### PR TITLE
Simplify service object constructors

### DIFF
--- a/datatypes/expanded-node-id.go
+++ b/datatypes/expanded-node-id.go
@@ -37,6 +37,20 @@ func NewExpandedNodeID(hasURI, hasIndex bool, nodeID NodeID, uri string, idx uin
 	return e
 }
 
+// NewTwoByteExpandedNodeID creates a two byte numeric expanded node id.
+func NewTwoByteExpandedNodeID(id uint8) *ExpandedNodeID {
+	return &ExpandedNodeID{
+		NodeID: NewTwoByteNodeID(id),
+	}
+}
+
+// NewFourByteExpandedNodeID creates a four byte numeric expanded node id.
+func NewFourByteExpandedNodeID(ns uint8, id uint16) *ExpandedNodeID {
+	return &ExpandedNodeID{
+		NodeID: NewFourByteNodeID(ns, id),
+	}
+}
+
 // DecodeExpandedNodeID decodes given bytes into ExpandedNodeID.
 func DecodeExpandedNodeID(b []byte) (*ExpandedNodeID, error) {
 	e := &ExpandedNodeID{}

--- a/services/activate-session-request.go
+++ b/services/activate-session-request.go
@@ -33,13 +33,7 @@ type ActivateSessionRequest struct {
 // NewActivateSessionRequest creates a new ActivateSessionRequest.
 func NewActivateSessionRequest(reqHeader *RequestHeader, sig *SignatureData, locales []string, userToken datatypes.UserIdentityToken, tokenSig *SignatureData) *ActivateSessionRequest {
 	return &ActivateSessionRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeActivateSessionRequest,
-			),
-			"", 0,
-		),
+		TypeID:                     datatypes.NewFourByteExpandedNodeID(0, ServiceTypeActivateSessionRequest),
 		RequestHeader:              reqHeader,
 		ClientSignature:            sig,
 		ClientSoftwareCertificates: &SignedSoftwareCertificateArray{ArraySize: 0},

--- a/services/activate-session-response.go
+++ b/services/activate-session-response.go
@@ -33,13 +33,7 @@ type ActivateSessionResponse struct {
 // NewActivateSessionResponse creates a new NewActivateSessionResponse.
 func NewActivateSessionResponse(resHeader *ResponseHeader, nonce []byte, results []uint32, diags []*DiagnosticInfo) *ActivateSessionResponse {
 	return &ActivateSessionResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeActivateSessionResponse,
-			),
-			"", 0,
-		),
+		TypeID:          datatypes.NewFourByteExpandedNodeID(0, ServiceTypeActivateSessionResponse),
 		ResponseHeader:  resHeader,
 		ServerNonce:     datatypes.NewByteString(nonce),
 		Results:         datatypes.NewUint32Array(results),

--- a/services/additional-header.go
+++ b/services/additional-header.go
@@ -24,11 +24,7 @@ func NewAdditionalHeader(typeID *datatypes.ExpandedNodeID, mask uint8) *Addition
 // NewNullAdditionalHeader creates a new AdditionalHeader without meaningful values.
 func NewNullAdditionalHeader() *AdditionalHeader {
 	return &AdditionalHeader{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewTwoByteNodeID(0),
-			"", 0,
-		),
+		TypeID:       datatypes.NewTwoByteExpandedNodeID(0),
 		EncodingMask: 0x00,
 	}
 }

--- a/services/cancel-request.go
+++ b/services/cancel-request.go
@@ -24,11 +24,7 @@ type CancelRequest struct {
 // NewCancelRequest creates a new CancelRequest.
 func NewCancelRequest(reqHeader *RequestHeader, reqHandle uint32) *CancelRequest {
 	return &CancelRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, ServiceTypeCancelRequest),
-			"", 0,
-		),
+		TypeID:        datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCancelRequest),
 		RequestHeader: reqHeader,
 		RequestHandle: reqHandle,
 	}

--- a/services/cancel-response.go
+++ b/services/cancel-response.go
@@ -24,11 +24,7 @@ type CancelResponse struct {
 // NewCancelResponse creates a new CancelResponse.
 func NewCancelResponse(resHeader *ResponseHeader, cancelCount uint32) *CancelResponse {
 	return &CancelResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, ServiceTypeCancelResponse),
-			"", 0,
-		),
+		TypeID:         datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCancelResponse),
 		ResponseHeader: resHeader,
 		CancelCount:    cancelCount,
 	}

--- a/services/close-secure-channel-request.go
+++ b/services/close-secure-channel-request.go
@@ -24,13 +24,7 @@ type CloseSecureChannelRequest struct {
 // NewCloseSecureChannelRequest creates an CloseSecureChannelRequest.
 func NewCloseSecureChannelRequest(reqHeader *RequestHeader, chanID uint32) *CloseSecureChannelRequest {
 	return &CloseSecureChannelRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeCloseSecureChannelRequest,
-			),
-			"", 0,
-		),
+		TypeID:          datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCloseSecureChannelRequest),
 		RequestHeader:   reqHeader,
 		SecureChannelID: chanID,
 	}

--- a/services/close-secure-channel-response.go
+++ b/services/close-secure-channel-response.go
@@ -20,13 +20,7 @@ type CloseSecureChannelResponse struct {
 // NewCloseSecureChannelResponse creates an CloseSecureChannelResponse.
 func NewCloseSecureChannelResponse(resHeader *ResponseHeader) *CloseSecureChannelResponse {
 	return &CloseSecureChannelResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeCloseSecureChannelResponse,
-			),
-			"", 0,
-		),
+		TypeID:         datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCloseSecureChannelResponse),
 		ResponseHeader: resHeader,
 	}
 }

--- a/services/close-session-request.go
+++ b/services/close-session-request.go
@@ -21,13 +21,7 @@ type CloseSessionRequest struct {
 // NewCloseSessionRequest creates a CloseSessionRequest.
 func NewCloseSessionRequest(reqHeader *RequestHeader, deleteSubs bool) *CloseSessionRequest {
 	return &CloseSessionRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeCloseSessionRequest,
-			),
-			"", 0,
-		),
+		TypeID:              datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCloseSessionRequest),
 		RequestHeader:       reqHeader,
 		DeleteSubscriptions: datatypes.NewBoolean(deleteSubs),
 	}

--- a/services/close-session-response.go
+++ b/services/close-session-response.go
@@ -20,13 +20,7 @@ type CloseSessionResponse struct {
 // NewCloseSessionResponse creates an CloseSessionResponse.
 func NewCloseSessionResponse(resHeader *ResponseHeader) *CloseSessionResponse {
 	return &CloseSessionResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeCloseSessionResponse,
-			),
-			"", 0,
-		),
+		TypeID:         datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCloseSessionResponse),
 		ResponseHeader: resHeader,
 	}
 }

--- a/services/create-session-request.go
+++ b/services/create-session-request.go
@@ -31,11 +31,7 @@ type CreateSessionRequest struct {
 // NewCreateSessionRequest creates a new NewCreateSessionRequest with the given parameters.
 func NewCreateSessionRequest(reqHeader *RequestHeader, appDescr *ApplicationDescription, serverURI, endpoint, sessionName string, nonce, cert []byte, timeout uint64, maxRespSize uint32) *CreateSessionRequest {
 	return &CreateSessionRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, ServiceTypeCreateSessionRequest),
-			"", 0,
-		),
+		TypeID:                  datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCreateSessionRequest),
 		RequestHeader:           reqHeader,
 		ClientDescription:       appDescr,
 		ServerURI:               datatypes.NewString(serverURI),

--- a/services/create-session-response.go
+++ b/services/create-session-response.go
@@ -32,11 +32,7 @@ type CreateSessionResponse struct {
 // NewCreateSessionResponse creates a new NewCreateSessionResponse with the given parameters.
 func NewCreateSessionResponse(resHeader *ResponseHeader, sessionID, authToken datatypes.NodeID, timeout uint64, nonce, cert []byte, svrSignature *SignatureData, maxRespSize uint32, endpoints ...*EndpointDescription) *CreateSessionResponse {
 	return &CreateSessionResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, ServiceTypeCreateSessionResponse),
-			"", 0,
-		),
+		TypeID:                     datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCreateSessionResponse),
 		ResponseHeader:             resHeader,
 		SessionID:                  sessionID,
 		AuthenticationToken:        authToken,

--- a/services/create-subscription-request.go
+++ b/services/create-subscription-request.go
@@ -9,7 +9,6 @@ import (
 	"math"
 
 	"github.com/wmnsk/gopcua/datatypes"
-	"github.com/wmnsk/gopcua/id"
 )
 
 // CreateSubscriptionRequest is used to create a Subscription. Subscriptions monitor a set of MonitoredItems for
@@ -40,11 +39,7 @@ func NewCreateSubscriptionRequest(
 	priority byte,
 ) *CreateSubscriptionRequest {
 	return &CreateSubscriptionRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, id.CreateSubscriptionRequest_Encoding_DefaultBinary),
-			"", 0,
-		),
+		TypeID:                      datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCreateSubscriptionRequest),
 		RequestHeader:               reqHeader,
 		RequestedPublishingInterval: pubInterval,
 		RequestedLifetimeCount:      lifetime,
@@ -192,5 +187,5 @@ func (c *CreateSubscriptionRequest) Len() int {
 
 // ServiceType returns type of Service in uint16.
 func (c *CreateSubscriptionRequest) ServiceType() uint16 {
-	return id.CreateSubscriptionRequest_Encoding_DefaultBinary
+	return ServiceTypeCreateSubscriptionRequest
 }

--- a/services/find-servers-on-network-request.go
+++ b/services/find-servers-on-network-request.go
@@ -43,13 +43,7 @@ type FindServersOnNetworkRequest struct {
 // NewFindServersOnNetworkRequest creates a new FindServersOnNetworkRequest.
 func NewFindServersOnNetworkRequest(reqHeader *RequestHeader, startRecord, maxRecords uint32, filters ...string) *FindServersOnNetworkRequest {
 	f := &FindServersOnNetworkRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeFindServersOnNetworkRequest,
-			),
-			"", 0,
-		),
+		TypeID:             datatypes.NewFourByteExpandedNodeID(0, ServiceTypeFindServersOnNetworkRequest),
 		RequestHeader:      reqHeader,
 		StartingRecordID:   startRecord,
 		MaxRecordsToReturn: maxRecords,

--- a/services/find-servers-on-network-response.go
+++ b/services/find-servers-on-network-response.go
@@ -26,13 +26,7 @@ type FindServersOnNetworkResponse struct {
 // NewFindServersOnNetworkResponse creates an FindServersOnNetworkResponse.
 func NewFindServersOnNetworkResponse(resHeader *ResponseHeader, resetTime time.Time, servers ...*datatypes.ServersOnNetwork) *FindServersOnNetworkResponse {
 	return &FindServersOnNetworkResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeFindServersOnNetworkResponse,
-			),
-			"", 0,
-		),
+		TypeID:               datatypes.NewFourByteExpandedNodeID(0, ServiceTypeFindServersOnNetworkResponse),
 		ResponseHeader:       resHeader,
 		LastCounterResetTime: resetTime,
 		Servers:              datatypes.NewServersOnNetworkArray(servers),

--- a/services/find-servers-request.go
+++ b/services/find-servers-request.go
@@ -27,13 +27,7 @@ type FindServersRequest struct {
 // NewFindServersRequest creates a new FindServersRequest.
 func NewFindServersRequest(reqHeader *RequestHeader, url string, locales []string, serverURIs ...string) *FindServersRequest {
 	f := &FindServersRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeFindServersRequest,
-			),
-			"", 0,
-		),
+		TypeID:        datatypes.NewFourByteExpandedNodeID(0, ServiceTypeFindServersRequest),
 		RequestHeader: reqHeader,
 		EndpointURL:   datatypes.NewString(url),
 		LocaleIDs:     datatypes.NewStringArray(locales),

--- a/services/find-servers-response.go
+++ b/services/find-servers-response.go
@@ -22,13 +22,7 @@ type FindServersResponse struct {
 // NewFindServersResponse creates an FindServersResponse.
 func NewFindServersResponse(resHeader *ResponseHeader, servers ...*ApplicationDescription) *FindServersResponse {
 	return &FindServersResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeFindServersResponse,
-			),
-			"", 0,
-		),
+		TypeID:         datatypes.NewFourByteExpandedNodeID(0, ServiceTypeFindServersResponse),
 		ResponseHeader: resHeader,
 		Servers:        NewApplicationDescriptionArray(servers),
 	}

--- a/services/get-endpoints-request.go
+++ b/services/get-endpoints-request.go
@@ -25,13 +25,7 @@ type GetEndpointsRequest struct {
 // NewGetEndpointsRequest creates an GetEndpointsRequest.
 func NewGetEndpointsRequest(reqHeader *RequestHeader, endpoint string, localIDs, profileURIs []string) *GetEndpointsRequest {
 	return &GetEndpointsRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeGetEndpointsRequest,
-			),
-			"", 0,
-		),
+		TypeID:        datatypes.NewFourByteExpandedNodeID(0, ServiceTypeGetEndpointsRequest),
 		RequestHeader: reqHeader,
 		EndpointURL:   datatypes.NewString(endpoint),
 		LocaleIDs:     datatypes.NewStringArray(localIDs),

--- a/services/get-endpoints-response.go
+++ b/services/get-endpoints-response.go
@@ -19,13 +19,7 @@ type GetEndpointsResponse struct {
 // NewGetEndpointsResponse creates an GetEndpointsResponse.
 func NewGetEndpointsResponse(resHeader *ResponseHeader, endpoints ...*EndpointDescription) *GetEndpointsResponse {
 	return &GetEndpointsResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeGetEndpointsResponse,
-			),
-			"", 0,
-		),
+		TypeID:         datatypes.NewFourByteExpandedNodeID(0, ServiceTypeGetEndpointsResponse),
 		ResponseHeader: resHeader,
 		Endpoints:      NewEndpointDescriptionArray(endpoints),
 	}

--- a/services/open-secure-channel-request.go
+++ b/services/open-secure-channel-request.go
@@ -47,13 +47,7 @@ type OpenSecureChannelRequest struct {
 // NewOpenSecureChannelRequest creates an OpenSecureChannelRequest.
 func NewOpenSecureChannelRequest(reqHeader *RequestHeader, ver, tokenType, securityMode, lifetime uint32, nonce []byte) *OpenSecureChannelRequest {
 	return &OpenSecureChannelRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeOpenSecureChannelRequest,
-			),
-			"", 0,
-		),
+		TypeID:                   datatypes.NewFourByteExpandedNodeID(0, ServiceTypeOpenSecureChannelRequest),
 		RequestHeader:            reqHeader,
 		ClientProtocolVersion:    ver,
 		SecurityTokenRequestType: tokenType,

--- a/services/open-secure-channel-response.go
+++ b/services/open-secure-channel-response.go
@@ -23,13 +23,7 @@ type OpenSecureChannelResponse struct {
 // NewOpenSecureChannelResponse creates an OpenSecureChannelResponse.
 func NewOpenSecureChannelResponse(resHeader *ResponseHeader, ver uint32, secToken *ChannelSecurityToken, nonce []byte) *OpenSecureChannelResponse {
 	return &OpenSecureChannelResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeOpenSecureChannelResponse,
-			),
-			"", 0,
-		),
+		TypeID:                datatypes.NewFourByteExpandedNodeID(0, ServiceTypeOpenSecureChannelResponse),
 		ResponseHeader:        resHeader,
 		ServerProtocolVersion: ver,
 		SecurityToken:         secToken,

--- a/services/read-request.go
+++ b/services/read-request.go
@@ -85,13 +85,7 @@ type ReadRequest struct {
 // NewReadRequest creates a new ReadRequest.
 func NewReadRequest(reqHeader *RequestHeader, maxAge uint64, tsRet TimestampsToReturn, nodes ...*datatypes.ReadValueID) *ReadRequest {
 	return &ReadRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeReadRequest,
-			),
-			"", 0,
-		),
+		TypeID:             datatypes.NewFourByteExpandedNodeID(0, ServiceTypeReadRequest),
 		RequestHeader:      reqHeader,
 		MaxAge:             maxAge,
 		TimestampsToReturn: tsRet,

--- a/services/read-response.go
+++ b/services/read-response.go
@@ -22,13 +22,7 @@ type ReadResponse struct {
 // NewReadResponse creates a new ReadResponse.
 func NewReadResponse(resHeader *ResponseHeader, diag []*DiagnosticInfo, results ...*datatypes.DataValue) *ReadResponse {
 	return &ReadResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeReadResponse,
-			),
-			"", 0,
-		),
+		TypeID:          datatypes.NewFourByteExpandedNodeID(0, ServiceTypeReadResponse),
 		ResponseHeader:  resHeader,
 		Results:         datatypes.NewDataValueArray(results),
 		DiagnosticInfos: NewDiagnosticInfoArray(diag),

--- a/services/write-request.go
+++ b/services/write-request.go
@@ -23,13 +23,7 @@ type WriteRequest struct {
 // NewWriteRequest creates a new WriteRequest.
 func NewWriteRequest(reqHeader *RequestHeader, nodes ...*datatypes.WriteValue) *WriteRequest {
 	return &WriteRequest{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(
-				0, ServiceTypeWriteRequest,
-			),
-			"", 0,
-		),
+		TypeID:        datatypes.NewFourByteExpandedNodeID(0, ServiceTypeWriteRequest),
 		RequestHeader: reqHeader,
 		NodesToWrite:  datatypes.NewWriteValueArray(nodes),
 	}

--- a/services/write-response.go
+++ b/services/write-response.go
@@ -26,11 +26,7 @@ type WriteResponse struct {
 // NewWriteResponse creates a new WriteResponse.
 func NewWriteResponse(resHeader *ResponseHeader, diags []*DiagnosticInfo, results ...uint32) *WriteResponse {
 	return &WriteResponse{
-		TypeID: datatypes.NewExpandedNodeID(
-			false, false,
-			datatypes.NewFourByteNodeID(0, ServiceTypeWriteResponse),
-			"", 0,
-		),
+		TypeID:          datatypes.NewFourByteExpandedNodeID(0, ServiceTypeWriteResponse),
 		ResponseHeader:  resHeader,
 		Results:         datatypes.NewUint32Array(results),
 		DiagnosticInfos: NewDiagnosticInfoArray(diags),


### PR DESCRIPTION
The service object constructors all need a `TypeID` which is a four byte expanded node id in always all cases. This patch creates a helper function and uses it when creating service objects.