### PR TITLE
🚧 Add dial timeout and cleanup ResolveEndpoint

### DIFF
--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -21,7 +21,7 @@ func main() {
 	ctx := context.Background()
 
 	log.Printf("Listening on %s", *endpoint)
-	l, err := uacp.Listen(context.Background(), *endpoint, nil)
+	l, err := uacp.Listen(ctx, *endpoint, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -21,7 +21,7 @@ func main() {
 	ctx := context.Background()
 
 	log.Printf("Listening on %s", *endpoint)
-	l, err := uacp.Listen(*endpoint, nil)
+	l, err := uacp.Listen(context.Background(), *endpoint, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -47,7 +47,8 @@ func Dial(ctx context.Context, endpoint string) (*Conn, error) {
 		return nil, err
 	}
 
-	dialer := net.Dialer{}
+	var dialer net.Dialer
+
 	c, err := dialer.DialContext(ctx, network, url.Host)
 	if err != nil {
 		return nil, err

--- a/uacp/conn_test.go
+++ b/uacp/conn_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestConn(t *testing.T) {
 	ep := "opc.tcp://127.0.0.1:4840/foo/bar"
-	ln, err := Listen(ep, nil)
+	ln, err := Listen(context.Background(), ep, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestConn(t *testing.T) {
 
 func TestClientWrite(t *testing.T) {
 	ep := "opc.tcp://127.0.0.1:4840/foo/bar"
-	ln, err := Listen(ep, nil)
+	ln, err := Listen(context.Background(), ep, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ NEXT:
 
 func TestServerWrite(t *testing.T) {
 	ep := "opc.tcp://127.0.0.1:4840/foo/bar"
-	ln, err := Listen(ep, nil)
+	ln, err := Listen(context.Background(), ep, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/uacp/endpoint.go
+++ b/uacp/endpoint.go
@@ -34,7 +34,8 @@ func ResolveEndpoint(ctx context.Context, endpoint string) (network string, url 
 		port = defaultPort
 	}
 
-	resolver := net.Resolver{}
+	var resolver net.Resolver
+
 	addrs, err := resolver.LookupIPAddr(ctx, url.Hostname())
 	if err != nil {
 		return

--- a/uacp/endpoint_test.go
+++ b/uacp/endpoint_test.go
@@ -5,7 +5,8 @@
 package uacp
 
 import (
-	"net"
+	"context"
+	"net/url"
 	"testing"
 )
 
@@ -13,64 +14,68 @@ func TestResolveEndpoint(t *testing.T) {
 	cases := []struct {
 		input   string
 		network string
-		addr    *net.TCPAddr
+		u       *url.URL
 		errStr  string
 	}{
 		{ // Valid, full EndpointURL
 			"opc.tcp://10.0.0.1:4840/foo/bar",
 			"tcp",
-			&net.TCPAddr{
-				IP:   net.IP([]byte{0x0a, 0x00, 0x00, 0x01}),
-				Port: 4840,
+			&url.URL{
+				Scheme: "opc.tcp",
+				Host:   "10.0.0.1:4840",
+				Path:   "/foo/bar",
 			},
 			"",
 		},
 		{ // Valid, port number omitted
 			"opc.tcp://10.0.0.1/foo/bar",
 			"tcp",
-			&net.TCPAddr{
-				IP:   net.IP([]byte{0x0a, 0x00, 0x00, 0x01}),
-				Port: 4840,
+			&url.URL{
+				Scheme: "opc.tcp",
+				Host:   "10.0.0.1:4840",
+				Path:   "/foo/bar",
 			},
 			"",
 		},
 		{ // Valid, hostname resolved
 			"opc.tcp://localhost:4840/foo/bar",
 			"tcp",
-			&net.TCPAddr{
-				IP:   net.IP([]byte{0x7f, 0x00, 0x00, 0x01}),
-				Port: 4840,
+			&url.URL{
+				Scheme: "opc.tcp",
+				Host:   "127.0.0.1:4840",
+				Path:   "/foo/bar",
 			},
 			"",
 		},
-		{ // Invalid, schema is not "opc.tcp://"
+		{ // Invalid, scheme is not "opc.tcp://"
 			"tcp://10.0.0.1:4840/foo/bar",
 			"",
 			nil,
-			"invalid endpoint tcp://10.0.0.1:4840/foo/bar",
+			"unsupported scheme tcp",
 		},
-		{ // Invalid, bad formatted schema
-			"opc.tcp:/10.0.0.1:4840/foo/bar",
+		{ // Invalid, bad formatted endpoint
+			"opc.tcp://10.0.0.1:x4840/foo/bar",
 			"",
 			nil,
-			"could not resolve address foo:4840",
+			"parse opc.tcp://10.0.0.1:x4840/foo/bar: invalid port \":x4840\" after host",
 		},
 	}
 
 	for _, c := range cases {
 		var errStr string
-		network, addr, err := ResolveEndpoint(c.input)
+		network, u, err := ResolveEndpoint(context.Background(), c.input)
 		if err != nil {
 			errStr = err.Error()
-		}
-		if got, want := network, c.network; got != want {
-			t.Fatalf("got network %q want %q", got, want)
-		}
-		if got, want := addr.String(), c.addr.String(); got != want {
-			t.Fatalf("got addr %q want %q", got, want)
-		}
-		if got, want := errStr, c.errStr; got != want {
-			t.Fatalf("got error %q want %q", got, want)
+			if got, want := errStr, c.errStr; got != want {
+				t.Fatalf("got error %q want %q", got, want)
+			}
+		} else {
+			if got, want := network, c.network; got != want {
+				t.Fatalf("got network %q want %q", got, want)
+			}
+			if got, want := u.String(), c.u.String(); got != want {
+				t.Fatalf("got addr %q want %q", got, want)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a default timeout to the underlying `Dial` calls. This affects both the name resolution and the actual TCP setup. I also cleaned up the resolve logic. I left the logic in place that explicitly resolves a host name to a single IP address because I don't know the original reasons (I don't see any need for it. I would rather just create a `ValidateEndpoint` and let the regular dialer do its thing.)

I originally tried to enable a timeout by adding a `context.Timeout` to the call to `Client.Dial` (https://github.com/Intelecy/opcua/blob/net-ctx/client.go#L158-L189), but that backfired as the incoming context is also used for signaling, and not just the dial itself (as the name would imply).

TODO: more testing as I've only tested this in one local configuration