### PR TITLE
WIP: uasc securitypolicies - testing version of security policy client code

### DIFF
--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -1,0 +1,104 @@
+// Copyright 2018-2019 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"io/ioutil"
+	"log"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uasc"
+)
+
+func main() {
+	endpoint := flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
+	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging")
+	flag.Parse()
+	log.SetFlags(0)
+
+	// Get a list of the endpoints for our target server
+	endpoints, err := opcua.GetEndpoints(*endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Find the endpoint recommended by the server (highest SecurityMode+SecurityLevel)
+	var serverEndpoint *ua.EndpointDescription
+	for _, e := range endpoints {
+		if serverEndpoint == nil || (e.SecurityMode >= serverEndpoint.SecurityMode && e.SecurityLevel >= serverEndpoint.SecurityLevel) {
+			serverEndpoint = e
+		}
+	}
+
+	// Local certificate
+	localCert, localKey, err := getCert()
+	if err != nil {
+		log.Fatalf("unable to get cert: %s", err)
+	}
+
+	log.Printf("Creating client with security: %s , %s\n", serverEndpoint.SecurityPolicyURI, serverEndpoint.SecurityMode)
+	config := uasc.NewClientConfig(
+		serverEndpoint,
+		localKey,
+		localCert.Raw,
+		0, //lifetime,
+	)
+
+	c := opcua.NewClient(*endpoint, config)
+	if err := c.Open(); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	// Request the server time
+	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("time: %v", v.Value)
+}
+
+func getCert() (*x509.Certificate, *rsa.PrivateKey, error) {
+
+	certPEM, err := ioutil.ReadFile("cert.pem")
+	if err != nil {
+		log.Printf("could not load cert, generating new one.  Error: %s\n", err)
+		generate_cert("urn:gopcua-client", 2048)
+		certPEM, _ = ioutil.ReadFile("cert.pem")
+	}
+
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		panic("failed to parse certificate: " + err.Error())
+	}
+
+	keyPem, err := ioutil.ReadFile("key.pem")
+	if err != nil {
+		log.Printf("could not load private key: %s\n", err)
+	}
+
+	block, _ = pem.Decode([]byte(keyPem))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+
+	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		panic("failed to parse private key: " + err.Error())
+	}
+
+	return cert, pkey, nil
+}

--- a/examples/crypto/generate_cert.go
+++ b/examples/crypto/generate_cert.go
@@ -1,0 +1,134 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Generate a self-signed X.509 certificate for a TLS server. Outputs to
+// 'cert.pem' and 'key.pem' and will overwrite existing files.
+
+// Modified by the Gopcua Authors for use in creating an OPC-UA compliant client certificate
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+func generate_cert(host string, rsaBits int) {
+
+	if len(host) == 0 {
+		log.Fatalf("Missing required host parameter")
+	}
+	if rsaBits == 0 {
+		rsaBits = 2048
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	if err != nil {
+		log.Fatalf("failed to generate private key: %s", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour) // 1 year
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Gopcua Test Client"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageDataEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+		if uri, err := url.Parse(h); err == nil {
+			template.URIs = append(template.URIs, uri)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	certOut, err := os.Create("cert.pem")
+	if err != nil {
+		log.Fatalf("failed to open cert.pem for writing: %s", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		log.Fatalf("failed to write data to cert.pem: %s", err)
+	}
+	if err := certOut.Close(); err != nil {
+		log.Fatalf("error closing cert.pem: %s", err)
+	}
+	log.Print("wrote cert.pem\n")
+
+	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		log.Print("failed to open key.pem for writing:", err)
+		return
+	}
+	if err := pem.Encode(keyOut, pemBlockForKey(priv)); err != nil {
+		log.Fatalf("failed to write data to key.pem: %s", err)
+	}
+	if err := keyOut.Close(); err != nil {
+		log.Fatalf("error closing key.pem: %s", err)
+	}
+	log.Print("wrote key.pem\n")
+
+}
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+			os.Exit(2)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}

--- a/keyring/keyring.go
+++ b/keyring/keyring.go
@@ -1,0 +1,97 @@
+// Copyright 2018-2019 gopcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+// Package keyring implements a simple key-value store for certificates,
+// public and private RSA keys, and the certificate thumbprints.
+// It is meant to be an internal use only package to the gopcua library.
+package keyring
+
+import (
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+type privateKeys struct {
+	thumbprint []byte
+	cert       *x509.Certificate
+	key        *rsa.PrivateKey
+}
+
+var localKeys sync.Map
+
+// Add adds a new key to the keyring
+func Add(c *x509.Certificate, k *rsa.PrivateKey) []byte {
+	thumbprint := sha1.Sum(c.Raw)
+	t := hex.EncodeToString(thumbprint[:])
+
+	pk, _ := localKeys.LoadOrStore(t, privateKeys{
+		thumbprint: thumbprint[:],
+		cert:       c,
+		key:        k,
+	})
+
+	return pk.(privateKeys).thumbprint
+}
+
+// Certificate returns the stored certificate for a given key thumbprint
+func Certificate(thumbprint []byte) (*x509.Certificate, error) {
+	t := hex.EncodeToString(thumbprint)
+
+	pk, ok := localKeys.Load(t)
+	if !ok {
+		return nil, errors.New("could not fetch certificate, unknown thumbprint: " + t)
+	}
+
+	return pk.(privateKeys).cert, nil
+}
+
+// PrivateKey returns the stored RSA private key for a given thumbprint
+func PrivateKey(thumbprint []byte) (*rsa.PrivateKey, error) {
+	t := hex.EncodeToString(thumbprint)
+
+	pk, ok := localKeys.Load(t)
+	if !ok {
+		return nil, errors.New("could not fetch private key, unknown thumbprint: " + t)
+	}
+
+	if pk.(privateKeys).key == nil {
+		return nil, errors.New("thumbprint stored without private key: " + t)
+	}
+	return pk.(privateKeys).key, nil
+}
+
+// PublicKey returns the stored RSA public key for a given thumbprint
+func PublicKey(thumbprint []byte) (*rsa.PublicKey, error) {
+	t := hex.EncodeToString(thumbprint)
+
+	pk, ok := localKeys.Load(t)
+	if !ok {
+		return nil, errors.New("could not fetch public key, unknown thumbprint")
+	}
+
+	return pk.(privateKeys).cert.PublicKey.(*rsa.PublicKey), nil
+}
+
+// Thumbprint returns the thumbprint of a DER-encoded certificate
+func Thumbprint(c []byte) []byte {
+	thumbprint := sha1.Sum(c)
+
+	return thumbprint[:]
+}
+
+// Thumbprints returns a slice of thumbprints for all keys in the keyring
+func Thumbprints() [][]byte {
+	tt := make([][]byte, 0)
+
+	localKeys.Range(func(k, v interface{}) bool {
+		tt = append(tt, v.(privateKeys).thumbprint)
+		return true
+	})
+
+	return tt
+}

--- a/securitypolicy/cryptoRsaPss.go
+++ b/securitypolicy/cryptoRsaPss.go
@@ -22,7 +22,7 @@ func signRsaPss(hash crypto.Hash, privKey *rsa.PrivateKey) func([]byte) ([]byte,
 		h.Write(msg)
 		hashed := h.Sum(nil)
 
-		signature, err := rsa.SignPSS(rng, privKey, hash, hashed[:], nil)
+		signature, err := rsa.SignPSS(rng, privKey, hash, hashed[:], &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 		if err != nil {
 			return nil, err
 		}

--- a/securitypolicy/policyAes256Sha256RsaPss.go
+++ b/securitypolicy/policyAes256Sha256RsaPss.go
@@ -69,7 +69,7 @@ func newAes256Sha256RsaPssSymmetric(localNonce []byte, remoteNonce []byte) (*Enc
 	remoteKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	e.blockSize = aes.BlockSize
-	e.minPadding = minPaddingAES()
+	e.plainttextBlockSize = aes.BlockSize - minPaddingAES()
 	e.encrypt = encryptAES(256, remoteKeys.iv, remoteKeys.encryption) // AES256-CBC
 	e.decrypt = decryptAES(256, localKeys.iv, localKeys.encryption)   // AES256-CBC
 	e.signature = computeHmac(crypto.SHA256, remoteKeys.signing)      // HMAC-SHA2-256
@@ -85,6 +85,7 @@ func newAes256Sha256RsaPssAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Pu
 	const (
 		minAsymmetricKeyLength = 256 // 2048 bits
 		maxAsymmetricKeyLength = 512 // 4096 bits
+		nonceLength            = 32
 	)
 
 	if localKey != nil && (localKey.PublicKey.Size() < minAsymmetricKeyLength || localKey.PublicKey.Size() > maxAsymmetricKeyLength) {
@@ -100,11 +101,12 @@ func newAes256Sha256RsaPssAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Pu
 	e := new(EncryptionAlgorithm)
 
 	e.blockSize = remoteKey.Size()
-	e.minPadding = minPaddingRsaOAEP(crypto.SHA1)
+	e.plainttextBlockSize = remoteKey.Size() - minPaddingRsaOAEP(crypto.SHA1)
 	e.encrypt = encryptRsaOAEP(crypto.SHA1, remoteKey)         // RSA-OAEP-SHA1
 	e.decrypt = decryptRsaOAEP(crypto.SHA1, localKey)          // RSA-OAEP-SHA1
 	e.signature = signRsaPss(crypto.SHA256, localKey)          // RSA-PSS-SHA2-256
 	e.verifySignature = verifyRsaPss(crypto.SHA256, remoteKey) // RSA-PSS-SHA2-256
+	e.nonceLength = nonceLength
 	e.signatureLength = localKey.PublicKey.Size()
 	e.encryptionURI = "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256"
 	e.signatureURI = "http://opcfoundation.org/UA/security/rsa-pss-sha2-256"

--- a/securitypolicy/policyAes256Sha256RsaPss.go
+++ b/securitypolicy/policyAes256Sha256RsaPss.go
@@ -101,9 +101,9 @@ func newAes256Sha256RsaPssAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Pu
 	e := new(EncryptionAlgorithm)
 
 	e.blockSize = remoteKey.Size()
-	e.plainttextBlockSize = remoteKey.Size() - minPaddingRsaOAEP(crypto.SHA1)
-	e.encrypt = encryptRsaOAEP(crypto.SHA1, remoteKey)         // RSA-OAEP-SHA1
-	e.decrypt = decryptRsaOAEP(crypto.SHA1, localKey)          // RSA-OAEP-SHA1
+	e.plainttextBlockSize = remoteKey.Size() - minPaddingRsaOAEP(crypto.SHA256)
+	e.encrypt = encryptRsaOAEP(crypto.SHA256, remoteKey)       // RSA-OAEP-SHA256
+	e.decrypt = decryptRsaOAEP(crypto.SHA256, localKey)        // RSA-OAEP-SHA256
 	e.signature = signRsaPss(crypto.SHA256, localKey)          // RSA-PSS-SHA2-256
 	e.verifySignature = verifyRsaPss(crypto.SHA256, remoteKey) // RSA-PSS-SHA2-256
 	e.nonceLength = nonceLength

--- a/securitypolicy/policyBasic256Sha256.go
+++ b/securitypolicy/policyBasic256Sha256.go
@@ -67,7 +67,7 @@ func newBasic256Rsa256Symmetric(localNonce []byte, remoteNonce []byte) (*Encrypt
 	remoteKeys := generateKeys(computeHmac(crypto.SHA256, remoteNonce), localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	e.blockSize = aes.BlockSize
-	e.minPadding = minPaddingAES()
+	e.plainttextBlockSize = aes.BlockSize - minPaddingAES()
 	e.encrypt = encryptAES(256, remoteKeys.iv, remoteKeys.encryption) // AES256-CBC
 	e.decrypt = decryptAES(256, localKeys.iv, localKeys.encryption)   // AES256-CBC
 	e.signature = computeHmac(crypto.SHA256, remoteKeys.signing)      // HMAC-SHA2-256
@@ -82,6 +82,7 @@ func newBasic256Rsa256Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Public
 	const (
 		minAsymmetricKeyLength = 256 // 2048 bits
 		maxAsymmetricKeyLength = 512 // 4096 bits
+		nonceLength            = 32
 	)
 
 	if localKey != nil && (localKey.PublicKey.Size() < minAsymmetricKeyLength || localKey.PublicKey.Size() > maxAsymmetricKeyLength) {
@@ -97,11 +98,12 @@ func newBasic256Rsa256Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Public
 	e := new(EncryptionAlgorithm)
 
 	e.blockSize = remoteKey.Size()
-	e.minPadding = minPaddingRsaOAEP(crypto.SHA1)
+	e.plainttextBlockSize = remoteKey.Size() - minPaddingRsaOAEP(crypto.SHA1)
 	e.encrypt = encryptRsaOAEP(crypto.SHA1, remoteKey)           // RSA-OAEP-SHA1
 	e.decrypt = decryptRsaOAEP(crypto.SHA1, localKey)            // RSA-OAEP-SHA1
 	e.signature = signPKCS1v15(crypto.SHA256, localKey)          // RSA-PKCS15-SHA2-256
 	e.verifySignature = verifyPKCS1v15(crypto.SHA256, remoteKey) // RSA-PKCS15-SHA2-256
+	e.nonceLength = nonceLength
 	e.signatureLength = localKey.PublicKey.Size()
 	e.encryptionURI = "http://www.w3.org/2001/04/xmlenc#rsa-oaep"
 	e.signatureURI = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"

--- a/securitypolicy/policyBasic256Sha256.go
+++ b/securitypolicy/policyBasic256Sha256.go
@@ -72,6 +72,7 @@ func newBasic256Rsa256Symmetric(localNonce []byte, remoteNonce []byte) (*Encrypt
 	e.decrypt = decryptAES(256, localKeys.iv, localKeys.encryption)   // AES256-CBC
 	e.signature = computeHmac(crypto.SHA256, remoteKeys.signing)      // HMAC-SHA2-256
 	e.verifySignature = verifyHmac(crypto.SHA256, localKeys.signing)  // HMAC-SHA2-256
+	e.signatureLength = 256 / 8
 	e.encryptionURI = "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
 	e.signatureURI = "http://www.w3.org/2000/09/xmldsig#hmac-sha256"
 

--- a/securitypolicy/policyNone.go
+++ b/securitypolicy/policyNone.go
@@ -27,7 +27,7 @@ func newNoneAsymmetric(*rsa.PrivateKey, *rsa.PublicKey) (*EncryptionAlgorithm, e
 	e := new(EncryptionAlgorithm)
 
 	e.blockSize = blockSizeNone()
-	e.minPadding = minPaddingNone()
+	e.plainttextBlockSize = blockSizeNone() - minPaddingNone()
 	e.encrypt = encryptNone
 	e.decrypt = decryptNone
 	e.signature = signatureNone
@@ -41,7 +41,7 @@ func newNoneSymmetric([]byte, []byte) (*EncryptionAlgorithm, error) {
 	e := new(EncryptionAlgorithm)
 
 	e.blockSize = blockSizeNone()
-	e.minPadding = minPaddingNone()
+	e.plainttextBlockSize = blockSizeNone() - minPaddingNone()
 	e.encrypt = encryptNone
 	e.decrypt = decryptNone
 	e.signature = signatureNone

--- a/securitypolicy/securitypolicy.go
+++ b/securitypolicy/securitypolicy.go
@@ -23,15 +23,16 @@ import (
 // The zero value of this struct will use SecurityPolicy#None although
 // using in this manner is discouraged for readability
 type EncryptionAlgorithm struct {
-	blockSize       int
-	minPadding      int
-	encrypt         func(cleartext []byte) (ciphertext []byte, err error)
-	decrypt         func(ciphertext []byte) (cleartext []byte, err error)
-	signature       func(message []byte) (signature []byte, err error)
-	verifySignature func(message, signature []byte) error
-	signatureLength int
-	encryptionURI   string
-	signatureURI    string
+	blockSize           int
+	plainttextBlockSize int
+	encrypt             func(cleartext []byte) (ciphertext []byte, err error)
+	decrypt             func(ciphertext []byte) (cleartext []byte, err error)
+	signature           func(message []byte) (signature []byte, err error)
+	verifySignature     func(message, signature []byte) error
+	nonceLength         int
+	signatureLength     int
+	encryptionURI       string
+	signatureURI        string
 }
 
 // Asymmetric returns the EncryptionAlgorithm struct seeded with the required public
@@ -75,11 +76,12 @@ func (e *EncryptionAlgorithm) BlockSize() int {
 	return e.blockSize
 }
 
-// MinPadding returns the underlying encryption algorithm's minimum padding.
-// Used to calculate the maximum plaintext blocksize that can be fed into
-// the encryption algorithm.
-func (e *EncryptionAlgorithm) MinPadding() int {
-	return e.minPadding
+// PlaintextBlockSize returns the size of the plaintext blocksize that
+// can be fed into the encryption algorithm.
+// Used to calculate the amount of padding to add to the
+// unencrypted message
+func (e *EncryptionAlgorithm) PlaintextBlockSize() int {
+	return e.plainttextBlockSize
 }
 
 // Encrypt encrypts the input cleartext based on the algorithms and keys passed in
@@ -123,6 +125,13 @@ func (e *EncryptionAlgorithm) VerifySignature(message, signature []byte) error {
 // SignatureLength returns the length in bytes for the signature algorithm
 func (e *EncryptionAlgorithm) SignatureLength() int {
 	return e.signatureLength
+}
+
+// NonceLength returns the recommended nonce length in bytes for the security policy
+// Only applicable for the Asymmetric security algorithm.  Symmetric algorithms should
+// report NonceLength as zero
+func (e *EncryptionAlgorithm) NonceLength() int {
+	return e.nonceLength
 }
 
 // EncryptionURI returns the URI for the encryption algorithm as defined

--- a/uasc/symmetric_security_header.go
+++ b/uasc/symmetric_security_header.go
@@ -35,9 +35,14 @@ func (h *SymmetricSecurityHeader) Encode() ([]byte, error) {
 }
 
 // String returns Header in string.
-func (s *SymmetricSecurityHeader) String() string {
+func (h *SymmetricSecurityHeader) String() string {
 	return fmt.Sprintf(
 		"TokenID: %d",
-		s.TokenID,
+		h.TokenID,
 	)
+}
+
+// Len returns the Header Length in bytes.
+func (h *SymmetricSecurityHeader) Len() int {
+	return 4
 }


### PR DESCRIPTION
** DO NOT MERGE YET **

This is a first draft of the security implementation.  I'm submitting this PR to open it up
for testing and comments.  This is **not** a complete implementation yet.

Sample code on connecting to a server is in examples/crypto

I've tested Basic128Rsa15 and Basic256 policies against Kepware and Ignition (Basic128Rsa15 only).
Kepware was very particular about the format of the client certificate so any testing with other servers
with different policy support will help greatly.

A few things to note,
- Server logic is not written yet and old functions haven't been tested; it may have broken completely
- Testing has only been done with None, Basic128Rsa15, and Basic256 policies
- Changes to the UASC headers broke testing; fixing the testing will
  follow implementing the server code in case further changes are necessary
- There is a lot of code cleanup to occur; commented out struct fields, etc, will disappear eventually

Please review and test and let me know of any comments.