### PR TITLE
Refactor NewNodeID

### DIFF
--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -65,7 +65,7 @@ func main() {
 	defer c.Close()
 
 	// Use our connection (read the server's time)
-	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value()
+	v, err := c.Node(ua.NewNodeID(0, 2258)).Value()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func main() {
 	}
 
 	// Read the time again to prove our session is still OK
-	v, err = d.Node(ua.NewNumericNodeID(0, 2258)).Value()
+	v, err = d.Node(ua.NewNodeID(0, 2258)).Value()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -25,7 +25,7 @@ func main() {
 	}
 	defer c.Close()
 
-	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value()
+	v, err := c.Node(ua.NewNodeID(0, 2258)).Value()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	defer c.Close()
 
-	id, err := ua.NewNodeID(*nodeID)
+	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
 		log.Fatalf("invalid node id: %v", err)
 	}

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -29,7 +29,7 @@ func main() {
 	}
 	defer c.Close()
 
-	id, err := ua.NewNodeID(*nodeID)
+	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
 		log.Fatalf("invalid node id: %v", err)
 	}


### PR DESCRIPTION
This patch renames the `NewNodeID` function to `ParseNodeID` since it takes a `string` as input and returns a `*NodeID`. 

It also adds a different `NewNodeID()` function which detects the type of node id and returns an empty node id if the values do not represent a valid node id. It also returns the smallest numerical node id type for the give namespace and id value. 

This would replace `id := NewNumericNodeID(0, 2258)` with `id := NewNodeID(0, 2258)` and you can also write `id := NewNodeID(5, "abc")` or `id := NewNodeID(4, []byte(...))` or `id := NewNodeID(6, NewGUID("..."))`.

I think that this is more in line with how node ids might be used and hides the different numeric node id types behind a single call. However, this also gives up compiler type checking for ranges since it is impossible to create invalid node ids with the specific calls. `NewNodeID` fails silently with `NewNodeID(0, -1)` and returns a `NewTwoByteNodeID(0)`. 

Initially, I thought this was a good idea but while I'm writing this down I'm wondering whether this is too much magic. I still think that we should rename `NewNodeID` to `ParseNodeID` but I'm not sure on the magic detection version.

What do you think?