### PR TITLE
Honor session timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,11 +164,12 @@ func (c *Client) CreateSession(cfg *uasc.SessionConfig) (*Session, error) {
 	}
 
 	req := &ua.CreateSessionRequest{
-		ClientDescription: cfg.ClientDescription,
-		EndpointURL:       c.endpointURL,
-		SessionName:       fmt.Sprintf("gopcua-%d", time.Now().UnixNano()),
-		ClientNonce:       nonce,
-		ClientCertificate: c.cfg.Certificate,
+		ClientDescription:       cfg.ClientDescription,
+		EndpointURL:             c.endpointURL,
+		SessionName:             fmt.Sprintf("gopcua-%d", time.Now().UnixNano()),
+		ClientNonce:             nonce,
+		ClientCertificate:       c.cfg.Certificate,
+		RequestedSessionTimeout: float64(cfg.SessionTimeout / time.Millisecond),
 	}
 
 	var s *Session

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ func DefaultClientConfig() *uasc.Config {
 
 func DefaultSessionConfig() *uasc.SessionConfig {
 	return &uasc.SessionConfig{
-		SessionTimeout: 0xffff,
+		SessionTimeout: 30 * time.Second,
 		ClientDescription: &ua.ApplicationDescription{
 			ApplicationURI:  "urn:gopcua:client",
 			ProductURI:      "urn:gopcua",
@@ -102,9 +102,9 @@ func SecurityPolicy(s string) Option {
 }
 
 // SessionTimeout sets the timeout in the session configuration.
-func SessionTimeout(seconds float64) Option {
+func SessionTimeout(d time.Duration) Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.SessionTimeout = seconds
+		sc.SessionTimeout = d
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ func DefaultClientConfig() *uasc.Config {
 
 func DefaultSessionConfig() *uasc.SessionConfig {
 	return &uasc.SessionConfig{
-		SessionTimeout: 30 * time.Second,
+		SessionTimeout: time.Minute,
 		ClientDescription: &ua.ApplicationDescription{
 			ApplicationURI:  "urn:gopcua:client",
 			ProductURI:      "urn:gopcua",

--- a/config.go
+++ b/config.go
@@ -36,8 +36,7 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 			ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
 			ApplicationType: ua.ApplicationTypeClient,
 		},
-		LocaleIDs: []string{"en-us"},
-		//UserIdentityToken:  &ua.AnonymousIdentityToken{PolicyID: "open62541-anonymous-policy"},
+		LocaleIDs:          []string{"en-us"},
 		UserTokenSignature: &ua.SignatureData{},
 	}
 }

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -6,6 +6,7 @@ package uasc
 
 import (
 	"crypto/rsa"
+	"time"
 
 	"github.com/gopcua/opcua/ua"
 )
@@ -135,7 +136,7 @@ type SessionConfig struct {
 	// If Session works as a server, SessionTimeout is an actual maximum number of milliseconds
 	// that a Session shall remain open without activity. The Server should attempt to honour the
 	// Client request for this parameter,but may negotiate this value up or down to meet its own constraints.
-	SessionTimeout float64
+	SessionTimeout time.Duration
 
 	// Stored version of the password to authenticate against a server
 	// todo: storing passwords in memory seems wrong

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -146,30 +146,3 @@ type SessionConfig struct {
 	// Could be different from the secure channel's policy
 	AuthPolicyURI string
 }
-
-// // NewServerSessionConfig creates a new SessionConfigServer for server.
-// func NewServerSessionConfig(secChan *SecureChannel) SessionConfig {
-// 	rawToken := make([]byte, 2)
-// 	if _, err := rand.Read(rawToken); err != nil {
-// 		binary.LittleEndian.PutUint16(rawToken, uint16(time.Now().UnixNano()))
-// 	}
-// 	return SessionConfig{
-// 		AuthenticationToken: ua.NewFourByteNodeID(0, binary.LittleEndian.Uint16(rawToken)),
-// 		SessionTimeout:      0xffff,
-// 		ServerEndpoints: []*ua.EndpointDescription{
-// 			&ua.EndpointDescription{
-// 				EndpointURL: secChan.LocalEndpoint(),
-// 				Server: &ua.ApplicationDescription{
-// 					ApplicationURI:  "urn:gopcua:client",
-// 					ProductURI:      "urn:gopcua",
-// 					ApplicationName: &ua.LocalizedText{Text: "gopcua - OPC UA implementation in Go"},
-// 					ApplicationType: ua.ApplicationTypeServer,
-// 				},
-// 				ServerCertificate: secChan.cfg.Certificate,
-// 				SecurityMode:      secChan.cfg.SecurityMode,
-// 				SecurityPolicyURI: secChan.cfg.SecurityPolicyURI,
-// 				// UserIdentityTokens: []*ua.UserTokenPolicy{&ua.UserTokenPolicy{}},
-// 			},
-// 		},
-// 	}
-// }


### PR DESCRIPTION
This patch honors the session timeout when creating a
session. It also changes the type of the SessionTimeout
from `float64` to a `time.Duration` and sets the default to 
60 seconds.

Fixes #170
