### PR TITLE
refactor config to use options

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,8 +33,11 @@ type Client struct {
 	// endpointURL is the endpoint URL the client connects to.
 	endpointURL string
 
-	// cfg is the configuration for the client.
+	// cfg is the configuration for the secure channel.
 	cfg *uasc.Config
+
+	// sessionCfg is the configuration for the session.
+	sessionCfg *uasc.SessionConfig
 
 	// sechan is the open secure channel.
 	sechan *uasc.SecureChannel
@@ -47,9 +50,13 @@ type Client struct {
 }
 
 func NewClient(endpoint string, opts ...Option) *Client {
-	c := &Client{endpointURL: endpoint, cfg: DefaultClientConfig()}
+	c := &Client{
+		endpointURL: endpoint,
+		cfg:         DefaultClientConfig(),
+		sessionCfg:  DefaultSessionConfig(),
+	}
 	for _, opt := range opts {
-		opt(c.cfg)
+		opt(c.cfg, c.sessionCfg)
 	}
 	return c
 }
@@ -62,7 +69,7 @@ func (c *Client) Connect() (err error) {
 	if err := c.Dial(); err != nil {
 		return err
 	}
-	s, err := c.CreateSession(c.cfg.Session)
+	s, err := c.CreateSession(c.sessionCfg)
 	if err != nil {
 		_ = c.Close()
 		return err

--- a/config.go
+++ b/config.go
@@ -1,0 +1,78 @@
+package opcua
+
+import (
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uasc"
+)
+
+// DefaultClientConfig returns the default configuration for a client
+// to establish a secure channel and a session.
+func DefaultClientConfig() *uasc.Config {
+	return &uasc.Config{
+		SecurityPolicyURI: uasc.SecurityPolicyNone,
+		SecurityMode:      ua.MessageSecurityModeNone,
+		Session: &uasc.SessionConfig{
+			SessionTimeout: 0xffff,
+			ClientDescription: &ua.ApplicationDescription{
+				ApplicationURI:  "urn:gopcua:client",
+				ProductURI:      "urn:gopcua",
+				ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
+				ApplicationType: ua.ApplicationTypeClient,
+			},
+			LocaleIDs:         []string{"en-us"},
+			UserIdentityToken: &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
+		},
+	}
+}
+
+// Option is an option function type to modify the configuration.
+type Option func(*uasc.Config)
+
+// ApplicationURI sets the application uri in the session configuration.
+func ApplicationURI(s string) Option {
+	return func(c *uasc.Config) {
+		c.Session.ClientDescription.ApplicationURI = s
+	}
+}
+
+// ApplicationName sets the application name in the session configuration.
+func ApplicationName(s string) Option {
+	return func(c *uasc.Config) {
+		c.Session.ClientDescription.ApplicationName = &ua.LocalizedText{Text: s}
+	}
+}
+
+// Locales sets the locales in the session configuration.
+func Locales(locale ...string) Option {
+	return func(c *uasc.Config) {
+		c.Session.LocaleIDs = locale
+	}
+}
+
+// ProductURI sets the product uri in the session configuration.
+func ProductURI(s string) Option {
+	return func(c *uasc.Config) {
+		c.Session.ClientDescription.ProductURI = s
+	}
+}
+
+// SecurityMode sets the security mode for the secure channel.
+func SecurityMode(m ua.MessageSecurityMode) Option {
+	return func(c *uasc.Config) {
+		c.SecurityMode = m
+	}
+}
+
+// SecurityPolicy sets the security policy uri for the secure channel.
+func SecurityPolicy(s string) Option {
+	return func(c *uasc.Config) {
+		c.SecurityPolicyURI = s
+	}
+}
+
+// SessionTimeout sets the timeout in the session configuration.
+func SessionTimeout(seconds float64) Option {
+	return func(c *uasc.Config) {
+		c.Session.SessionTimeout = seconds
+	}
+}

--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package opcua
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uasc"
 )
@@ -11,6 +14,7 @@ func DefaultClientConfig() *uasc.Config {
 	return &uasc.Config{
 		SecurityPolicyURI: uasc.SecurityPolicyNone,
 		SecurityMode:      ua.MessageSecurityModeNone,
+		Lifetime:          uint32(time.Hour / time.Millisecond),
 		Session: &uasc.SessionConfig{
 			SessionTimeout: 0xffff,
 			ClientDescription: &ua.ApplicationDescription{
@@ -42,10 +46,24 @@ func ApplicationName(s string) Option {
 	}
 }
 
+// Lifetime sets the lifetime of the secure channel in milliseconds.
+func Lifetime(d time.Duration) Option {
+	return func(c *uasc.Config) {
+		c.Lifetime = uint32(d / time.Millisecond)
+	}
+}
+
 // Locales sets the locales in the session configuration.
 func Locales(locale ...string) Option {
 	return func(c *uasc.Config) {
 		c.Session.LocaleIDs = locale
+	}
+}
+
+// RandomRequestID assigns a random initial request id.
+func RandomRequestID() Option {
+	return func(c *uasc.Config) {
+		c.RequestID = uint32(rand.Int31())
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -27,8 +27,9 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 			ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
 			ApplicationType: ua.ApplicationTypeClient,
 		},
-		LocaleIDs:         []string{"en-us"},
-		UserIdentityToken: &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
+		LocaleIDs:          []string{"en-us"},
+		UserIdentityToken:  &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
+		UserTokenSignature: &ua.SignatureData{},
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -15,82 +15,85 @@ func DefaultClientConfig() *uasc.Config {
 		SecurityPolicyURI: uasc.SecurityPolicyNone,
 		SecurityMode:      ua.MessageSecurityModeNone,
 		Lifetime:          uint32(time.Hour / time.Millisecond),
-		Session: &uasc.SessionConfig{
-			SessionTimeout: 0xffff,
-			ClientDescription: &ua.ApplicationDescription{
-				ApplicationURI:  "urn:gopcua:client",
-				ProductURI:      "urn:gopcua",
-				ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
-				ApplicationType: ua.ApplicationTypeClient,
-			},
-			LocaleIDs:         []string{"en-us"},
-			UserIdentityToken: &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
+	}
+}
+
+func DefaultSessionConfig() *uasc.SessionConfig {
+	return &uasc.SessionConfig{
+		SessionTimeout: 0xffff,
+		ClientDescription: &ua.ApplicationDescription{
+			ApplicationURI:  "urn:gopcua:client",
+			ProductURI:      "urn:gopcua",
+			ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
+			ApplicationType: ua.ApplicationTypeClient,
 		},
+		LocaleIDs:         []string{"en-us"},
+		UserIdentityToken: &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
 	}
 }
 
 // Option is an option function type to modify the configuration.
-type Option func(*uasc.Config)
+type Option func(*uasc.Config, *uasc.SessionConfig)
 
 // ApplicationURI sets the application uri in the session configuration.
 func ApplicationURI(s string) Option {
-	return func(c *uasc.Config) {
-		c.Session.ClientDescription.ApplicationURI = s
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		sc.ClientDescription.ApplicationURI = s
 	}
 }
 
 // ApplicationName sets the application name in the session configuration.
 func ApplicationName(s string) Option {
-	return func(c *uasc.Config) {
-		c.Session.ClientDescription.ApplicationName = &ua.LocalizedText{Text: s}
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		sc.ClientDescription.ApplicationName = &ua.LocalizedText{Text: s}
 	}
 }
 
 // Lifetime sets the lifetime of the secure channel in milliseconds.
 func Lifetime(d time.Duration) Option {
-	return func(c *uasc.Config) {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.Lifetime = uint32(d / time.Millisecond)
 	}
 }
 
 // Locales sets the locales in the session configuration.
 func Locales(locale ...string) Option {
-	return func(c *uasc.Config) {
-		c.Session.LocaleIDs = locale
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		sc.LocaleIDs = locale
 	}
 }
 
 // RandomRequestID assigns a random initial request id.
 func RandomRequestID() Option {
-	return func(c *uasc.Config) {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.RequestID = uint32(rand.Int31())
 	}
 }
 
 // ProductURI sets the product uri in the session configuration.
 func ProductURI(s string) Option {
-	return func(c *uasc.Config) {
-		c.Session.ClientDescription.ProductURI = s
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		sc.ClientDescription.ProductURI = s
 	}
 }
 
 // SecurityMode sets the security mode for the secure channel.
 func SecurityMode(m ua.MessageSecurityMode) Option {
-	return func(c *uasc.Config) {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.SecurityMode = m
 	}
 }
 
 // SecurityPolicy sets the security policy uri for the secure channel.
 func SecurityPolicy(s string) Option {
-	return func(c *uasc.Config) {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.SecurityPolicyURI = s
 	}
 }
 
 // SessionTimeout sets the timeout in the session configuration.
 func SessionTimeout(seconds float64) Option {
-	return func(c *uasc.Config) {
-		c.Session.SessionTimeout = seconds
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		sc.SessionTimeout = seconds
 	}
 }

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -52,7 +52,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	c := &opcua.Client{EndpointURL: *endpoint}
+	c := opcua.NewClient(*endpoint)
 	if err := c.Connect(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -19,7 +19,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	c := &opcua.Client{EndpointURL: *endpoint}
+	c := opcua.NewClient(*endpoint)
 	if err := c.Connect(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -22,7 +22,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	c := &opcua.Client{EndpointURL: *endpoint}
+	c := opcua.NewClient(*endpoint, opcua.SecurityMode(ua.MessageSecurityModeNone))
 	if err := c.Connect(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -19,7 +19,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	c := &opcua.Client{EndpointURL: *endpoint}
+	c := opcua.NewClient(*endpoint)
 	if err := c.Connect(); err != nil {
 		log.Fatal(err)
 	}

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -23,7 +23,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
-	c := &opcua.Client{EndpointURL: *endpoint}
+	c := opcua.NewClient(*endpoint)
 	if err := c.Connect(); err != nil {
 		log.Fatal(err)
 	}

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -79,9 +79,6 @@ type Config struct {
 	// Lifetime can also be the revised lifetime, the lifetime of the SecurityToken in milliseconds.
 	// The UTC expiration time for the token may be calculated by adding the lifetime to the createdAt time.
 	Lifetime uint32
-
-	// Session is the session configuration.
-	Session *SessionConfig
 }
 
 // SessionConfig is a set of common configurations used in Session.


### PR DESCRIPTION
This patch refactors the client configuration to include both the secure channel and session configuration and to configure the client with options.

See #161 