### PR TITLE
Handle float32 NaN according to OPC/UA spec

### DIFF
--- a/datatypes/float.go
+++ b/datatypes/float.go
@@ -55,6 +55,12 @@ func (f *Float) Serialize() ([]byte, error) {
 
 // SerializeTo serializes Float into bytes.
 func (f *Float) SerializeTo(b []byte) error {
+	// Part 6, 5.2.2.3 encode NaN as IEEE 754 silent NaN
+	if math.IsNaN(float64(f.Value)) {
+		binary.LittleEndian.PutUint32(b, 0xFFC00000)
+		return nil
+	}
+
 	bits := math.Float32bits(f.Value)
 	binary.LittleEndian.PutUint32(b, bits)
 	return nil

--- a/datatypes/float_test.go
+++ b/datatypes/float_test.go
@@ -35,6 +35,29 @@ func TestNewFloat(t *testing.T) {
 	}
 }
 
+func TestFloatNaN(t *testing.T) {
+	qnan32 := []byte{0x00, 0x00, 0xc0, 0xff}
+	t.Run("decode silent nan", func(t *testing.T) {
+		f, err := DecodeFloat(qnan32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !math.IsNaN(float64(f.Value)) {
+			t.Fatal("should be NaN")
+		}
+	})
+	t.Run("encode nan", func(t *testing.T) {
+		f := &Float{float32(math.NaN())}
+		b, err := f.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(b, qnan32); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}
+
 func TestDecodeFloat(t *testing.T) {
 	b := []byte{0x64, 0x06, 0xa0, 0x40}
 	f, err := DecodeFloat(b)


### PR DESCRIPTION
From Part 6, 5.2.2.3 Float:

> The floating-point type supports positive and negative infinity and not-a-number (NaN). The IEEE specification allows for multiple NaN variants; however, the encoders/decoders may not preserve the distinction. Encoders shall encode a NaN value as an IEEE quiet-NAN (000000000000F8FF) or (0000C0FF). Any unsupported types such as denormalized numbers shall also be encoded as an IEEE quiet-NAN. Any test for equality between NaN values always fails.