### PR TITLE
Correct the symmetric keygeneration algorithm

### DIFF
--- a/securitypolicy/cryptoRsaOaep.go
+++ b/securitypolicy/cryptoRsaOaep.go
@@ -14,7 +14,7 @@ import (
 	_ "crypto/sha256"
 )
 
-func minPaddingRsaOAEP(hash crypto.Hash) func() int {
+func minPaddingRsaOAEP(hash crypto.Hash) int {
 	// messageLen = (keyLenBits / 8) - 2*(hashLenBits / 8) - 2
 	// paddingLen = keyLen - messageLen
 	//            = 2*hashLenBytes + 2
@@ -26,9 +26,7 @@ func minPaddingRsaOAEP(hash crypto.Hash) func() int {
 		hLen = 64
 	}
 
-	return func() int {
-		return (2 * hLen) + 2
-	}
+	return (2 * hLen) + 2
 }
 
 func decryptRsaOAEP(hash crypto.Hash, privKey *rsa.PrivateKey) func([]byte) ([]byte, error) {
@@ -67,7 +65,7 @@ func encryptRsaOAEP(hash crypto.Hash, pubKey *rsa.PublicKey) func([]byte) ([]byt
 	return func(src []byte) ([]byte, error) {
 		var ciphertext []byte
 
-		maxBlock := keySize(pubKey) - minPaddingRsaOAEP(hash)()
+		maxBlock := keySize(pubKey) - minPaddingRsaOAEP(hash)
 		srcRemaining := len(src)
 		start := 0
 		for srcRemaining > 0 {

--- a/securitypolicy/keyDerivation.go
+++ b/securitypolicy/keyDerivation.go
@@ -44,10 +44,12 @@ type derivedKeys struct {
 
 func generateKeys(hmacFunc func(input []byte) ([]byte, error), seed []byte, signingLength, encryptingLength, encryptingBlockSize int) *derivedKeys {
 	var p []byte
+	a, _ := hmacFunc(seed)
 	for len(p) < signingLength+encryptingLength+encryptingBlockSize {
-		input := append(p, seed...)
+		input := append(a, seed...)
 		h, _ := hmacFunc(input)
 		p = append(p, h...)
+		a, _ = hmacFunc(a)
 	}
 
 	return &derivedKeys{

--- a/securitypolicy/policyAes256Sha256RsaPss.go
+++ b/securitypolicy/policyAes256Sha256RsaPss.go
@@ -6,6 +6,7 @@ package securitypolicy
 
 import (
 	"crypto"
+	"crypto/aes"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -64,15 +65,16 @@ func newAes256Sha256RsaPssSymmetric(localNonce []byte, remoteNonce []byte) (*Enc
 		encryptionBlockSize = blockSizeAES()
 	)
 
-	localKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
-	remoteKeys := generateKeys(computeHmac(crypto.SHA256, localNonce), remoteNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
+	localKeys := generateKeys(computeHmac(crypto.SHA256, localNonce), remoteNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
+	remoteKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
-	e.blockSize = blockSizeAES
-	e.minPadding = minPaddingAES
+	e.blockSize = aes.BlockSize
+	e.minPadding = minPaddingAES()
 	e.encrypt = encryptAES(256, remoteKeys.iv, remoteKeys.encryption) // AES256-CBC
 	e.decrypt = decryptAES(256, localKeys.iv, localKeys.encryption)   // AES256-CBC
 	e.signature = computeHmac(crypto.SHA256, remoteKeys.signing)      // HMAC-SHA2-256
 	e.verifySignature = verifyHmac(crypto.SHA256, localKeys.signing)  // HMAC-SHA2-256
+	e.signatureLength = 256 / 8
 	e.encryptionURI = "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256"
 	e.signatureURI = "http://www.w3.org/2000/09/xmldsig#hmac-sha256"
 
@@ -97,12 +99,13 @@ func newAes256Sha256RsaPssAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Pu
 
 	e := new(EncryptionAlgorithm)
 
-	e.blockSize = blockSizeNone
+	e.blockSize = keySize(remoteKey)
 	e.minPadding = minPaddingRsaOAEP(crypto.SHA1)
 	e.encrypt = encryptRsaOAEP(crypto.SHA1, remoteKey)         // RSA-OAEP-SHA1
 	e.decrypt = decryptRsaOAEP(crypto.SHA1, localKey)          // RSA-OAEP-SHA1
 	e.signature = signRsaPss(crypto.SHA256, localKey)          // RSA-PSS-SHA2-256
 	e.verifySignature = verifyRsaPss(crypto.SHA256, remoteKey) // RSA-PSS-SHA2-256
+	e.signatureLength = keySize(&localKey.PublicKey)
 	e.encryptionURI = "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256"
 	e.signatureURI = "http://opcfoundation.org/UA/security/rsa-pss-sha2-256"
 

--- a/securitypolicy/policyBasic256Sha256.go
+++ b/securitypolicy/policyBasic256Sha256.go
@@ -6,6 +6,7 @@ package securitypolicy
 
 import (
 	"crypto"
+	"crypto/aes"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -62,11 +63,11 @@ func newBasic256Rsa256Symmetric(localNonce []byte, remoteNonce []byte) (*Encrypt
 		encryptionBlockSize = blockSizeAES()
 	)
 
-	localKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
-	remoteKeys := generateKeys(computeHmac(crypto.SHA256, localNonce), remoteNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
+	localKeys := generateKeys(computeHmac(crypto.SHA256, localNonce), remoteNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
+	remoteKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
-	e.blockSize = blockSizeAES
-	e.minPadding = minPaddingAES
+	e.blockSize = aes.BlockSize
+	e.minPadding = minPaddingAES()
 	e.encrypt = encryptAES(256, remoteKeys.iv, remoteKeys.encryption) // AES256-CBC
 	e.decrypt = decryptAES(256, localKeys.iv, localKeys.encryption)   // AES256-CBC
 	e.signature = computeHmac(crypto.SHA256, remoteKeys.signing)      // HMAC-SHA2-256
@@ -95,12 +96,13 @@ func newBasic256Rsa256Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Public
 
 	e := new(EncryptionAlgorithm)
 
-	e.blockSize = blockSizeNone
+	e.blockSize = keySize(remoteKey)
 	e.minPadding = minPaddingRsaOAEP(crypto.SHA1)
 	e.encrypt = encryptRsaOAEP(crypto.SHA1, remoteKey)           // RSA-OAEP-SHA1
 	e.decrypt = decryptRsaOAEP(crypto.SHA1, localKey)            // RSA-OAEP-SHA1
 	e.signature = signPKCS1v15(crypto.SHA256, localKey)          // RSA-PKCS15-SHA2-256
 	e.verifySignature = verifyPKCS1v15(crypto.SHA256, remoteKey) // RSA-PKCS15-SHA2-256
+	e.signatureLength = keySize(&localKey.PublicKey)
 	e.encryptionURI = "http://www.w3.org/2001/04/xmlenc#rsa-oaep"
 	e.signatureURI = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 

--- a/securitypolicy/policyNone.go
+++ b/securitypolicy/policyNone.go
@@ -26,12 +26,13 @@ SecurityPolicy_None_Limits 		DerivedSignatureKeyLength: 0
 func newNoneAsymmetric(*rsa.PrivateKey, *rsa.PublicKey) (*EncryptionAlgorithm, error) {
 	e := new(EncryptionAlgorithm)
 
-	e.blockSize = blockSizeNone
-	e.minPadding = minPaddingNone
+	e.blockSize = blockSizeNone()
+	e.minPadding = minPaddingNone()
 	e.encrypt = encryptNone
 	e.decrypt = decryptNone
 	e.signature = signatureNone
 	e.verifySignature = verifySignatureNone
+	e.signatureLength = 0
 
 	return e, nil
 }
@@ -39,12 +40,13 @@ func newNoneAsymmetric(*rsa.PrivateKey, *rsa.PublicKey) (*EncryptionAlgorithm, e
 func newNoneSymmetric([]byte, []byte) (*EncryptionAlgorithm, error) {
 	e := new(EncryptionAlgorithm)
 
-	e.blockSize = blockSizeNone
-	e.minPadding = minPaddingNone
+	e.blockSize = blockSizeNone()
+	e.minPadding = minPaddingNone()
 	e.encrypt = encryptNone
 	e.decrypt = decryptNone
 	e.signature = signatureNone
 	e.verifySignature = verifySignatureNone
+	e.signatureLength = 0
 
 	return e, nil
 }

--- a/securitypolicy/securitypolicy.go
+++ b/securitypolicy/securitypolicy.go
@@ -23,12 +23,13 @@ import (
 // The zero value of this struct will use SecurityPolicy#None although
 // using in this manner is discouraged for readability
 type EncryptionAlgorithm struct {
-	blockSize       func() int
-	minPadding      func() int
+	blockSize       int
+	minPadding      int
 	encrypt         func(cleartext []byte) (ciphertext []byte, err error)
 	decrypt         func(ciphertext []byte) (cleartext []byte, err error)
 	signature       func(message []byte) (signature []byte, err error)
 	verifySignature func(message, signature []byte) error
+	signatureLength int
 	encryptionURI   string
 	signatureURI    string
 }
@@ -71,22 +72,14 @@ func Symmetric(policyURI string, localNonce []byte, remoteNonce []byte) (*Encryp
 // Used to calculate the padding required to make the cleartext an
 // even multiple of the blocksize
 func (e *EncryptionAlgorithm) BlockSize() int {
-	if e.blockSize == nil {
-		e.blockSize = blockSizeNone
-	}
-
-	return e.blockSize()
+	return e.blockSize
 }
 
 // MinPadding returns the underlying encryption algorithm's minimum padding.
 // Used to calculate the maximum plaintext blocksize that can be fed into
 // the encryption algorithm.
 func (e *EncryptionAlgorithm) MinPadding() int {
-	if e.minPadding == nil {
-		e.minPadding = minPaddingNone
-	}
-
-	return e.minPadding()
+	return e.minPadding
 }
 
 // Encrypt encrypts the input cleartext based on the algorithms and keys passed in
@@ -125,6 +118,11 @@ func (e *EncryptionAlgorithm) VerifySignature(message, signature []byte) error {
 	}
 
 	return e.verifySignature(message, signature)
+}
+
+// SignatureLength returns the length in bytes for the signature algorithm
+func (e *EncryptionAlgorithm) SignatureLength() int {
+	return e.signatureLength
 }
 
 // EncryptionURI returns the URI for the encryption algorithm as defined


### PR DESCRIPTION
Been busy and haven't had much time to work on this, but I found a few bugs in the symmetric security algorithm logic as I was implementing a security-enabled client.  I've got a client that can establish a secured UA Session but not without some ugly hacks to the uacp/uasc packages.  I'll put together some issues and/or some small PRs for this.

===
Corrected a misinterpretation of the symmetric encryption key
generation algorithm.
Also added method SignatureLength() to assist the caller in
determining how large the signature suffix of an encrypted
message is