### PR TITLE
move recv() loop from uasc into opcua package

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ import (
 // GetEndpoints returns the available endpoint descriptions for the server.
 func GetEndpoints(endpoint string) ([]*ua.EndpointDescription, error) {
 	c := NewClient(endpoint)
-	if err := c.Dial(); err != nil {
+	if err := c.Dial(context.Background()); err != nil {
 		return nil, err
 	}
 	defer c.Close()
@@ -127,11 +127,15 @@ func NewClient(endpoint string, opts ...Option) *Client {
 }
 
 // Connect establishes a secure channel and creates a new session.
-func (c *Client) Connect() (err error) {
+func (c *Client) Connect(ctx context.Context) (err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	if c.sechan != nil {
 		return fmt.Errorf("already connected")
 	}
-	if err := c.Dial(); err != nil {
+	if err := c.Dial(ctx); err != nil {
 		return err
 	}
 	s, err := c.CreateSession(c.sessionCfg)
@@ -147,12 +151,16 @@ func (c *Client) Connect() (err error) {
 }
 
 // Dial establishes a secure channel.
-func (c *Client) Dial() error {
+func (c *Client) Dial(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	c.once.Do(func() { c.session.Store((*Session)(nil)) })
 	if c.sechan != nil {
 		return fmt.Errorf("secure channel already connected")
 	}
-	conn, err := uacp.Dial(context.Background(), c.endpointURL)
+	conn, err := uacp.Dial(ctx, c.endpointURL)
 	if err != nil {
 		return err
 	}
@@ -161,12 +169,32 @@ func (c *Client) Dial() error {
 		_ = conn.Close()
 		return err
 	}
+	c.sechan = sechan
+	go c.monitorChannel(ctx)
+
 	if err := sechan.Open(); err != nil {
 		_ = conn.Close()
+		c.sechan = nil
 		return err
 	}
-	c.sechan = sechan
+
 	return nil
+}
+
+func (c *Client) monitorChannel(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			msg := c.sechan.Receive(ctx)
+			debug.Printf("Received unsolicited message from server: %T", msg.V)
+			if msg.Err != nil {
+				debug.Printf("Received error: %s", msg.Err)
+				return msg.Err
+			}
+		}
+	}
 }
 
 // Close closes the session and the secure channel.

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"log"
 	"reflect"
 	"sort"
@@ -181,18 +182,24 @@ func (c *Client) Dial(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) monitorChannel(ctx context.Context) error {
+func (c *Client) monitorChannel(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return
 		default:
 			msg := c.sechan.Receive(ctx)
-			debug.Printf("Received unsolicited message from server: %T", msg.V)
 			if msg.Err != nil {
-				debug.Printf("Received error: %s", msg.Err)
-				return msg.Err
+				if msg.Err == io.EOF {
+					debug.Printf("Connection closed")
+				} else {
+					debug.Printf("Received error: %s", msg.Err)
+				}
+				// todo (dh): apart from the above message, we're ignoring this error because there is nothing watching it
+				// I'd prefer to have a way to return the error to the upper application.
+				return
 			}
+			debug.Printf("Received unsolicited message from server: %T", msg.V)
 		}
 	}
 }

--- a/examples/accesslevel/accesslevel.go
+++ b/examples/accesslevel/accesslevel.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
@@ -23,7 +24,7 @@ func main() {
 	log.SetFlags(0)
 
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/accesslevel/accesslevel.go
+++ b/examples/accesslevel/accesslevel.go
@@ -23,8 +23,10 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -53,7 +54,7 @@ func main() {
 	log.SetFlags(0)
 
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -53,8 +53,10 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"crypto/rsa"
 	"crypto/tls"
 	"flag"
@@ -58,7 +59,7 @@ func main() {
 
 	// Create a Client with the selected options
 	c := opcua.NewClient(*endpoint, opts...)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()
@@ -83,7 +84,7 @@ func main() {
 	d := opcua.NewClient(*endpoint, opts...)
 
 	// Create a channel only and do not activate it automatically
-	d.Dial()
+	d.Dial(context.Background())
 	defer d.Close()
 
 	// Activate the previous session on the new channel

--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -42,6 +42,8 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	// Get a list of the endpoints for our target server
 	endpoints, err := opcua.GetEndpoints(*endpoint)
 	if err != nil {
@@ -59,7 +61,7 @@ func main() {
 
 	// Create a Client with the selected options
 	c := opcua.NewClient(*endpoint, opts...)
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()
@@ -84,7 +86,7 @@ func main() {
 	d := opcua.NewClient(*endpoint, opts...)
 
 	// Create a channel only and do not activate it automatically
-	d.Dial(context.Background())
+	d.Dial(ctx)
 	defer d.Close()
 
 	// Activate the previous session on the new channel

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -25,6 +25,8 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	endpoints, err := opcua.GetEndpoints(*endpoint)
 	if err != nil {
 		log.Fatal(err)
@@ -46,7 +48,7 @@ func main() {
 	}
 
 	c := opcua.NewClient(ep.EndpointURL, opts...)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/history-read/history-read.go
+++ b/examples/history-read/history-read.go
@@ -22,8 +22,10 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/history-read/history-read.go
+++ b/examples/history-read/history-read.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"time"
@@ -22,7 +23,7 @@ func main() {
 	log.SetFlags(0)
 
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -23,8 +23,10 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	c := opcua.NewClient(*endpoint, opcua.SecurityMode(ua.MessageSecurityModeNone))
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
@@ -23,7 +24,7 @@ func main() {
 	log.SetFlags(0)
 
 	c := opcua.NewClient(*endpoint, opcua.SecurityMode(ua.MessageSecurityModeNone))
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -18,12 +18,14 @@ func main() {
 	)
 	flag.Parse()
 
+	ctx := context.Background()
+
 	log.Printf("Listening on %s", *endpoint)
 	l, err := uacp.Listen(*endpoint, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	c, err := l.Accept(context.Background())
+	c, err := l.Accept(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -29,6 +29,12 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	// add an arbitrary timeout to demonstrate how to stop a subscription
+	// with a context.
+	d := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+
 	endpoints, err := opcua.GetEndpoints(*endpoint)
 	if err != nil {
 		log.Fatal(err)
@@ -50,7 +56,7 @@ func main() {
 	}
 
 	c := opcua.NewClient(ep.EndpointURL, opts...)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()
@@ -76,12 +82,6 @@ func main() {
 	if err != nil || res.Results[0].StatusCode != ua.StatusOK {
 		log.Fatal(err)
 	}
-
-	// add an arbitrary timeout to demonstrate how to stop a subscription
-	// with a context.
-	d := 30 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), d)
-	defer cancel()
 
 	go sub.Run(ctx) // start Publish loop
 

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -24,8 +24,10 @@ func main() {
 	flag.Parse()
 	log.SetFlags(0)
 
+	ctx := context.Background()
+
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(context.Background()); err != nil {
+	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 	log.SetFlags(0)
 
 	c := opcua.NewClient(*endpoint)
-	if err := c.Connect(); err != nil {
+	if err := c.Connect(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 	defer c.Close()

--- a/uapolicy/cert_utils.go
+++ b/uapolicy/cert_utils.go
@@ -4,11 +4,25 @@
 
 package uapolicy
 
-import "crypto/sha1"
+import (
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+)
 
 // Thumbprint returns the thumbprint of a DER-encoded certificate
 func Thumbprint(c []byte) []byte {
 	thumbprint := sha1.Sum(c)
 
 	return thumbprint[:]
+}
+
+// PublicKey returns the RSA PublicKey from a DER-encoded certificate
+func PublicKey(c []byte) (*rsa.PublicKey, error) {
+	cert, err := x509.ParseCertificate(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return cert.PublicKey.(*rsa.PublicKey), nil
 }

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -5,6 +5,7 @@
 package uasc
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -32,8 +33,10 @@ const (
 )
 
 type Response struct {
-	V   interface{}
-	Err error
+	ReqID uint32
+	SCID  uint32
+	V     interface{}
+	Err   error
 }
 
 type SecureChannel struct {
@@ -48,9 +51,6 @@ type SecureChannel struct {
 	// reqhdr is the header for the next request.
 	reqhdr *ua.RequestHeader
 
-	// quit signals the termination of the recv loop.
-	quit chan struct{}
-
 	// state is the state of the secure channel.
 	// Must be accessed with atomic.LoadInt32/StoreInt32
 	state int32
@@ -60,6 +60,8 @@ type SecureChannel struct {
 	// handle which is part of the Request and Response headers.
 	mu      sync.Mutex
 	handler map[uint32]chan Response
+
+	chunks map[uint32][]*MessageChunk
 
 	enc *uapolicy.EncryptionAlgorithm
 }
@@ -86,9 +88,6 @@ func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChanne
 		cfg.SecurityMode = ua.MessageSecurityModeNone
 	}
 
-	// always reset the secure channel id
-	cfg.SecureChannelID = 0
-
 	return &SecureChannel{
 		EndpointURL: endpoint,
 		c:           c,
@@ -100,22 +99,9 @@ func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChanne
 			AdditionalHeader:    ua.NewExtensionObject(nil),
 		},
 		state:   secureChannelCreated,
-		quit:    make(chan struct{}),
 		handler: make(map[uint32]chan Response),
+		chunks:  make(map[uint32][]*MessageChunk),
 	}, nil
-}
-
-func (s *SecureChannel) Open() error {
-	go s.recv()
-	return s.openSecureChannel()
-}
-
-func (s *SecureChannel) Close() error {
-	if err := s.closeSecureChannel(); err != nil {
-		log.Print("failed to send close secure channel request")
-	}
-	close(s.quit)
-	return s.c.Close()
 }
 
 func (s *SecureChannel) LocalEndpoint() string {
@@ -128,6 +114,434 @@ func (s *SecureChannel) setState(n int32) {
 
 func (s *SecureChannel) hasState(n int32) bool {
 	return atomic.LoadInt32(&s.state) == n
+}
+
+// Send sends the service request and calls h with the response.
+func (s *SecureChannel) Send(svc interface{}, authToken *ua.NodeID, h func(interface{}) error) error {
+	return s.SendWithTimeout(svc, authToken, s.cfg.RequestTimeout, h)
+}
+
+// SendWithTimeout sends the service request and calls h with the response with a specific timeout.
+func (s *SecureChannel) SendWithTimeout(svc interface{}, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
+	ch, reqid, err := s.sendAsyncWithTimeout(svc, authToken, timeout)
+	respRequired := !(h == nil)
+
+	ch, reqid, err := s.SendAsync(svc, authToken, respRequired)
+	if err != nil {
+		return err
+	}
+
+	if !respRequired {
+		return nil
+	}
+
+	select {
+	case resp := <-ch:
+		if resp.Err != nil {
+			if resp.V != nil {
+				_ = h(resp.V) // ignore result because resp.Err takes precedence
+			}
+			return resp.Err
+		}
+		return h(resp.V)
+	case <-time.After(timeout + timeoutLeniency): // `+ timeoutLeniency` to give the server a chance to respond to TimeoutHint
+		s.mu.Lock()
+		s.popHandlerLock(reqid)
+		s.mu.Unlock()
+		return ua.StatusBadTimeout
+	}
+}
+
+// SendAsync sends the service request and returns a channel which will receive the
+// response when it arrives.
+func (s *SecureChannel) SendAsync(svc interface{}, authToken *ua.NodeID, respReq bool) (resp chan Response, reqID uint32, err error) {
+	return s.sendAsyncWithTimeout(svc, authToken, respReq, s.cfg.RequestTimeout)
+}
+
+// sendAsyncWithTimeout sends the service request with a specific timeout and returns a channel which will receive the
+// response when it arrives.
+func (s *SecureChannel) sendAsyncWithTimeout(svc interface{}, authToken *ua.NodeID, respReq bool, timeout time.Duration) (resp chan Response, reqID uint32, err error) {
+	typeID := ua.ServiceTypeID(svc)
+	if typeID == 0 {
+		return nil, 0, fmt.Errorf("unknown service %T. Did you call register?", svc)
+	}
+	if authToken == nil {
+		authToken = ua.NewTwoByteNodeID(0)
+	}
+
+	s.mu.Lock()
+	// the request header is always the first field
+	val := reflect.ValueOf(svc)
+	rHdr := val.Elem().Field(0)
+	s.cfg.SequenceNumber++
+	if _, ok := rHdr.Interface().(*ua.RequestHeader); ok {
+		val.Elem().Field(0).Set(reflect.ValueOf(s.reqhdr))
+
+		s.reqhdr.AuthenticationToken = authToken
+		s.cfg.RequestID++
+		s.reqhdr.RequestHandle++
+		s.reqhdr.Timestamp = time.Now()
+		if timeout > 0 && timeout < s.cfg.RequestTimeout {
+			timeout = s.cfg.RequestTimeout
+		}
+		s.reqhdr.TimeoutHint = uint32(timeout / time.Millisecond)
+	}
+
+	// encode the message
+	m := NewMessage(svc, typeID, s.cfg)
+	reqid := m.SequenceHeader.RequestID
+	s.mu.Unlock()
+	b, err := m.Encode()
+	if err != nil {
+		return nil, reqid, err
+	}
+
+	// encrypt the message prior to sending it
+	// if SecurityMode == None, this returns the byte stream untouched
+	b, err = s.signAndEncrypt(m, b)
+	if err != nil {
+		return nil, reqid, err
+	}
+
+	// send the message
+	if _, err := s.c.Write(b); err != nil {
+		return nil, reqid, err
+	}
+	debug.Printf("uasc %d/%d: send %T with %d bytes", s.c.ID(), reqid, svc, len(b))
+
+	// register the handler if a callback was passed
+	if !respReq {
+		return nil, 0, nil
+	}
+	resp = make(chan Response)
+	s.mu.Lock()
+	if s.handler[reqid] != nil {
+		s.mu.Unlock()
+		return nil, reqid, fmt.Errorf("error: duplicate handler registration for request id %d", reqid)
+	}
+	s.handler[reqid] = resp
+	s.mu.Unlock()
+	return resp, reqid, nil
+}
+
+func (s *SecureChannel) readChunk() (*MessageChunk, error) {
+	// read a full message from the underlying conn.
+	b, err := s.c.Receive()
+	if err == io.EOF || s.hasState(secureChannelClosed) {
+		return nil, io.EOF
+	}
+	if errf, ok := err.(*uacp.Error); ok {
+		return nil, errf
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sechan: read header failed: %s %#v", err, err)
+	}
+
+	const hdrlen = 12
+	h := new(Header)
+	if _, err := h.Decode(b[:hdrlen]); err != nil {
+		return nil, fmt.Errorf("sechan: decode header failed: %s", err)
+	}
+
+	// decode the other headers
+	m := new(MessageChunk)
+	if _, err := m.Decode(b); err != nil {
+		return nil, fmt.Errorf("sechan: decode chunk failed: %s", err)
+	}
+
+	// OPN Request, initialize encryption
+	// todo(dh): How to account for renew requests?
+	switch m.MessageType {
+	case "OPN":
+		debug.Printf("uasc: OPN Request")
+		// Make sure we have a valid security header
+		if m.AsymmetricSecurityHeader == nil {
+			return nil, ua.StatusBadDecodingError // todo(dh): check if this is the correct error
+		}
+
+		// Load the remote certificates from the security header, if present
+		var remoteKey *rsa.PublicKey
+		if m.SecurityPolicyURI != ua.SecurityPolicyURINone {
+			remoteKey, err = uapolicy.PublicKey(m.AsymmetricSecurityHeader.SenderCertificate)
+			if err != nil {
+				return nil, err
+			}
+
+			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
+			debug.Printf("Setting securityPolicy to %s", m.SecurityPolicyURI)
+		}
+
+		s.cfg.SecurityPolicyURI = m.SecurityPolicyURI
+		s.cfg.RequestID = m.RequestID
+
+		s.enc, err = uapolicy.Asymmetric(m.SecurityPolicyURI, s.cfg.LocalKey, remoteKey)
+		if err != nil {
+			return nil, err
+		}
+
+	case "CLO":
+		if !s.hasState(secureChannelOpen) {
+			return nil, ua.StatusBadSecureChannelIDInvalid
+		}
+
+		// We received the close request so no response is necessary.
+		// Returning io.EOF signals to the calling methods that the channel is to be shut down
+		s.setState(secureChannelClosed)
+
+		return nil, io.EOF
+
+	case "MSG":
+	}
+
+	// Decrypts the block and returns data back into m.Data
+	m.Data, err = s.verifyAndDecrypt(m, b)
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := m.SequenceHeader.Decode(m.Data)
+	if err != nil {
+		return nil, fmt.Errorf("sechan: decode sequence header failed: %s", err)
+	}
+	m.Data = m.Data[n:]
+
+	if s.cfg.SecureChannelID == 0 {
+		s.cfg.SecureChannelID = h.SecureChannelID
+		debug.Printf("uasc %d/%d: set secure channel id to %d", s.c.ID(), m.SequenceHeader.RequestID, s.cfg.SecureChannelID)
+	}
+
+	return m, nil
+}
+
+// Receive waits for a complete message to be read from the channel and
+// sends it back to the caller.  If the caller was initiated from a
+// Send(), the message is directed to the registered callback function
+// and Receive() does not return. Otherwise, if no handler is detected,
+// the Receive returns with the message as a return value.
+// This behaviour means that anticipated results are automatically directed back to
+// their callers but unsolicited messages are sent to the caller of
+// Receive() to handle.
+func (s *SecureChannel) Receive(ctx context.Context) Response {
+	for {
+		select {
+		case <-ctx.Done():
+			return Response{Err: io.EOF}
+		default:
+			reqid, svc, err := s.receive(ctx)
+			if _, ok := err.(*uacp.Error); ok || err == io.EOF {
+				// todo: notifyCaller has been deprecated, but how else to purge all pending callbacks?
+				s.notifyCallers(err)
+				s.Close()
+				return Response{
+					ReqID: reqid,
+					SCID:  s.cfg.SecureChannelID,
+					V:     svc,
+					Err:   err,
+				}
+			}
+			if err != nil {
+				debug.Printf("uasc %d/%d: err: %v", s.c.ID(), reqid, err)
+			} else {
+				debug.Printf("uasc %d/%d: recv %T", s.c.ID(), reqid, svc)
+			}
+
+			// todo: validate request ID / check that it is increasing correctly
+			s.cfg.RequestID = reqid
+
+			switch svc.(type) {
+			case *ua.OpenSecureChannelRequest:
+				err := s.handleOpenSecureChannelRequest(svc)
+				if err != nil {
+					return Response{
+						Err: err,
+					}
+				}
+				continue
+			}
+
+			// check if we have a pending request handler for this response.
+			s.mu.Lock()
+			ch, ok := s.handler[reqid]
+			delete(s.handler, reqid)
+			s.mu.Unlock()
+			if !ok {
+				debug.Printf("uasc %d/%d: no handler for %T, returning result to caller", s.c.ID(), reqid, svc)
+				return Response{
+					ReqID: reqid,
+					SCID:  s.cfg.SecureChannelID,
+					V:     svc,
+					Err:   err,
+				}
+			}
+
+			// send response to caller
+			go func() {
+				debug.Printf("sending %T to handler\n", svc)
+				ch <- Response{
+					ReqID: reqid,
+					SCID:  s.cfg.SecureChannelID,
+					V:     svc,
+					Err:   err,
+				}
+			}()
+		}
+	}
+}
+
+// receive receives message chunks from the secure channel, decodes and forwards
+// them to the registered callback channel, if there is one. Otherwise,
+// the message is dropped.
+func (s *SecureChannel) receive(ctx context.Context) (uint32, interface{}, error) {
+
+	for {
+		select {
+		case <-ctx.Done():
+			return 0, nil, nil
+
+		default:
+			chunk, err := s.readChunk()
+			if err == io.EOF {
+				return 0, nil, err
+			}
+			if errf, ok := err.(*uacp.Error); ok {
+				s.notifyCallers(errf)
+				return 0, nil, errf
+			}
+			if err != nil {
+				debug.Printf("error received while receiving chunk: %s", err)
+				continue
+			}
+
+			hdr := chunk.Header
+			reqid := chunk.SequenceHeader.RequestID
+			debug.Printf("uasc %d/%d: recv %s%c with %d bytes", s.c.ID(), reqid, hdr.MessageType, hdr.ChunkType, hdr.MessageSize)
+
+			switch hdr.ChunkType {
+			case 'A':
+				delete(s.chunks, reqid)
+
+				msga := new(MessageAbort)
+				if _, err := msga.Decode(chunk.Data); err != nil {
+					debug.Printf("conn %d/%d: invalid MSGA chunk. %s", s.c.ID(), reqid, err)
+					return reqid, nil, ua.StatusBadDecodingError
+				}
+
+				return reqid, nil, ua.StatusCode(msga.ErrorCode)
+
+			case 'C':
+				s.chunks[reqid] = append(s.chunks[reqid], chunk)
+				if n := len(s.chunks[reqid]); uint32(n) > s.c.MaxChunkCount() {
+					delete(s.chunks, reqid)
+					return reqid, nil, fmt.Errorf("too many chunks: %d > %d", n, s.c.MaxChunkCount())
+				}
+				continue
+			}
+
+			// merge chunks
+			all := append(s.chunks[reqid], chunk)
+			delete(s.chunks, reqid)
+			b, err := mergeChunks(all)
+			if err != nil {
+				return reqid, nil, fmt.Errorf("chunk merge error: %v", err)
+			}
+
+			if uint32(len(b)) > s.c.MaxMessageSize() {
+				return reqid, nil, fmt.Errorf("message too large: %d > %d", uint32(len(b)), s.c.MaxMessageSize())
+			}
+
+			// since we are not decoding the ResponseHeader separately
+			// we need to drop every message that has an error since we
+			// cannot get to the RequestHandle in the ResponseHeader.
+			// To fix this we must a) decode the ResponseHeader separately
+			// and subsequently remove it and the TypeID from all service
+			// structs and tests. We also need to add a deadline to all
+			// handlers and check them periodically to time them out.
+			_, svc, err := ua.DecodeService(b)
+			if err != nil {
+				return reqid, nil, err
+			}
+
+			// extract the ServiceStatus field from the
+			// ResponseHeader which is always the first
+			// field in the struct.
+			//
+			// If the service status is not OK then bubble
+			// that error up to the caller.
+			val := reflect.ValueOf(svc)
+			field0 := val.Elem().Field(0).Interface()
+			if hdr, ok := field0.(*ua.ResponseHeader); ok {
+				debug.Printf("uasc %d/%d: res:%v", s.c.ID(), reqid, hdr.ServiceResult)
+				if hdr.ServiceResult != ua.StatusOK {
+					return reqid, svc, hdr.ServiceResult
+				}
+			}
+			return reqid, svc, err
+		}
+	}
+}
+
+func (s *SecureChannel) notifyCallers(err error) {
+	s.mu.Lock()
+	var reqids []uint32
+	for id := range s.handler {
+		reqids = append(reqids, id)
+	}
+	for _, id := range reqids {
+		s.notifyCallerLock(id, nil, err)
+	}
+	s.mu.Unlock()
+}
+
+func (s *SecureChannel) notifyCaller(reqid uint32, svc interface{}, err error) {
+	s.mu.Lock()
+	s.notifyCallerLock(reqid, svc, err)
+	s.mu.Unlock()
+}
+
+func (s *SecureChannel) notifyCallerLock(reqid uint32, svc interface{}, err error) {
+	if err != nil {
+		debug.Printf("uasc %d/%d: %v", s.c.ID(), reqid, err)
+	} else {
+		debug.Printf("uasc %d/%d: recv %T", s.c.ID(), reqid, svc)
+	}
+
+	// check if we have a pending request handler for this response.
+	ch := s.popHandlerLock(reqid)
+
+	// no handler -> next response
+	if ch == nil {
+		debug.Printf("uasc %d/%d: no handler for %T", s.c.ID(), reqid, svc)
+		return
+	}
+
+	// send response to caller
+	go func() {
+		ch <- Response{
+			ReqID: reqid,
+			SCID:  s.cfg.SecureChannelID,
+			V:     svc,
+			Err:   err,
+		}
+		close(ch)
+	}()
+}
+
+// Open opens a new secure channel with a server
+func (s *SecureChannel) Open() error {
+	return s.openSecureChannel()
+}
+
+// Close closes an existing secure channel
+func (s *SecureChannel) Close() error {
+	if err := s.closeSecureChannel(); err != nil && err != io.EOF {
+		debug.Printf("failed to send close secure channel request: %s", err)
+	}
+
+	if err := s.c.Close(); err != nil && err != io.EOF {
+		debug.Printf("failed to close transport connection: %s", err)
+	}
+
+	return io.EOF
 }
 
 func (s *SecureChannel) openSecureChannel() error {
@@ -197,299 +611,60 @@ func (s *SecureChannel) closeSecureChannel() error {
 	defer s.setState(secureChannelClosed)
 	// Don't send the CloseSecureChannel message if it was never fully opened (due to ERR, etc)
 	if !s.hasState(secureChannelOpen) {
-		return nil
+		return io.EOF
 	}
-	return s.Send(req, nil, nil)
-}
 
-// Send sends the service request and calls h with the response.
-func (s *SecureChannel) Send(svc interface{}, authToken *ua.NodeID, h func(interface{}) error) error {
-	return s.SendWithTimeout(svc, authToken, s.cfg.RequestTimeout, h)
-}
-
-// SendWithTimeout sends the service request and calls h with the response with a specific timeout.
-func (s *SecureChannel) SendWithTimeout(svc interface{}, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
-	ch, reqid, err := s.sendAsyncWithTimeout(svc, authToken, timeout)
+	err := s.Send(req, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if h == nil {
-		return nil
-	}
-
-	select {
-	case resp := <-ch:
-		if resp.Err != nil {
-			if resp.V != nil {
-				_ = h(resp.V) // ignore result because resp.Err takes precedence
-			}
-			return resp.Err
-		}
-		return h(resp.V)
-	case <-time.After(timeout + timeoutLeniency): // `+ timeoutLeniency` to give the server a chance to respond to TimeoutHint
-		s.mu.Lock()
-		s.popHandlerLock(reqid)
-		s.mu.Unlock()
-		return ua.StatusBadTimeout
-	}
+	return io.EOF
 }
 
-// SendAsync sends the service request and returns a channel which will receive the
-// response when it arrives.
-func (s *SecureChannel) SendAsync(svc interface{}, authToken *ua.NodeID) (resp chan Response, reqID uint32, err error) {
-	return s.sendAsyncWithTimeout(svc, authToken, s.cfg.RequestTimeout)
-}
+func (s *SecureChannel) handleOpenSecureChannelRequest(svc interface{}) error {
+	debug.Printf("handleOpenSecureChannelRequest: Got OPN Request\n")
 
-// sendAsyncWithTimeout sends the service request with a specific timeout and returns a channel which will receive the
-// response when it arrives.
-func (s *SecureChannel) sendAsyncWithTimeout(svc interface{}, authToken *ua.NodeID, timeout time.Duration) (resp chan Response, reqID uint32, err error) {
-	typeID := ua.ServiceTypeID(svc)
-	if typeID == 0 {
-		return nil, 0, fmt.Errorf("unknown service %T. Did you call register?", svc)
-	}
-	if authToken == nil {
-		authToken = ua.NewTwoByteNodeID(0)
+	var err error
+
+	req, ok := svc.(*ua.OpenSecureChannelRequest)
+	if !ok {
+		debug.Printf("Expected OpenSecureChannel Request, got %T\n", svc)
 	}
 
-	s.mu.Lock()
-	// the request header is always the first field
-	val := reflect.ValueOf(svc)
-	val.Elem().Field(0).Set(reflect.ValueOf(s.reqhdr))
-	// update counters
-	s.cfg.SequenceNumber++
-	s.cfg.RequestID++
-	s.reqhdr.AuthenticationToken = authToken
-	s.reqhdr.RequestHandle++
-	s.reqhdr.Timestamp = time.Now()
-	if timeout > 0 && timeout < s.cfg.RequestTimeout {
-		timeout = s.cfg.RequestTimeout
-	}
-	s.reqhdr.TimeoutHint = uint32(timeout / time.Millisecond)
+	s.cfg.Lifetime = req.RequestedLifetime
+	s.cfg.SecurityMode = req.SecurityMode
 
-	// encode the message
-	m := NewMessage(svc, typeID, s.cfg)
-	reqid := m.SequenceHeader.RequestID
-	s.mu.Unlock()
-	b, err := m.Encode()
+	nonce := make([]byte, s.enc.NonceLength())
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
+	resp := &ua.OpenSecureChannelResponse{
+		ResponseHeader: &ua.ResponseHeader{
+			Timestamp:          time.Now(),
+			RequestHandle:      req.RequestHeader.RequestHandle,
+			ServiceDiagnostics: &ua.DiagnosticInfo{},
+			StringTable:        []string{},
+			AdditionalHeader:   ua.NewExtensionObject(nil),
+		},
+		ServerProtocolVersion: 0,
+		SecurityToken: &ua.ChannelSecurityToken{
+			ChannelID:       s.cfg.SecureChannelID,
+			TokenID:         s.cfg.SecurityTokenID,
+			CreatedAt:       time.Now(),
+			RevisedLifetime: req.RequestedLifetime,
+		},
+		ServerNonce: nonce,
+	}
+
+	s.Send(resp, nil, nil)
+	s.enc, err = uapolicy.Symmetric(s.cfg.SecurityPolicyURI, nonce, req.ClientNonce)
 	if err != nil {
-		return nil, reqid, err
+		return err
 	}
+	s.setState(secureChannelOpen)
 
-	// encrypt the message prior to sending it
-	// if SecurityMode == None, this returns the byte stream untouched
-	b, err = s.signAndEncrypt(m, b)
-	if err != nil {
-		return nil, reqid, err
-	}
-
-	// send the message
-	if _, err := s.c.Write(b); err != nil {
-		return nil, reqid, err
-	}
-	debug.Printf("conn %d/%d: send %T with %d bytes", s.c.ID(), reqid, svc, len(b))
-
-	// register the handler
-	resp = make(chan Response)
-	s.mu.Lock()
-	if s.handler[reqid] != nil {
-		s.mu.Unlock()
-		return nil, reqid, fmt.Errorf("error: duplicate handler registration for request id %d", reqid)
-	}
-	s.handler[reqid] = resp
-	s.mu.Unlock()
-	return resp, reqid, nil
-}
-
-func (s *SecureChannel) readchunk() (*MessageChunk, error) {
-	// read a full message from the underlying conn.
-	b, err := s.c.Receive()
-	if err == io.EOF || s.hasState(secureChannelClosed) {
-		return nil, io.EOF
-	}
-	if errf, ok := err.(*uacp.Error); ok {
-		return nil, errf
-	}
-	if err != nil {
-		return nil, fmt.Errorf("sechan: read header failed: %s %#v", err, err)
-	}
-
-	const hdrlen = 12
-	h := new(Header)
-	if _, err := h.Decode(b[:hdrlen]); err != nil {
-		return nil, fmt.Errorf("sechan: decode header failed: %s", err)
-	}
-
-	// drop if the channel id does not match
-	if s.cfg.SecureChannelID > 0 && s.cfg.SecureChannelID != h.SecureChannelID {
-		return nil, fmt.Errorf("sechan: secure channel id mismatch: got 0x%04x, want 0x%04x", h.SecureChannelID, s.cfg.SecureChannelID)
-	}
-
-	// decode the other headers
-	m := new(MessageChunk)
-	if _, err := m.Decode(b); err != nil {
-		return nil, fmt.Errorf("sechan: decode chunk failed: %s", err)
-	}
-
-	// decrypt the block
-	m.Data, err = s.verifyAndDecrypt(m, b)
-	if err != nil {
-		return nil, err
-	}
-
-	n, err := m.SequenceHeader.Decode(m.Data)
-	if err != nil {
-		return nil, fmt.Errorf("sechan: decode sequence header failed: %s", err)
-	}
-	m.Data = m.Data[n:]
-
-	if s.cfg.SecureChannelID == 0 {
-		s.cfg.SecureChannelID = h.SecureChannelID
-		debug.Printf("conn %d/%d: set secure channel id to %d", s.c.ID(), m.SequenceHeader.RequestID, s.cfg.SecureChannelID)
-	}
-
-	return m, nil
-}
-
-// recv receives message chunks from the secure channel, decodes and forwards
-// them to the registered callback channel, if there is one. Otherwise,
-// the message is dropped.
-func (s *SecureChannel) recv() {
-	// chunks maps request id to message chunks
-	chunks := map[uint32][]*MessageChunk{}
-
-	for {
-		select {
-		case <-s.quit:
-			return
-
-		default:
-			chunk, err := s.readchunk()
-			if err == io.EOF {
-				return
-			}
-			if errf, ok := err.(*uacp.Error); ok {
-				s.notifyCallers(errf)
-				continue
-			}
-			if err != nil {
-				debug.Printf("error received while receiving chunk: %s", err)
-				continue
-			}
-
-			hdr := chunk.Header
-			reqid := chunk.SequenceHeader.RequestID
-			debug.Printf("conn %d/%d: recv %s%c with %d bytes", s.c.ID(), reqid, hdr.MessageType, hdr.ChunkType, hdr.MessageSize)
-
-			switch hdr.ChunkType {
-			case 'A':
-				delete(chunks, reqid)
-
-				msga := new(MessageAbort)
-				if _, err := msga.Decode(chunk.Data); err != nil {
-					debug.Printf("conn %d/%d: invalid MSGA chunk. %s", s.c.ID(), reqid, err)
-					s.notifyCaller(reqid, nil, ua.StatusBadDecodingError)
-					continue
-				}
-
-				s.notifyCaller(reqid, nil, ua.StatusCode(msga.ErrorCode))
-				continue
-
-			case 'C':
-				chunks[reqid] = append(chunks[reqid], chunk)
-				if n := len(chunks[reqid]); uint32(n) > s.c.MaxChunkCount() {
-					delete(chunks, reqid)
-					s.notifyCaller(reqid, nil, fmt.Errorf("too many chunks: %d > %d", n, s.c.MaxChunkCount()))
-				}
-				continue
-			}
-
-			// merge chunks
-			all := append(chunks[reqid], chunk)
-			delete(chunks, reqid)
-			b, err := mergeChunks(all)
-			if err != nil {
-				s.notifyCaller(reqid, nil, fmt.Errorf("chunk merge error: %v", err))
-				continue
-			}
-
-			if uint32(len(b)) > s.c.MaxMessageSize() {
-				s.notifyCaller(reqid, nil, fmt.Errorf("message too large: %d > %d", uint32(len(b)), s.c.MaxMessageSize()))
-				continue
-			}
-
-			// since we are not decoding the ResponseHeader separately
-			// we need to drop every message that has an error since we
-			// cannot get to the RequestHandle in the ResponseHeader.
-			// To fix this we must a) decode the ResponseHeader separately
-			// and subsequently remove it and the TypeID from all service
-			// structs and tests. We also need to add a deadline to all
-			// handlers and check them periodically to time them out.
-			_, svc, err := ua.DecodeService(b)
-			if err != nil {
-				s.notifyCaller(reqid, nil, err)
-				continue
-			}
-
-			// extract the ServiceStatus field from the
-			// ResponseHeader which is always the first
-			// field in the struct.
-			//
-			// If the service status is not OK then bubble
-			// that error up to the caller.
-			val := reflect.ValueOf(svc)
-			field0 := val.Elem().Field(0).Interface()
-			if hdr, ok := field0.(*ua.ResponseHeader); ok {
-				debug.Printf("conn %d/%d: res:%v", s.c.ID(), reqid, hdr.ServiceResult)
-				if hdr.ServiceResult != ua.StatusOK {
-					s.notifyCaller(reqid, svc, hdr.ServiceResult)
-					continue
-				}
-			}
-			s.notifyCaller(reqid, svc, err)
-		}
-	}
-}
-
-func (s *SecureChannel) notifyCallers(err error) {
-	s.mu.Lock()
-	var reqids []uint32
-	for id := range s.handler {
-		reqids = append(reqids, id)
-	}
-	for _, id := range reqids {
-		s.notifyCallerLock(id, nil, err)
-	}
-	s.mu.Unlock()
-}
-
-func (s *SecureChannel) notifyCaller(reqid uint32, svc interface{}, err error) {
-	s.mu.Lock()
-	s.notifyCallerLock(reqid, svc, err)
-	s.mu.Unlock()
-}
-
-func (s *SecureChannel) notifyCallerLock(reqid uint32, svc interface{}, err error) {
-	if err != nil {
-		debug.Printf("conn %d/%d: %v", s.c.ID(), reqid, err)
-	} else {
-		debug.Printf("conn %d/%d: recv %T", s.c.ID(), reqid, svc)
-	}
-
-	// check if we have a pending request handler for this response.
-	ch := s.popHandlerLock(reqid)
-
-	// no handler -> next response
-	if ch == nil {
-		debug.Printf("conn %d/%d: no handler for %T", s.c.ID(), reqid, svc)
-		return
-	}
-
-	// send response to caller
-	go func() {
-		ch <- Response{svc, err}
-		close(ch)
-	}()
+	return nil
 }
 
 func (s *SecureChannel) popHandlerLock(reqid uint32) chan Response {

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -496,12 +496,6 @@ func (s *SecureChannel) notifyCallers(ctx context.Context, err error) {
 	s.mu.Unlock()
 }
 
-func (s *SecureChannel) notifyCaller(ctx context.Context, reqid uint32, svc interface{}, err error) {
-	s.mu.Lock()
-	s.notifyCallerLock(ctx, reqid, svc, err)
-	s.mu.Unlock()
-}
-
 func (s *SecureChannel) notifyCallerLock(ctx context.Context, reqid uint32, svc interface{}, err error) {
 	if err != nil {
 		debug.Printf("uasc %d/%d: %v", s.c.ID(), reqid, err)

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -657,7 +657,11 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(svc interface{}) error {
 		ServerNonce: nonce,
 	}
 
-	s.Send(resp, nil, nil)
+	err = s.Send(resp, nil, nil)
+	if err != nil {
+		return err
+	}
+
 	s.enc, err = uapolicy.Symmetric(s.cfg.SecurityPolicyURI, nonce, req.ClientNonce)
 	if err != nil {
 		return err


### PR DESCRIPTION
In preparation for a server implementation, move the main read
loop out of the uasc package into the application layer.   The primary change is `recv()` (renamed to `receive`), now returns each time it receives a full message.  This allows the caller (client or server) to receive unsolicited uasc messages from the channel.

The context can be better seen in https://github.com/gopcua/opcua/tree/feature/server although that code isn't fleshed out enough to merge.  The remainder of the server implementation shouldn't have further impact on the uasc package as this change so I'm hoping to get this into the main branch to avoid needing to constantly fix merge conflicts with master.