### PR TITLE
First stab at integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-{{ checksum "go.sum" }}
+      - run: pip3 install opcua
       - run: go test -v $GO_TEST_FLAGS ./...
+      - run: go test -v -tags=integration ./uatest
       - run: go install ./...
       - save_cache:
           key: go-mod-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-{{ checksum "go.sum" }}
+      - run: sudo apt-get install -y python3-pip
       - run: pip3 install opcua
       - run: go test -v $GO_TEST_FLAGS ./...
       - run: go test -v -tags=integration ./uatest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: test integration
+
+test:
+	go test ./...
+
+integration:
+	go test -v -tags=integration ./uatest/...
+
+install-py-opcua:
+	pip3 install opcua

--- a/uatest/read_test.go
+++ b/uatest/read_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func TestReadWrite(t *testing.T) {
+// TestRead performs an integration test to read values
+// from an OPC/UA server.
+func TestRead(t *testing.T) {
 	tests := []struct {
 		id *ua.NodeID
 		v  interface{}

--- a/uatest/rw_server.py
+++ b/uatest/rw_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import logging
+from opcua import ua, Server
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARN)
+
+    server = Server()
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/gopcua/server/")
+    server.set_server_name("OPC/UA server Read/Write tests")
+
+    uri = "http://gopcua.com/"
+    ns = server.register_namespace(uri)
+
+    main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
+    roBool = main.add_variable(ua.NodeId("ro_bool", ns), "ro_bool", True, ua.VariantType.Boolean)
+    rwBool = main.add_variable(ua.NodeId("rw_bool", ns), "rw_bool", True, ua.VariantType.Boolean)
+    rwBool.set_writable()
+
+    roInt32 = main.add_variable(ua.NodeId("ro_int32", ns), "ro_int32", 5, ua.VariantType.Int32)
+    rwInt32 = main.add_variable(ua.NodeId("rw_int32", ns), "rw_int32", 5, ua.VariantType.Int32)
+    rwInt32.set_writable()
+
+    server.start()

--- a/uatest/rw_test.go
+++ b/uatest/rw_test.go
@@ -1,0 +1,59 @@
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func TestReadWrite(t *testing.T) {
+	tests := []struct {
+		id *ua.NodeID
+		v  interface{}
+	}{
+		{ua.NewStringNodeID(2, "ro_bool"), true},
+		{ua.NewStringNodeID(2, "rw_bool"), true},
+		{ua.NewStringNodeID(2, "ro_int32"), int32(5)},
+		{ua.NewStringNodeID(2, "rw_int32"), int32(5)},
+	}
+
+	srv := NewServer("rw_server.py")
+	defer srv.Close()
+
+	c := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			testRead(t, c, tt.v, &ua.ReadRequest{
+				NodesToRead: []*ua.ReadValueID{
+					&ua.ReadValueID{NodeID: tt.id},
+				},
+				TimestampsToReturn: ua.TimestampsToReturnBoth,
+			})
+		})
+	}
+}
+
+func testRead(t *testing.T, c *opcua.Client, v interface{}, req *ua.ReadRequest) {
+	t.Helper()
+
+	resp, err := c.Read(req)
+	if err != nil {
+		t.Fatalf("Read failed: %s", err)
+	}
+	if resp.Results[0].Status != ua.StatusOK {
+		t.Fatalf("Status not OK: %v", resp.Results[0].Status)
+	}
+	if got, want := resp.Results[0].Value.Value(), v; !verify.Values(t, "", got, want) {
+		t.Fail()
+	}
+}

--- a/uatest/server.go
+++ b/uatest/server.go
@@ -1,0 +1,76 @@
+// +build integration
+
+package uatest
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+)
+
+// Server runs a python test server.
+type Server struct {
+	// Path is the path to the Python server.
+	Path string
+
+	// Endpoint is the endpoint address which will be set
+	// after the server has started.
+	Endpoint string
+
+	// Opts contains the client options required to connect to the server.
+	// They are valid after the server has been started.
+	Opts []opcua.Option
+
+	cmd *exec.Cmd
+}
+
+// NewServer creates a test server and starts it. The function
+// panics if the server cannot be started.
+func NewServer(path string) *Server {
+	s := &Server{Path: path}
+	if err := s.Run(); err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (s *Server) Run() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(wd, s.Path)
+	s.cmd = exec.Command("python3", path)
+	s.Endpoint = "opc.tcp://127.0.0.1:4840"
+	s.Opts = []opcua.Option{opcua.SecurityMode(ua.MessageSecurityModeNone)}
+	if err := s.cmd.Start(); err != nil {
+		return err
+	}
+
+	// wait until endpoint is available
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.Dial("tcp", "127.0.0.1:4840")
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		c.Close()
+		return nil
+	}
+	return fmt.Errorf("timeout")
+}
+
+func (s *Server) Close() error {
+	if s.cmd == nil {
+		return fmt.Errorf("not running")
+	}
+	go func() { s.cmd.Process.Kill() }()
+	return s.cmd.Wait()
+}

--- a/uatest/write_test.go
+++ b/uatest/write_test.go
@@ -1,0 +1,78 @@
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+)
+
+// TestWrite performs an integration test to first write
+// and then read values from an OPC/UA server.
+func TestWrite(t *testing.T) {
+	tests := []struct {
+		id     *ua.NodeID
+		v      interface{}
+		status ua.StatusCode
+	}{
+		// happy flows
+		{ua.NewStringNodeID(2, "rw_bool"), false, ua.StatusOK},
+		{ua.NewStringNodeID(2, "rw_int32"), int32(9), ua.StatusOK},
+
+		// error flows
+		{ua.NewStringNodeID(2, "ro_bool"), false, ua.StatusBadUserAccessDenied},
+	}
+
+	srv := NewServer("rw_server.py")
+	defer srv.Close()
+
+	c := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			testWrite(t, c, tt.status, &ua.WriteRequest{
+				NodesToWrite: []*ua.WriteValue{
+					&ua.WriteValue{
+						NodeID:      tt.id,
+						AttributeID: ua.AttributeIDValue,
+						Value: &ua.DataValue{
+							EncodingMask: ua.DataValueValue,
+							Value:        ua.MustVariant(tt.v),
+						},
+					},
+				},
+			})
+
+			// skip read tests if the write is expected to fail
+			if tt.status != ua.StatusOK {
+				return
+			}
+
+			testRead(t, c, tt.v, &ua.ReadRequest{
+				NodesToRead: []*ua.ReadValueID{
+					&ua.ReadValueID{NodeID: tt.id},
+				},
+				TimestampsToReturn: ua.TimestampsToReturnBoth,
+			})
+		})
+	}
+}
+
+func testWrite(t *testing.T, c *opcua.Client, status ua.StatusCode, req *ua.WriteRequest) {
+	t.Helper()
+
+	resp, err := c.Write(req)
+	if err != nil {
+		t.Fatalf("Write failed: %s", err)
+	}
+	if got, want := resp.Results[0], status; got != want {
+		t.Fatalf("got status %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
This patch creates a separate integration test suite which uses the python server from https://github.com/FreeOPCUA until we have our own server implementation. 

The approach is similar to the `httptest` package in that it provides a `Server` which you initialize with a `path` to the Python server. It panics if the startup fails. Currently, the server is expected to run on `127.0.0.1:4840` and have no security. 

The python server needs between 1-2 seconds of startup. The `Server` waits a couple of seconds until the endpoint is available before continuing. Because of this the integration tests are hidden behind a build flag, `go test -tags=integration ./uatest`. Got the inspiration from https://medium.com/@povilasve/go-advanced-tips-tricks-a872503ac859

This should provide a platform for writing integration tests. 

The following things still need solving:

* How to ensure that the `opcua` package is installed? Do we care about the version? (I've added a `make install-py-opcua` target to make this easier)
* Not sure if the path resolution to the python server is done properly. My guess is that this breaks when the test is in a different package.

@alexbrdn and @kung-foo This could be useful for subscription testing.