### PR TITLE
fix(secure_channel): fix data race in Receive()

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -341,9 +341,6 @@ func (s *SecureChannel) Receive(ctx context.Context) Response {
 				debug.Printf("uasc %d/%d: recv %T", s.c.ID(), reqid, svc)
 			}
 
-			// todo: validate request ID / check that it is increasing correctly
-			s.cfg.RequestID = reqid
-
 			switch svc.(type) {
 			case *ua.OpenSecureChannelRequest:
 				err := s.handleOpenSecureChannelRequest(svc)


### PR DESCRIPTION
fixed by removing the offending line (see https://github.com/gopcua/opcua/issues/231#issuecomment-506775781)

closes #231