### PR TITLE
Make NodeID a union type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - checkout
       - run: go get -u github.com/pkg/errors
       - run: go get -u github.com/google/go-cmp/cmp
+      - run: go get -u github.com/pascaldekloe/goe/verify
       - run: go install ./...
       - run: go get -v -t -d ./...
       - run: go get -u golang.org/x/lint/golint

--- a/datatypes/expanded-node-id.go
+++ b/datatypes/expanded-node-id.go
@@ -14,13 +14,13 @@ import (
 //
 // Specification: Part 6, 5.2.2.10
 type ExpandedNodeID struct {
-	NodeID
+	NodeID       *NodeID
 	NamespaceURI *String
 	ServerIndex  uint32
 }
 
 // NewExpandedNodeID creates a new ExpandedNodeID.
-func NewExpandedNodeID(hasURI, hasIndex bool, nodeID NodeID, uri string, idx uint32) *ExpandedNodeID {
+func NewExpandedNodeID(hasURI, hasIndex bool, nodeID *NodeID, uri string, idx uint32) *ExpandedNodeID {
 	e := &ExpandedNodeID{
 		NodeID:      nodeID,
 		ServerIndex: idx,
@@ -63,8 +63,8 @@ func DecodeExpandedNodeID(b []byte) (*ExpandedNodeID, error) {
 
 // DecodeFromBytes decodes given bytes into ExpandedNodeID.
 func (e *ExpandedNodeID) DecodeFromBytes(b []byte) error {
-	node, err := DecodeNodeID(b)
-	if err != nil {
+	node := &NodeID{}
+	if err := node.DecodeFromBytes(b); err != nil {
 		return err
 	}
 	e.NodeID = node
@@ -140,10 +140,10 @@ func (e *ExpandedNodeID) Len() int {
 
 // HasNamespaceURI checks if an ExpandedNodeID has NamespaceURI Flag.
 func (e *ExpandedNodeID) HasNamespaceURI() bool {
-	return e.NodeID.EncodingMaskValue()>>7&0x1 == 1
+	return e.NodeID.EncodingMask()>>7&0x1 == 1
 }
 
 // HasServerIndex checks if an ExpandedNodeID has ServerIndex Flag.
 func (e *ExpandedNodeID) HasServerIndex() bool {
-	return e.NodeID.EncodingMaskValue()>>6&0x1 == 1
+	return e.NodeID.EncodingMask()>>6&0x1 == 1
 }

--- a/datatypes/extension-object.go
+++ b/datatypes/extension-object.go
@@ -64,13 +64,10 @@ func (e *ExtensionObject) DecodeFromBytes(b []byte) error {
 
 	// extension object parameter
 	var id int
-	switch e.TypeID.NodeID.(type) {
-	case *TwoByteNodeID:
-		id = int(nodeID.GetIdentifier()[0])
-	case *FourByteNodeID:
-		id = int(binary.LittleEndian.Uint16(nodeID.GetIdentifier()))
-	case *NumericNodeID:
-		id = int(binary.LittleEndian.Uint32(nodeID.GetIdentifier()))
+	node := e.TypeID.NodeID
+	switch node.Type() {
+	case TypeTwoByte, TypeFourByte, TypeNumeric:
+		id = node.IntID()
 	default:
 		return errors.NewErrInvalidType(e.TypeID.NodeID, "decode", "NodeID should be TwoByte, FourByte or Numeric")
 	}

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -330,6 +330,36 @@ func (n *NodeID) IntID() int {
 	return int(n.nid)
 }
 
+// SetIntID sets the identifier value for two byte, four byte and
+// numeric node ids. It returns an error for other types.
+func (n *NodeID) SetIntID(v int) error {
+	switch n.Type() {
+	case TypeTwoByte:
+		if max := math.MaxUint8; v < 0 || v > max {
+			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+		}
+		n.nid = uint32(v)
+		return nil
+
+	case TypeFourByte:
+		if max := math.MaxUint16; v < 0 || v > max {
+			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+		}
+		n.nid = uint32(v)
+		return nil
+
+	case TypeNumeric:
+		if max := math.MaxUint32; v < 0 || v > max {
+			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+		}
+		n.nid = uint32(v)
+		return nil
+
+	default:
+		return fmt.Errorf("incompatible node id type")
+	}
+}
+
 // StringID returns the string value of the identifier
 // for String and GUID NodeIDs, and the base64 encoded
 // value for Opaque types. For all other types StringID
@@ -347,6 +377,31 @@ func (n *NodeID) StringID() string {
 		return base64.StdEncoding.EncodeToString(n.bid)
 	default:
 		return ""
+	}
+}
+
+// SetStringID sets the identifier value for string, guid and opaque
+// node ids. It returns an error for other types.
+func (n *NodeID) SetStringID(v string) error {
+	switch n.Type() {
+	case TypeGUID:
+		n.gid = NewGUID(v)
+		return nil
+
+	case TypeString:
+		n.bid = []byte(v)
+		return nil
+
+	case TypeOpaque:
+		b, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
+			return err
+		}
+		n.bid = b
+		return nil
+
+	default:
+		return fmt.Errorf("incompatible node id type")
 	}
 }
 

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -90,9 +90,15 @@ func NewOpaqueNodeID(ns uint16, id []byte) *NodeID {
 }
 
 // NewNodeID returns a node id from a string definition of the format
-// 'ns=<namespace>;{s,i,b,g}=<identifier>'. Namespace URLs 'nsu=' are not
-// supported since they require a lookup. For string node ids the 's='
-// prefix can be omitted.
+// 'ns=<namespace>;{s,i,b,g}=<identifier>'.
+//
+// For string node ids the 's=' prefix can be omitted.
+//
+// For numeric ids the smallest possible type which can store the namespace
+// and id value is returned.
+//
+// Namespace URLs 'nsu=' are not supported since they require a lookup.
+//
 func NewNodeID(s string) (*NodeID, error) {
 	if s == "" {
 		return NewTwoByteNodeID(0), nil

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 )
 
-// NodeId type definitions.
+// NodeID type definitions.
 //
 // Specification: Part 6, 5.2.2.9
 const (
-	TypeTwoByte uint8 = iota
+	TypeTwoByte = iota
 	TypeFourByte
 	TypeNumeric
 	TypeString
@@ -26,6 +26,8 @@ const (
 	TypeOpaque
 )
 
+// NodeID is an identifier for a node in the address space of an OPC UA Server.
+// The NodeID object encodes all different node id types.
 type NodeID struct {
 	mask uint8
 	ns   uint16
@@ -34,6 +36,7 @@ type NodeID struct {
 	gid  *GUID
 }
 
+// NewTwoByteNodeID returns a new two byte node id.
 func NewTwoByteNodeID(id uint8) *NodeID {
 	return &NodeID{
 		mask: TypeTwoByte,
@@ -41,6 +44,7 @@ func NewTwoByteNodeID(id uint8) *NodeID {
 	}
 }
 
+// NewFourByteNodeID returns a new four byte node id.
 func NewFourByteNodeID(ns uint8, id uint16) *NodeID {
 	return &NodeID{
 		mask: TypeFourByte,
@@ -49,6 +53,7 @@ func NewFourByteNodeID(ns uint8, id uint16) *NodeID {
 	}
 }
 
+// NewNumericNodeID returns a new numeric node id.
 func NewNumericNodeID(ns uint16, id uint32) *NodeID {
 	return &NodeID{
 		mask: TypeNumeric,
@@ -57,6 +62,7 @@ func NewNumericNodeID(ns uint16, id uint32) *NodeID {
 	}
 }
 
+// NewStringNodeID returns a new string node id.
 func NewStringNodeID(ns uint16, id string) *NodeID {
 	return &NodeID{
 		mask: TypeString,
@@ -65,6 +71,7 @@ func NewStringNodeID(ns uint16, id string) *NodeID {
 	}
 }
 
+// NewGUIDNodeID returns a new GUID node id.
 func NewGUIDNodeID(ns uint16, id string) *NodeID {
 	return &NodeID{
 		mask: TypeGUID,
@@ -73,6 +80,7 @@ func NewGUIDNodeID(ns uint16, id string) *NodeID {
 	}
 }
 
+// NewOpaqueNodeID returns a new opaque node id.
 func NewOpaqueNodeID(ns uint16, id []byte) *NodeID {
 	return &NodeID{
 		mask: TypeOpaque,
@@ -81,257 +89,11 @@ func NewOpaqueNodeID(ns uint16, id []byte) *NodeID {
 	}
 }
 
-func (n *NodeID) EncodingMask() uint8 {
-	return n.mask
-}
-
-func (n *NodeID) Type() uint8 {
-	return n.mask & 0xf
-}
-
-// URIFlag returns whether the URI flag is set in EncodingMask.
-func (n *NodeID) URIFlag() bool {
-	return n.mask&0x80 == 0x80
-}
-
-// SetURIFlag sets NamespaceURI flag in EncodingMask.
-func (n *NodeID) SetURIFlag() {
-	n.mask |= 0x80
-}
-
-// IndexFlag returns whether the Index flag is set in EncodingMask.
-func (n *NodeID) IndexFlag() bool {
-	return n.mask&0x40 == 0x40
-}
-
-// SetIndexFlag sets NamespaceURI flag in EncodingMask.
-func (n *NodeID) SetIndexFlag() {
-	n.mask |= 0x40
-}
-
-// GetIdentifier returns value in Identifier field in bytes.
-func (n *NodeID) GetIdentifier() []byte {
-	switch n.Type() {
-	case TypeTwoByte:
-		return []byte{uint8(n.nid)}
-
-	case TypeFourByte:
-		b := make([]byte, 2)
-		binary.LittleEndian.PutUint16(b, uint16(n.nid))
-		return b
-
-	case TypeNumeric:
-		b := make([]byte, 4)
-		binary.LittleEndian.PutUint32(b, n.nid)
-		return b
-
-	case TypeGUID:
-		b, _ := n.gid.Serialize()
-		return b
-
-	case TypeString, TypeOpaque:
-		return n.bid
-
-	default:
-		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
-	}
-}
-
-// Serialize serializes NodeID into bytes.
-func (n *NodeID) Serialize() ([]byte, error) {
-	b := make([]byte, n.Len())
-	if err := n.SerializeTo(b); err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
-// SerializeTo serializes NodeID into bytes.
-func (n *NodeID) SerializeTo(b []byte) error {
-	switch n.Type() {
-	case TypeTwoByte:
-		b[0] = n.mask
-		b[1] = uint8(n.nid)
-		return nil
-
-	case TypeFourByte:
-		b[0] = n.mask
-		b[1] = uint8(n.ns)
-		binary.LittleEndian.PutUint16(b[2:], uint16(n.nid))
-		return nil
-
-	case TypeNumeric:
-		b[0] = n.mask
-		binary.LittleEndian.PutUint16(b[1:3], n.ns)
-		binary.LittleEndian.PutUint32(b[3:7], n.nid)
-		return nil
-
-	case TypeGUID:
-		b[0] = n.mask
-		binary.LittleEndian.PutUint16(b[1:3], n.ns)
-		return n.gid.SerializeTo(b[3:])
-
-	case TypeString, TypeOpaque:
-		b[0] = n.mask
-		binary.LittleEndian.PutUint16(b[1:3], n.ns)
-		binary.LittleEndian.PutUint32(b[3:7], uint32(len(n.bid)))
-		copy(b[7:7+len(n.bid)], n.bid)
-		return nil
-
-	default:
-		return fmt.Errorf("invalid node id type: %d", n.Type())
-	}
-
-	return nil
-}
-
-func (n *NodeID) DecodeFromBytes(b []byte) error {
-	if len(b) == 0 {
-		return io.ErrUnexpectedEOF
-	}
-	n.mask = b[0]
-
-	switch n.Type() {
-	case TypeTwoByte:
-		if len(b) < 2 {
-			return io.ErrUnexpectedEOF
-		}
-		n.nid = uint32(b[1])
-		return nil
-
-	case TypeFourByte:
-		if len(b) < 4 {
-			return io.ErrUnexpectedEOF
-		}
-		n.ns = uint16(b[1])
-		n.nid = uint32(binary.LittleEndian.Uint16(b[2:4]))
-		return nil
-
-	case TypeNumeric:
-		if len(b) < 7 {
-			return io.ErrUnexpectedEOF
-		}
-		n.ns = binary.LittleEndian.Uint16(b[1:3])
-		n.nid = binary.LittleEndian.Uint32(b[3:7])
-		return nil
-
-	case TypeGUID:
-		if len(b) < 19 {
-			return io.ErrUnexpectedEOF
-		}
-		n.ns = binary.LittleEndian.Uint16(b[1:3])
-		n.gid = &GUID{}
-		return n.gid.DecodeFromBytes(b[3:19])
-
-	case TypeString, TypeOpaque:
-		if len(b) < 7 {
-			return io.ErrUnexpectedEOF
-		}
-		n.ns = binary.LittleEndian.Uint16(b[1:3])
-		l := binary.LittleEndian.Uint32(b[3:7])
-		if len(b) < int(l) {
-			return io.ErrUnexpectedEOF
-		}
-		n.bid = make([]byte, l)
-		copy(n.bid, b[7:7+l])
-		return nil
-
-	default:
-		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
-	}
-}
-
-// GetIdentifier returns value in Identifier field in bytes.
-func (n *NodeID) Len() int {
-	switch n.Type() {
-	case TypeTwoByte:
-		return 2
-
-	case TypeFourByte:
-		return 4
-
-	case TypeNumeric:
-		return 7
-
-	case TypeString:
-		return 7 + len(n.bid)
-
-	case TypeGUID:
-		return 19
-
-	case TypeOpaque:
-		return 7 + len(n.bid)
-
-	default:
-		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
-	}
-}
-
-func (n *NodeID) IntID() int {
-	return int(n.nid)
-}
-
-func (n *NodeID) StringID() string {
-	switch n.Type() {
-	case TypeGUID:
-		if n.gid == nil {
-			return ""
-		}
-		return n.gid.String()
-	case TypeString:
-		return string(n.bid)
-	case TypeOpaque:
-		return base64.StdEncoding.EncodeToString(n.bid)
-	default:
-		return ""
-	}
-}
-
-func (n *NodeID) String() string {
-	switch n.Type() {
-	case TypeTwoByte:
-		return fmt.Sprintf("i=%d", n.nid)
-
-	case TypeFourByte:
-		if n.ns == 0 {
-			return fmt.Sprintf("i=%d", n.nid)
-		}
-		return fmt.Sprintf("ns=%d;i=%d", n.ns, n.nid)
-
-	case TypeNumeric:
-		if n.ns == 0 {
-			return fmt.Sprintf("i=%d", n.nid)
-		}
-		return fmt.Sprintf("ns=%d;i=%d", n.ns, n.nid)
-
-	case TypeString:
-		if n.ns == 0 {
-			return fmt.Sprintf("s=%s", n.StringID())
-		}
-		return fmt.Sprintf("ns=%d;s=%s", n.ns, n.StringID())
-
-	case TypeGUID:
-		if n.ns == 0 {
-			return fmt.Sprintf("g=%s", n.StringID())
-		}
-		return fmt.Sprintf("ns=%d;g=%s", n.ns, n.StringID())
-
-	case TypeOpaque:
-		if n.ns == 0 {
-			return fmt.Sprintf("o=%s", n.StringID())
-		}
-		return fmt.Sprintf("ns=%d;o=%s", n.ns, n.StringID())
-
-	default:
-		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
-	}
-}
-
-// ParseNodeID returns a node id from a string definition of the format
+// NewNodeID returns a node id from a string definition of the format
 // 'ns=<namespace>;{s,i,b,g}=<identifier>'. Namespace URLs 'nsu=' are not
-// supported since they require a lookup. The 's=' prefix can be omitted
-// for string node ids.
-func ParseNodeID(s string) (*NodeID, error) {
+// supported since they require a lookup. For string node ids the 's='
+// prefix can be omitted.
+func NewNodeID(s string) (*NodeID, error) {
 	if s == "" {
 		return NewTwoByteNodeID(0), nil
 	}
@@ -402,6 +164,235 @@ func ParseNodeID(s string) (*NodeID, error) {
 	}
 }
 
+// EncodingMask returns the encoding mask field including the
+// type information and additional flags.
+func (n *NodeID) EncodingMask() uint8 {
+	return n.mask
+}
+
+// Type returns the node id type in EncodingMask.
+func (n *NodeID) Type() uint8 {
+	return n.mask & 0xf
+}
+
+// URIFlag returns whether the URI flag is set in EncodingMask.
+func (n *NodeID) URIFlag() bool {
+	return n.mask&0x80 == 0x80
+}
+
+// SetURIFlag sets NamespaceURI flag in EncodingMask.
+func (n *NodeID) SetURIFlag() {
+	n.mask |= 0x80
+}
+
+// IndexFlag returns whether the Index flag is set in EncodingMask.
+func (n *NodeID) IndexFlag() bool {
+	return n.mask&0x40 == 0x40
+}
+
+// SetIndexFlag sets NamespaceURI flag in EncodingMask.
+func (n *NodeID) SetIndexFlag() {
+	n.mask |= 0x40
+}
+
+// Serialize serializes NodeID to bytes.
+func (n *NodeID) Serialize() ([]byte, error) {
+	b := make([]byte, n.Len())
+	if err := n.SerializeTo(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// SerializeTo serializes NodeID into bytes.
+func (n *NodeID) SerializeTo(b []byte) error {
+	switch n.Type() {
+	case TypeTwoByte:
+		b[0] = n.mask
+		b[1] = uint8(n.nid)
+		return nil
+
+	case TypeFourByte:
+		b[0] = n.mask
+		b[1] = uint8(n.ns)
+		binary.LittleEndian.PutUint16(b[2:], uint16(n.nid))
+		return nil
+
+	case TypeNumeric:
+		b[0] = n.mask
+		binary.LittleEndian.PutUint16(b[1:3], n.ns)
+		binary.LittleEndian.PutUint32(b[3:7], n.nid)
+		return nil
+
+	case TypeGUID:
+		b[0] = n.mask
+		binary.LittleEndian.PutUint16(b[1:3], n.ns)
+		return n.gid.SerializeTo(b[3:])
+
+	case TypeString, TypeOpaque:
+		b[0] = n.mask
+		binary.LittleEndian.PutUint16(b[1:3], n.ns)
+		binary.LittleEndian.PutUint32(b[3:7], uint32(len(n.bid)))
+		copy(b[7:7+len(n.bid)], n.bid)
+		return nil
+
+	default:
+		return fmt.Errorf("invalid node id type: %d", n.Type())
+	}
+
+	return nil
+}
+
+// DecodeFromBytes decodes a NodeID from bytes.
+func (n *NodeID) DecodeFromBytes(b []byte) error {
+	if len(b) == 0 {
+		return io.ErrUnexpectedEOF
+	}
+	n.mask = b[0]
+
+	switch n.Type() {
+	case TypeTwoByte:
+		if len(b) < 2 {
+			return io.ErrUnexpectedEOF
+		}
+		n.nid = uint32(b[1])
+		return nil
+
+	case TypeFourByte:
+		if len(b) < 4 {
+			return io.ErrUnexpectedEOF
+		}
+		n.ns = uint16(b[1])
+		n.nid = uint32(binary.LittleEndian.Uint16(b[2:4]))
+		return nil
+
+	case TypeNumeric:
+		if len(b) < 7 {
+			return io.ErrUnexpectedEOF
+		}
+		n.ns = binary.LittleEndian.Uint16(b[1:3])
+		n.nid = binary.LittleEndian.Uint32(b[3:7])
+		return nil
+
+	case TypeGUID:
+		if len(b) < 19 {
+			return io.ErrUnexpectedEOF
+		}
+		n.ns = binary.LittleEndian.Uint16(b[1:3])
+		n.gid = &GUID{}
+		return n.gid.DecodeFromBytes(b[3:19])
+
+	case TypeString, TypeOpaque:
+		if len(b) < 7 {
+			return io.ErrUnexpectedEOF
+		}
+		n.ns = binary.LittleEndian.Uint16(b[1:3])
+		l := binary.LittleEndian.Uint32(b[3:7])
+		if len(b) < int(l) {
+			return io.ErrUnexpectedEOF
+		}
+		n.bid = make([]byte, l)
+		copy(n.bid, b[7:7+l])
+		return nil
+
+	default:
+		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
+	}
+}
+
+// Len returns the length of a serialized NodeID in bytes.
+func (n *NodeID) Len() int {
+	switch n.Type() {
+	case TypeTwoByte:
+		return 2
+
+	case TypeFourByte:
+		return 4
+
+	case TypeNumeric:
+		return 7
+
+	case TypeGUID:
+		return 19
+
+	case TypeString, TypeOpaque:
+		return 7 + len(n.bid)
+
+	default:
+		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
+	}
+}
+
+// IntID returns the identifier value if the type is
+// TwoByte, FourByte or Numeric. For all other types IntID
+// returns 0.
+func (n *NodeID) IntID() int {
+	return int(n.nid)
+}
+
+// StringID returns the string value of the identifier
+// for String and GUID NodeIDs, and the base64 encoded
+// value for Opaque types. For all other types StringID
+// returns an empty string.
+func (n *NodeID) StringID() string {
+	switch n.Type() {
+	case TypeGUID:
+		if n.gid == nil {
+			return ""
+		}
+		return n.gid.String()
+	case TypeString:
+		return string(n.bid)
+	case TypeOpaque:
+		return base64.StdEncoding.EncodeToString(n.bid)
+	default:
+		return ""
+	}
+}
+
+// String returns the string representation of the NodeID
+// in the format described by NewNodeID.
+func (n *NodeID) String() string {
+	switch n.Type() {
+	case TypeTwoByte:
+		return fmt.Sprintf("i=%d", n.nid)
+
+	case TypeFourByte:
+		if n.ns == 0 {
+			return fmt.Sprintf("i=%d", n.nid)
+		}
+		return fmt.Sprintf("ns=%d;i=%d", n.ns, n.nid)
+
+	case TypeNumeric:
+		if n.ns == 0 {
+			return fmt.Sprintf("i=%d", n.nid)
+		}
+		return fmt.Sprintf("ns=%d;i=%d", n.ns, n.nid)
+
+	case TypeString:
+		if n.ns == 0 {
+			return fmt.Sprintf("s=%s", n.StringID())
+		}
+		return fmt.Sprintf("ns=%d;s=%s", n.ns, n.StringID())
+
+	case TypeGUID:
+		if n.ns == 0 {
+			return fmt.Sprintf("g=%s", n.StringID())
+		}
+		return fmt.Sprintf("ns=%d;g=%s", n.ns, n.StringID())
+
+	case TypeOpaque:
+		if n.ns == 0 {
+			return fmt.Sprintf("o=%s", n.StringID())
+		}
+		return fmt.Sprintf("ns=%d;o=%s", n.ns, n.StringID())
+
+	default:
+		panic(fmt.Sprintf("invalid node id type: %d", n.Type()))
+	}
+}
+
+// DecodeNodeID decodes a node id from bytes.
 func DecodeNodeID(b []byte) (*NodeID, error) {
 	n := &NodeID{}
 	if err := n.DecodeFromBytes(b); err != nil {

--- a/datatypes/node-id.go
+++ b/datatypes/node-id.go
@@ -323,6 +323,38 @@ func (n *NodeID) Len() int {
 	}
 }
 
+// Namespace returns the namespace id. For two byte node ids
+// this will always be zero.
+func (n *NodeID) Namespace() int {
+	return int(n.ns)
+}
+
+// SetNamespace sets the namespace id. It returns an error
+// if the id is not within the range of the node id type.
+func (n *NodeID) SetNamespace(v int) error {
+	switch n.Type() {
+	case TypeTwoByte:
+		if v != 0 {
+			return fmt.Errorf("out of range [0..0]: %d", v)
+		}
+		return nil
+
+	case TypeFourByte:
+		if max := math.MaxUint8; v < 0 || v > max {
+			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+		}
+		n.ns = uint16(v)
+		return nil
+
+	default:
+		if max := math.MaxUint16; v < 0 || v > max {
+			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+		}
+		n.ns = uint16(v)
+		return nil
+	}
+}
+
 // IntID returns the identifier value if the type is
 // TwoByte, FourByte or Numeric. For all other types IntID
 // returns 0.

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/wmnsk/gopcua/utils/codectest"
 )
 
@@ -64,7 +63,7 @@ func TestNodeID(t *testing.T) {
 func TestParseNodeID(t *testing.T) {
 	cases := []struct {
 		s   string
-		n   NodeID
+		n   *NodeID
 		err error
 	}{
 		// happy flows
@@ -96,8 +95,8 @@ func TestParseNodeID(t *testing.T) {
 			if got, want := err, c.err; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got error %v want %v", got, want)
 			}
-			if got, want := n, c.n; !cmp.Equal(got, want) {
-				t.Fatal(cmp.Diff(got, want))
+			if got, want := n, c.n; !reflect.DeepEqual(got, want) {
+				t.Fatalf("\ngot  %#v\nwant %#v", got, want)
 			}
 		})
 	}

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -319,3 +319,114 @@ func TestSetStringID(t *testing.T) {
 		})
 	}
 }
+
+func TestSetNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		n    *NodeID
+		v    int
+		err  error
+	}{
+		// happy flows
+		{
+			name: "TwoByte",
+			n:    NewTwoByteNodeID(1),
+			v:    0,
+		},
+		{
+			name: "FourByte",
+			n:    NewFourByteNodeID(0, 1),
+			v:    1,
+		},
+		{
+			name: "Numeric",
+			n:    NewNumericNodeID(0, 1),
+			v:    1,
+		},
+
+		// error flows
+		{
+			name: "TwoByte.invalid",
+			n:    NewTwoByteNodeID(1),
+			v:    1,
+			err:  errors.New("out of range [0..0]: 1"),
+		},
+		{
+			name: "FourByte.tooSmall",
+			n:    NewFourByteNodeID(0, 1),
+			v:    -1,
+			err:  errors.New("out of range [0..255]: -1"),
+		},
+		{
+			name: "FourByte.tooBig",
+			n:    NewFourByteNodeID(0, 1),
+			v:    256,
+			err:  errors.New("out of range [0..255]: 256"),
+		},
+		{
+			name: "Numeric.tooSmall",
+			n:    NewNumericNodeID(0, 1),
+			v:    -1,
+			err:  errors.New("out of range [0..65535]: -1"),
+		},
+		{
+			name: "Numeric.toobBig",
+			n:    NewNumericNodeID(0, 1),
+			v:    65536,
+			err:  errors.New("out of range [0..65535]: 65536"),
+		},
+		{
+			name: "String.tooSmall",
+			n:    NewStringNodeID(0, "a"),
+			v:    -1,
+			err:  errors.New("out of range [0..65535]: -1"),
+		},
+		{
+			name: "String.tooBig",
+			n:    NewStringNodeID(0, "a"),
+			v:    65536,
+			err:  errors.New("out of range [0..65535]: 65536"),
+		},
+		{
+			name: "GUID.tooSmall",
+			n:    NewGUIDNodeID(0, "a"),
+			v:    -1,
+			err:  errors.New("out of range [0..65535]: -1"),
+		},
+		{
+			name: "GUID.tooBig",
+			n:    NewGUIDNodeID(0, "a"),
+			v:    65536,
+			err:  errors.New("out of range [0..65535]: 65536"),
+		},
+		{
+			name: "Opaque.tooSmall",
+			n:    NewOpaqueNodeID(0, []byte{'a'}),
+			v:    -1,
+			err:  errors.New("out of range [0..65535]: -1"),
+		},
+		{
+			name: "Opaque.tooBig",
+			n:    NewOpaqueNodeID(0, []byte{'a'}),
+			v:    65536,
+			err:  errors.New("out of range [0..65535]: 65536"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.n.SetNamespace(tt.v)
+			if got, want := err, tt.err; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got error %v want %v", got, want)
+			}
+			// if the test should fail and the error was correct
+			// we need to stop here.
+			if tt.err != nil {
+				return
+			}
+			if got, want := tt.n.Namespace(), tt.v; got != want {
+				t.Fatalf("got value %d want %d", got, want)
+			}
+		})
+	}
+}

--- a/datatypes/node-id_test.go
+++ b/datatypes/node-id_test.go
@@ -17,31 +17,60 @@ func TestNodeID(t *testing.T) {
 		{
 			Name:   "TwoByte",
 			Struct: NewTwoByteNodeID(0xff),
-			Bytes:  []byte{0x00, 0xff},
+			Bytes: []byte{
+				// mask
+				0x00,
+				// id
+				0xff,
+			},
 		},
 		{
 			Name:   "FourByte",
 			Struct: NewFourByteNodeID(0, 0xcafe),
-			Bytes:  []byte{0x01, 0x00, 0xfe, 0xca},
+			Bytes: []byte{
+				// mask
+				0x01,
+				// namespace
+				0x00,
+				// id
+				0xfe, 0xca,
+			},
 		},
 		{
 			Name:   "Numeric",
 			Struct: NewNumericNodeID(10, 0xdeadbeef),
-			Bytes:  []byte{0x02, 0x0a, 0x00, 0xef, 0xbe, 0xad, 0xde},
+			Bytes: []byte{
+				// mask
+				0x02,
+				// namespace
+				0x0a, 0x00,
+				// id
+				0xef, 0xbe, 0xad, 0xde,
+			},
 		},
 		{
 			Name:   "String",
 			Struct: NewStringNodeID(255, "foobar"),
 			Bytes: []byte{
-				0x03, 0xff, 0x00, 0x06, 0x00, 0x00, 0x00, 0x66,
-				0x6f, 0x6f, 0x62, 0x61, 0x72,
+				// mask
+				0x03,
+				// namespace
+				0xff, 0x00,
+				// length
+				0x06, 0x00, 0x00, 0x00,
+				// value
+				0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72,
 			},
 		},
 		{
 			Name:   "GUID",
 			Struct: NewGUIDNodeID(4660, "AAAABBBB-CCDD-EEFF-0101-0123456789AB"),
 			Bytes: []byte{
-				0x04, 0x34, 0x12,
+				// mask
+				0x04,
+				// namespace
+				0x34, 0x12,
+				// id
 				0xbb, 0xbb, 0xaa, 0xaa, 0xdd, 0xcc, 0xff, 0xee,
 				0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x01, 0x01,
 			},
@@ -50,8 +79,14 @@ func TestNodeID(t *testing.T) {
 			Name:   "Opaque",
 			Struct: NewOpaqueNodeID(32768, []byte{0xde, 0xad, 0xbe, 0xef}),
 			Bytes: []byte{
-				0x05, 0x00, 0x80, 0x04, 0x00, 0x00, 0x00, 0xde,
-				0xad, 0xbe, 0xef,
+				// mask
+				0x05,
+				// namespace
+				0x00, 0x80,
+				// length
+				0x04, 0x00, 0x00, 0x00,
+				// value
+				0xde, 0xad, 0xbe, 0xef,
 			},
 		},
 	}
@@ -60,7 +95,7 @@ func TestNodeID(t *testing.T) {
 	})
 }
 
-func TestParseNodeID(t *testing.T) {
+func TestNewNodeID(t *testing.T) {
 	cases := []struct {
 		s   string
 		n   *NodeID
@@ -91,7 +126,7 @@ func TestParseNodeID(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.s, func(t *testing.T) {
-			n, err := ParseNodeID(c.s)
+			n, err := NewNodeID(c.s)
 			if got, want := err, c.err; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got error %v want %v", got, want)
 			}

--- a/datatypes/read-value-id.go
+++ b/datatypes/read-value-id.go
@@ -49,14 +49,14 @@ const (
 //
 // Specification: Part 4, 7.24
 type ReadValueID struct {
-	NodeID
+	NodeID       *NodeID
 	AttributeID  IntegerID
 	IndexRange   *String
 	DataEncoding *QualifiedName
 }
 
 // NewReadValueID creates a new ReadValueID.
-func NewReadValueID(nodeID NodeID, attrID IntegerID, idxRange string, qIdx uint16, qName string) *ReadValueID {
+func NewReadValueID(nodeID *NodeID, attrID IntegerID, idxRange string, qIdx uint16, qName string) *ReadValueID {
 	return &ReadValueID{
 		NodeID:       nodeID,
 		AttributeID:  attrID,
@@ -76,8 +76,8 @@ func DecodeReadValueID(b []byte) (*ReadValueID, error) {
 
 // DecodeFromBytes decodes given bytes into OPC UA ReadValueID.
 func (r *ReadValueID) DecodeFromBytes(b []byte) error {
-	nodeID, err := DecodeNodeID(b)
-	if err != nil {
+	nodeID := &NodeID{}
+	if err := nodeID.DecodeFromBytes(b); err != nil {
 		return err
 	}
 	r.NodeID = nodeID

--- a/datatypes/write-value.go
+++ b/datatypes/write-value.go
@@ -12,14 +12,14 @@ import (
 //
 // Specification: Part4, 5.10.4.2
 type WriteValue struct {
-	NodeID
+	NodeID      *NodeID
 	AttributeID IntegerID
 	IndexRange  *String
 	Value       *DataValue
 }
 
 // NewWriteValue creates a new NewWriteValue.
-func NewWriteValue(node NodeID, attr IntegerID, idxRange string, value *DataValue) *WriteValue {
+func NewWriteValue(node *NodeID, attr IntegerID, idxRange string, value *DataValue) *WriteValue {
 	return &WriteValue{
 		NodeID:      node,
 		AttributeID: attr,
@@ -40,8 +40,8 @@ func DecodeWriteValue(b []byte) (*WriteValue, error) {
 
 // DecodeFromBytes decodes given bytes into OPC UA WriteValue.
 func (w *WriteValue) DecodeFromBytes(b []byte) error {
-	nodeID, err := DecodeNodeID(b)
-	if err != nil {
+	nodeID := &NodeID{}
+	if err := nodeID.DecodeFromBytes(b); err != nil {
 		return err
 	}
 	w.NodeID = nodeID

--- a/services/create-session-response.go
+++ b/services/create-session-response.go
@@ -18,8 +18,8 @@ import (
 type CreateSessionResponse struct {
 	TypeID *datatypes.ExpandedNodeID
 	*ResponseHeader
-	SessionID                  datatypes.NodeID
-	AuthenticationToken        datatypes.NodeID
+	SessionID                  *datatypes.NodeID
+	AuthenticationToken        *datatypes.NodeID
 	RevisedSessionTimeout      uint64
 	ServerNonce                *datatypes.ByteString
 	ServerCertificate          *datatypes.ByteString
@@ -30,7 +30,7 @@ type CreateSessionResponse struct {
 }
 
 // NewCreateSessionResponse creates a new NewCreateSessionResponse with the given parameters.
-func NewCreateSessionResponse(resHeader *ResponseHeader, sessionID, authToken datatypes.NodeID, timeout uint64, nonce, cert []byte, svrSignature *SignatureData, maxRespSize uint32, endpoints ...*EndpointDescription) *CreateSessionResponse {
+func NewCreateSessionResponse(resHeader *ResponseHeader, sessionID, authToken *datatypes.NodeID, timeout uint64, nonce, cert []byte, svrSignature *SignatureData, maxRespSize uint32, endpoints ...*EndpointDescription) *CreateSessionResponse {
 	return &CreateSessionResponse{
 		TypeID:                     datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCreateSessionResponse),
 		ResponseHeader:             resHeader,

--- a/services/create-subscription-request_test.go
+++ b/services/create-subscription-request_test.go
@@ -17,13 +17,7 @@ func TestCreateSubscriptionRequest(t *testing.T) {
 		{
 			Name: "normal",
 			Struct: &CreateSubscriptionRequest{
-				TypeID: &datatypes.ExpandedNodeID{
-					NodeID: &datatypes.FourByteNodeID{
-						EncodingMask: 0x01,
-						Namespace:    0,
-						Identifier:   ServiceTypeCreateSubscriptionRequest,
-					},
-				},
+				TypeID: datatypes.NewFourByteExpandedNodeID(0, ServiceTypeCreateSubscriptionRequest),
 				RequestHeader: &RequestHeader{
 					AuthenticationToken: datatypes.NewOpaqueNodeID(0, []byte{
 						0xfe, 0x8d, 0x87, 0x79, 0xf7, 0x03, 0x27, 0x77,
@@ -33,9 +27,7 @@ func TestCreateSubscriptionRequest(t *testing.T) {
 					RequestHandle: 1003429,
 					TimeoutHint:   10000,
 					AdditionalHeader: &AdditionalHeader{
-						TypeID: &datatypes.ExpandedNodeID{
-							NodeID: datatypes.NewTwoByteNodeID(0),
-						},
+						TypeID:       datatypes.NewTwoByteExpandedNodeID(0),
 						EncodingMask: 0x00,
 					},
 					Timestamp: time.Date(2018, time.August, 10, 23, 0, 0, 0, time.UTC),

--- a/services/request-header.go
+++ b/services/request-header.go
@@ -17,7 +17,7 @@ import (
 //
 // Specification: Part 4, 7.28
 type RequestHeader struct {
-	AuthenticationToken datatypes.NodeID
+	AuthenticationToken *datatypes.NodeID
 	Timestamp           time.Time
 	RequestHandle       uint32
 	ReturnDiagnostics   uint32
@@ -28,7 +28,7 @@ type RequestHeader struct {
 }
 
 // NewRequestHeader creates a new RequestHeader.
-func NewRequestHeader(authToken datatypes.NodeID, timestamp time.Time, handle, diag, timeout uint32, auditID string, additionalHeader *AdditionalHeader, payload []byte) *RequestHeader {
+func NewRequestHeader(authToken *datatypes.NodeID, timestamp time.Time, handle, diag, timeout uint32, auditID string, additionalHeader *AdditionalHeader, payload []byte) *RequestHeader {
 	return &RequestHeader{
 		AuthenticationToken: authToken,
 		Timestamp:           timestamp,

--- a/services/service.go
+++ b/services/service.go
@@ -54,12 +54,12 @@ func Decode(b []byte) (Service, error) {
 	if err != nil {
 		return nil, errors.NewErrUnsupported(typeID, "cannot decode TypeID.")
 	}
-	n, ok := typeID.NodeID.(*datatypes.FourByteNodeID)
-	if !ok {
+	if typeID.NodeID.Type() != datatypes.TypeFourByte {
 		return nil, errors.NewErrUnsupported(typeID.NodeID, "should be FourByteNodeID.")
 	}
 
-	switch n.Identifier {
+	id := uint16(typeID.NodeID.IntID())
+	switch id {
 	case ServiceTypeFindServersRequest:
 		s = &FindServersRequest{}
 	case ServiceTypeFindServersResponse:
@@ -107,7 +107,7 @@ func Decode(b []byte) (Service, error) {
 	case ServiceTypeFindServersOnNetworkResponse:
 		s = &FindServersOnNetworkResponse{}
 	default:
-		return nil, errors.NewErrUnsupported(n.Identifier, "unsupported or not implemented yet.")
+		return nil, errors.NewErrUnsupported(id, "unsupported or not implemented yet.")
 	}
 
 	if err := s.DecodeFromBytes(b); err != nil {

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -238,7 +238,7 @@ func (c *Config) validateServerConfig() error {
 type SessionConfig struct {
 	// AuthenticationToken is the secret Session identifier used to verify that the request is
 	// associated with the Session. The SessionAuthenticationToken type is defined in 7.31.
-	AuthenticationToken datatypes.NodeID
+	AuthenticationToken *datatypes.NodeID
 	// ClientDescription is the information that describes the Client application.
 	// The type ApplicationDescription is defined in 7.1.
 	ClientDescription *services.ApplicationDescription

--- a/utils/codectest/testcase.go
+++ b/utils/codectest/testcase.go
@@ -3,7 +3,7 @@ package codectest
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/pascaldekloe/goe/verify"
 )
 
 type S interface {
@@ -35,8 +35,8 @@ func Run(t *testing.T, cases []Case, decode DecoderFunc) {
 					t.Fatal(err)
 				}
 
-				if got, want := v, c.Struct; !cmp.Equal(got, want) {
-					t.Fatal(cmp.Diff(got, want))
+				if got, want := v, c.Struct; !verify.Values(t, "", got, want) {
+					t.Fail()
 				}
 			})
 
@@ -46,8 +46,8 @@ func Run(t *testing.T, cases []Case, decode DecoderFunc) {
 					t.Fatal(err)
 				}
 
-				if got, want := b, c.Bytes; !cmp.Equal(got, want) {
-					t.Fatal(cmp.Diff(got, want))
+				if got, want := b, c.Bytes; !verify.Values(t, "", got, want) {
+					t.Fail()
 				}
 			})
 


### PR DESCRIPTION
NodeID is currently a polymorphic type with different implementations behind a rather large interface. This makes marshalling a bit different for `NodeID` since the decoder has to determine first the type and then create the right object. By making NodeID a regular struct this problem goes away and NodeID is created like any other type. This will make a generic codec (generated or reflected) simpler since it does not have to deal with this special case. The reflection codec for example will not have to deal with interfaces just to handle `NodeID`.

Since NodeID stores the state in unexported fields the codec tests break since `go-cmp` does not handle them by default and there is no simple option to turn this behavior on. There is an open issue in https://github.com/google/go-cmp/issues/40 with a somewhat clumsy workaround, IMO.

My suggested solution to this is to replace `go-cmp` with `github.com/pascaldekloe/goe/verify` (at least for the codectest) which we developed within my team at eBay for running tests. (so I have some skin in the game) `go-cmp` also feels a bit feature-rich which goes against the keep-it-simple attitude of Go, IMHO.

The heavy lifting was done in #128 which makes this a simple change either way. 

I'm open for suggestions.