### PR TITLE
Simpler float test

### DIFF
--- a/datatypes/data-value_test.go
+++ b/datatypes/data-value_test.go
@@ -50,7 +50,7 @@ func TestDecodeDataValue(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(v, test.dv, opt); diff != "" {
+			if diff := cmp.Diff(v, test.dv); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -64,7 +64,7 @@ func TestDataValueDecodeFromBytes(t *testing.T) {
 			if err := d.DecodeFromBytes(test.bytes); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(d, test.dv, opt); diff != "" {
+			if diff := cmp.Diff(d, test.dv); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -146,7 +146,7 @@ func TestDecodeDataValueArray(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(v, test.dva, opt); diff != "" {
+			if diff := cmp.Diff(v, test.dva); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -160,7 +160,7 @@ func TestDataValueArrayDecodeFromBytes(t *testing.T) {
 			if err := d.DecodeFromBytes(test.bytes); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(d, test.dva, opt); diff != "" {
+			if diff := cmp.Diff(d, test.dva); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/datatypes/float_test.go
+++ b/datatypes/float_test.go
@@ -5,25 +5,10 @@
 package datatypes
 
 import (
-	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
-
-// Testing floating point numbers
-// https://www.juliaferraioli.com/blog/2018/06/golang-testing-floats/
-
-// Approximate equality for floats can be handled by defining a custom comparer on floats
-// that determines two values to be equal if they are within some range of each other.
-// https://godoc.org/github.com/google/go-cmp/cmp#example-Option--ApproximateFloats
-var opt = cmp.Comparer(func(x, y float32) bool {
-	a := float64(x)
-	b := float64(y)
-	delta := math.Abs(a - b)
-	mean := math.Abs(a+b) / 2.0
-	return delta/mean < 0.00001
-})
 
 func TestNewFloat(t *testing.T) {
 	f := NewFloat(5.00078)
@@ -44,7 +29,7 @@ func TestDecodeFloat(t *testing.T) {
 	expected := &Float{
 		Value: 5.00078,
 	}
-	if diff := cmp.Diff(f, expected, opt); diff != "" {
+	if diff := cmp.Diff(f, expected); diff != "" {
 		t.Error(diff)
 	}
 }
@@ -58,7 +43,7 @@ func TestFloatDecodeFromBytes(t *testing.T) {
 	expected := &Float{
 		Value: 5.00078,
 	}
-	if diff := cmp.Diff(f, expected, opt); diff != "" {
+	if diff := cmp.Diff(f, expected); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/datatypes/variant_test.go
+++ b/datatypes/variant_test.go
@@ -60,7 +60,7 @@ func TestDecodeVariant(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(v, test.expected, opt); diff != "" {
+			if diff := cmp.Diff(v, test.expected); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -74,7 +74,7 @@ func TestVariantDecodeFromBytes(t *testing.T) {
 			if err := v.DecodeFromBytes(test.in); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(v, test.expected, opt); diff != "" {
+			if diff := cmp.Diff(v, test.expected); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/securitypolicy/securitypolicy_test.go
+++ b/securitypolicy/securitypolicy_test.go
@@ -134,7 +134,7 @@ func TestEncryptionAlgorithms(t *testing.T) {
 			t.Fatalf("failed to decrypt Symmetric (%s) : %s", c, err)
 		}
 		symDeciphered = symDeciphered[:len(symDeciphered)-padSize] // Trim off padding
-		if diff := cmp.Diff(symDeciphered, plaintext, nil); diff != "" {
+		if diff := cmp.Diff(symDeciphered, plaintext); diff != "" {
 			t.Errorf("Policy: %s\nsymmetric encryption failed:\n%s\n", c, diff)
 		}
 
@@ -142,7 +142,7 @@ func TestEncryptionAlgorithms(t *testing.T) {
 		// our byte slices are referencing the same data and the previous test may have
 		// been a false positive
 		paddedPlaintext[4] = 0xff ^ paddedPlaintext[4]
-		if diff := cmp.Diff(symDeciphered, payloadRef, nil); diff != "" {
+		if diff := cmp.Diff(symDeciphered, payloadRef); diff != "" {
 			t.Errorf("Policy: %s\nsymmetric input corruption detected:\n%s\n", c, diff)
 		}
 
@@ -165,12 +165,12 @@ func TestEncryptionAlgorithms(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to decrypt Asymmetric (%s) : %s", c, err)
 		}
-		if diff := cmp.Diff(asymDeciphered, plaintext, nil); diff != "" {
+		if diff := cmp.Diff(asymDeciphered, plaintext); diff != "" {
 			t.Errorf("Policy: %s\nasymmetric encryption failed:\n%s\n", c, diff)
 		}
 
 		paddedPlaintext[4] = 0xff ^ paddedPlaintext[4]
-		if diff := cmp.Diff(asymDeciphered, payloadRef, nil); diff != "" {
+		if diff := cmp.Diff(asymDeciphered, payloadRef); diff != "" {
 			t.Errorf("Policy: %s\nasymmetric input corruption detected:\n%s\n", c, diff)
 		}
 


### PR DESCRIPTION
As long as we are only testing float values within the range of precision
of the underlying datatype we should not require approximation. Any
deviation of the value from the bytes should be an error.