### PR TITLE
Add an IsConnected function to Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -154,6 +154,15 @@ func (c *Client) Connect(ctx context.Context) (err error) {
 	return nil
 }
 
+// IsConnected returns whether the a secure channel is currently established.
+func (c *Client) IsConnected(ctx context.Context) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return c.sechan != nil
+}
+
 // Dial establishes a secure channel.
 func (c *Client) Dial(ctx context.Context) error {
 	if ctx == nil {


### PR DESCRIPTION
Add an isConnected to the client - needed to determine whether a connection has been established prior to making a request.

Calling read/write functions on a non established connection from the library returns a panic!

Can call connect regardless on each request, but calling on an established connection returns a generic string error, so we cannot programmatically determine whether connect failed due to a failure, or due to being an existing connection, without parsing the result of err.Error(), which is a bad solution.

Need to either move to implementing proper (non string) error types, or add the attached function allowing it to be checked manually.