### PR TITLE
Add methods for AccessLevel and UserAccessLevel

### DIFF
--- a/examples/accesslevel/accesslevel.go
+++ b/examples/accesslevel/accesslevel.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2019 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/ua"
+)
+
+func main() {
+	var (
+		endpoint = flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
+		nodeID   = flag.String("node", "", "NodeID to read")
+	)
+	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging")
+	flag.Parse()
+	log.SetFlags(0)
+
+	c := opcua.NewClient(*endpoint)
+	if err := c.Connect(); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	id, err := ua.ParseNodeID(*nodeID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	n := c.Node(id)
+	accessLevel, err := n.AccessLevel()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Print("AccessLevel: ", accessLevel)
+
+	userAccessLevel, err := n.UserAccessLevel()
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Print("UserAccessLevel: ", userAccessLevel)
+
+	v, err := n.Value()
+	switch {
+	case err != nil:
+		log.Fatal(err)
+	case v == nil:
+		log.Print("v == nil")
+	default:
+		log.Print(v.Value)
+	}
+}

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -26,12 +26,12 @@ func main() {
 	defer c.Close()
 
 	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value()
-	if err != nil {
+	switch {
+	case err != nil:
 		log.Fatal(err)
-	}
-	if v != nil {
-		log.Print(v.Value)
-	} else {
+	case v == nil:
 		log.Print("v == nil")
+	default:
+		log.Print(v.Value)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -51,6 +51,46 @@ func (n *Node) DisplayName() (*ua.LocalizedText, error) {
 	return v.Value.(*ua.LocalizedText), nil
 }
 
+// AccessLevel returns the access level of the node.
+// The returned value is a mask where multiple values can be
+// set, e.g. read and write.
+func (n *Node) AccessLevel() (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ua.AttributeIDAccessLevel)
+	if err != nil {
+		return 0, err
+	}
+	return ua.AccessLevelType(v.Value.(uint8)), nil
+}
+
+// HasAccessLevel returns true if all bits from mask are
+// set in the access level mask of the node.
+func (n *Node) HasAccessLevel(mask ua.AccessLevelType) (bool, error) {
+	v, err := n.AccessLevel()
+	if err != nil {
+		return false, err
+	}
+	return (v & mask) == mask, nil
+}
+
+// UserAccessLevel returns the access level of the node.
+func (n *Node) UserAccessLevel() (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ua.AttributeIDUserAccessLevel)
+	if err != nil {
+		return 0, err
+	}
+	return ua.AccessLevelType(v.Value.(uint8)), nil
+}
+
+// HasUserAccessLevel returns true if all bits from mask are
+// set in the user access level mask of the node.
+func (n *Node) HasUserAccessLevel(mask ua.AccessLevelType) (bool, error) {
+	v, err := n.UserAccessLevel()
+	if err != nil {
+		return false, err
+	}
+	return (v & mask) == mask, nil
+}
+
 // Value returns the value of the node.
 func (n *Node) Value() (*ua.Variant, error) {
 	return n.Attribute(ua.AttributeIDValue)


### PR DESCRIPTION
This patch adds methods to get the access level and user access level of a node. Since the values can be masks I've also added `HasAccessLevel` and `HasUserAccessLevel` helpers. Not sure if that is a good idea since we then have to do this for all mask types. But maybe not. 

What do others think?

Addresses the question in https://github.com/gopcua/opcua/issues/191#issuecomment-491645673