### PR TITLE
Add error prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 dist/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The current set of supported services is only for the high-level client.
 |                             | Write                         | Yes       |              |
 |                             | HistoryRead                   | Yes       |              |
 |                             | HistoryUpdate                 |           |              |
-| Method Service Set          | Call                          |           |              |
+| Method Service Set          | Call                          | Yes       |              |
 | MonitoredItems Service Set  | CreateMonitoredItems          | Yes       |              |
 |                             | DeleteMonitoredItems          | Yes       |              |
 |                             | ModifyMonitoredItems          |           |              |

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 
 	"github.com/gopcua/opcua/cmd/service/goname"
+	"github.com/gopcua/opcua/errors"
 )
 
 var in, out, pkg string
@@ -45,6 +46,9 @@ func writeEnums(enums []Type) {
 
 func writeExtObjects(objs []Type) {
 	var b bytes.Buffer
+	if err := tmplReqResp.Execute(&b, nil); err != nil {
+		log.Fatal(err)
+	}
 	if err := FormatTypes(&b, objs); err != nil {
 		log.Fatal(err)
 	}
@@ -203,6 +207,14 @@ type Type struct {
 	Values []Value
 }
 
+func (t Type) IsRequest() bool {
+	return len(t.Fields) > 0 && t.Fields[0].Type == "*RequestHeader"
+}
+
+func (t Type) IsResponse() bool {
+	return len(t.Fields) > 0 && t.Fields[0].Type == "*ResponseHeader"
+}
+
 type Value struct {
 	Name      string
 	ShortName string
@@ -230,7 +242,7 @@ func FormatType(w io.Writer, t Type) error {
 	case KindExtensionObject:
 		return tmplExtObject.Execute(w, t)
 	default:
-		return fmt.Errorf("invalid type: %d", t.Kind)
+		return errors.Errorf("invalid type: %d", t.Kind)
 	}
 }
 
@@ -252,12 +264,44 @@ const (
 )
 `))
 
+var tmplReqResp = template.Must(template.New("").Parse(`
+type Request interface {
+	Header() *RequestHeader
+	SetHeader(*RequestHeader)
+}
+
+type Response interface {
+	Header() *ResponseHeader
+	SetHeader(*ResponseHeader)
+}
+`))
+
 var tmplExtObject = template.Must(template.New("").Parse(`
 {{if .Fields}}
 type {{.Name}} struct {
 	{{range $i, $v := .Fields}}{{$v.Name}} {{$v.Type}}
 	{{end}}
 }
+{{- if .IsRequest}}
+
+func (t *{{.Name}}) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *{{.Name}}) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+{{- end}}
+{{- if .IsResponse}}
+
+func (t *{{.Name}}) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *{{.Name}}) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+{{- end}}
 {{end}}
 `))
 

--- a/config.go
+++ b/config.go
@@ -8,13 +8,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"strings"
 	"time"
 
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uapolicy"
 	"github.com/gopcua/opcua/uasc"
@@ -176,21 +176,21 @@ func PrivateKeyFile(filename string) Option {
 func loadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load private key: %s", err)
+		return nil, errors.Errorf("Failed to load private key: %s", err)
 	}
 
 	derBytes := b
 	if strings.HasSuffix(filename, ".pem") {
 		block, _ := pem.Decode(b)
 		if block == nil || block.Type != "RSA PRIVATE KEY" {
-			return nil, fmt.Errorf("Failed to decode PEM block with private key")
+			return nil, errors.Errorf("Failed to decode PEM block with private key")
 		}
 		derBytes = block.Bytes
 	}
 
 	pk, err := x509.ParsePKCS1PrivateKey(derBytes)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse private key: %s", err)
+		return nil, errors.Errorf("Failed to parse private key: %s", err)
 	}
 	return pk, nil
 }
@@ -223,7 +223,7 @@ func CertificateFile(filename string) Option {
 func loadCertificate(filename string) ([]byte, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load certificate: %s", err)
+		return nil, errors.Errorf("Failed to load certificate: %s", err)
 	}
 
 	if !strings.HasSuffix(filename, ".pem") {
@@ -232,7 +232,7 @@ func loadCertificate(filename string) ([]byte, error) {
 
 	block, _ := pem.Decode(b)
 	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, fmt.Errorf("Failed to decode PEM block with certificate")
+		return nil, errors.Errorf("Failed to decode PEM block with certificate")
 	}
 	return block.Bytes, nil
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,18 @@
+package errors
+
+import (
+	pkg_errors "github.com/pkg/errors"
+)
+
+// Prefix is the default error string prefix
+const Prefix = "opcua: "
+
+// Errorf is a wrapper for `errors.Errorf`
+func Errorf(format string, a ...interface{}) error {
+	return pkg_errors.Errorf(Prefix+format, a...)
+}
+
+// New is a wrapper for `errors.New`
+func New(text string) error {
+	return pkg_errors.New(Prefix + text)
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,20 @@
+package errors
+
+import "testing"
+
+func TestErrors(t *testing.T) {
+	err := Errorf("hello %s", "world")
+	if err.Error() != "opcua: hello world" {
+		t.Fatalf("got %s, wanted %s", err.Error(), "opcua: hello world")
+	}
+
+	err = New("hello")
+	if err.Error() != "opcua: hello" {
+		t.Fatalf("got %s, wanted %s", err.Error(), "opcua: hello")
+	}
+
+	err = New("hello %s")
+	if err.Error() != "opcua: hello %s" {
+		t.Fatalf("got %s, wanted %s", err.Error(), "opcua: %s")
+	}
+}

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -6,15 +6,37 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"flag"
-	"fmt"
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 )
+
+type NodeDef struct {
+	NodeID      *ua.NodeID
+	NodeClass   ua.NodeClass
+	BrowseName  string
+	Description string
+	AccessLevel ua.AccessLevelType
+	Path        string
+	DataType    string
+	Writable    bool
+	Unit        string
+	Scale       string
+	Min         string
+	Max         string
+}
+
+func (n NodeDef) Records() []string {
+	return []string{n.BrowseName, n.DataType, n.NodeID.String(), n.Unit, n.Scale, n.Min, n.Max, strconv.FormatBool(n.Writable), n.Description}
+}
 
 func join(a, b string) string {
 	if a == "" {
@@ -23,32 +45,129 @@ func join(a, b string) string {
 	return a + "." + b
 }
 
-func browse(n *opcua.Node, path string, level int) ([]string, error) {
+func browse(n *opcua.Node, path string, level int) ([]NodeDef, error) {
+	// fmt.Printf("node:%s path:%q level:%d\n", n, path, level)
 	if level > 10 {
 		return nil, nil
 	}
-	// nodeClass, err := n.NodeClass()
-	// if err != nil {
-	// 	return nil, err
-	// }
-	browseName, err := n.BrowseName()
-	if err != nil {
-		return nil, err
-	}
-	path = join(path, browseName.Name)
 
-	typeDefs := ua.NewTwoByteNodeID(id.HasTypeDefinition)
-	refs, err := n.References(typeDefs)
+	attrs, err := n.Attributes(ua.AttributeIDNodeClass, ua.AttributeIDBrowseName, ua.AttributeIDDescription, ua.AttributeIDAccessLevel, ua.AttributeIDDataType)
 	if err != nil {
 		return nil, err
 	}
-	// todo(fs): example still incomplete
-	log.Printf("refs: %#v err: %v", refs, err)
-	return nil, nil
+
+	var def = NodeDef{
+		NodeID: n.ID,
+	}
+
+	switch err := attrs[0].Status; err {
+	case ua.StatusOK:
+		def.NodeClass = ua.NodeClass(attrs[0].Value.Int())
+	default:
+		return nil, err
+	}
+
+	switch err := attrs[1].Status; err {
+	case ua.StatusOK:
+		def.BrowseName = attrs[1].Value.String()
+	default:
+		return nil, err
+	}
+
+	switch err := attrs[2].Status; err {
+	case ua.StatusOK:
+		def.Description = attrs[2].Value.String()
+	case ua.StatusBadAttributeIDInvalid:
+		// ignore
+	default:
+		return nil, err
+	}
+
+	switch err := attrs[3].Status; err {
+	case ua.StatusOK:
+		def.AccessLevel = ua.AccessLevelType(attrs[3].Value.Int())
+		def.Writable = def.AccessLevel&ua.AccessLevelTypeCurrentWrite == ua.AccessLevelTypeCurrentWrite
+	case ua.StatusBadAttributeIDInvalid:
+		// ignore
+	default:
+		return nil, err
+	}
+
+	switch err := attrs[4].Status; err {
+	case ua.StatusOK:
+		switch v := attrs[4].Value.NodeID().IntID(); v {
+		case id.DateTime:
+			def.DataType = "time.Time"
+		case id.Boolean:
+			def.DataType = "bool"
+		case id.SByte:
+			def.DataType = "int8"
+		case id.Int16:
+			def.DataType = "int16"
+		case id.Int32:
+			def.DataType = "int32"
+		case id.Byte:
+			def.DataType = "byte"
+		case id.UInt16:
+			def.DataType = "uint16"
+		case id.UInt32:
+			def.DataType = "uint32"
+		case id.UtcTime:
+			def.DataType = "time.Time"
+		case id.String:
+			def.DataType = "string"
+		case id.Float:
+			def.DataType = "float32"
+		case id.Double:
+			def.DataType = "float64"
+		default:
+			def.DataType = attrs[4].Value.NodeID().String()
+		}
+	case ua.StatusBadAttributeIDInvalid:
+		// ignore
+	default:
+		return nil, err
+	}
+
+	def.Path = join(path, def.BrowseName)
+	// fmt.Printf("%d: def.Path:%s def.NodeClass:%s\n", level, def.Path, def.NodeClass)
+
+	var nodes []NodeDef
+	if def.NodeClass == ua.NodeClassVariable {
+		nodes = append(nodes, def)
+	}
+
+	browseChildren := func(refType uint32) error {
+		refs, err := n.ReferencedNodes(refType, ua.BrowseDirectionForward, ua.NodeClassAll, true)
+		if err != nil {
+			return errors.Errorf("References: %d: %s", refType, err)
+		}
+		// fmt.Printf("found %d child refs\n", len(refs))
+		for _, rn := range refs {
+			children, err := browse(rn, def.Path, level+1)
+			if err != nil {
+				return errors.Errorf("browse children: %s", err)
+			}
+			nodes = append(nodes, children...)
+		}
+		return nil
+	}
+
+	if err := browseChildren(id.HasComponent); err != nil {
+		return nil, err
+	}
+	if err := browseChildren(id.Organizes); err != nil {
+		return nil, err
+	}
+	if err := browseChildren(id.HasProperty); err != nil {
+		return nil, err
+	}
+	return nodes, nil
 }
 
 func main() {
 	endpoint := flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
+	nodeID := flag.String("node", "", "node id for the root node")
 	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging")
 	flag.Parse()
 	log.SetFlags(0)
@@ -61,13 +180,22 @@ func main() {
 	}
 	defer c.Close()
 
-	root := c.Node(ua.NewStringNodeID(1, "Root"))
+	id, err := ua.ParseNodeID(*nodeID)
+	if err != nil {
+		log.Fatalf("invalid node id: %s", err)
+	}
 
-	nodeList, err := browse(root, "", 0)
+	nodeList, err := browse(c.Node(id), "", 0)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	w := csv.NewWriter(os.Stdout)
+	w.Comma = ';'
+	hdr := []string{"Name", "Type", "Addr", "Unit (SI)", "Scale", "Min", "Max", "Writable", "Description"}
+	w.Write(hdr)
 	for _, s := range nodeList {
-		fmt.Println(s)
+		w.Write(s.Records())
 	}
+	w.Flush()
 }

--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -298,7 +299,7 @@ func validateEndpointConfig(endpoints []*ua.EndpointDescription, secPolicy strin
 		}
 	}
 
-	err := fmt.Errorf("server does not support an endpoint with security : %s , %s", secPolicy, secMode)
+	err := errors.Errorf("server does not support an endpoint with security : %s , %s", secPolicy, secMode)
 	printEndpointOptions(endpoints)
 	return err
 }

--- a/examples/method/method.go
+++ b/examples/method/method.go
@@ -1,0 +1,49 @@
+// Copyright 2018-2019 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/ua"
+)
+
+func main() {
+	var (
+		endpoint = flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
+	)
+	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging")
+	flag.Parse()
+	log.SetFlags(0)
+
+	ctx := context.Background()
+
+	c := opcua.NewClient(*endpoint, opcua.SecurityMode(ua.MessageSecurityModeNone))
+	if err := c.Connect(ctx); err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	in := int64(12)
+	req := &ua.CallMethodRequest{
+		ObjectID:       ua.NewStringNodeID(2, "main"),
+		MethodID:       ua.NewStringNodeID(2, "even"),
+		InputArguments: []*ua.Variant{ua.MustVariant(in)},
+	}
+
+	resp, err := c.Call(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if got, want := resp.StatusCode, ua.StatusOK; got != want {
+		log.Fatalf("got status %v want %v", got, want)
+	}
+	out := resp.OutputArguments[0].Value()
+	log.Printf("%d is even: %v", in, out)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/pascaldekloe/goe v0.1.0
+	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
 	golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/subscription.go
+++ b/subscription.go
@@ -2,9 +2,9 @@ package opcua
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uasc"
@@ -218,7 +218,7 @@ func (s *Subscription) Stats() (*ua.SubscriptionDiagnosticsDataType, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("opcua: unable to find SubscriptionDiagnostics for sub=%d", s.SubscriptionID)
+	return nil, errors.Errorf("unable to find SubscriptionDiagnostics for sub=%d", s.SubscriptionID)
 }
 
 func (p *SubscriptionParameters) setDefaults() {

--- a/ua/buffer.go
+++ b/ua/buffer.go
@@ -6,10 +6,11 @@ package ua
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"math"
 	"time"
+
+	"github.com/gopcua/opcua/errors"
 )
 
 const (
@@ -282,7 +283,7 @@ func (b *Buffer) WriteByteString(d []byte) {
 		return
 	}
 	if len(d) > math.MaxInt32 {
-		b.err = fmt.Errorf("value too large")
+		b.err = errors.Errorf("value too large")
 		return
 	}
 	if d == nil {

--- a/ua/datatypes.go
+++ b/ua/datatypes.go
@@ -166,11 +166,16 @@ func (g *GUID) String() string {
 	d4 := make([]byte, 8)
 	binary.BigEndian.PutUint64(d4, g.Data4)
 
-	return fmt.Sprintf("%X-%X-%X-%X-%X",
+	return fmt.Sprintf("%0*X-%0*X-%0*X-%0*X-%0*X",
+		8,
 		g.Data1,
+		4,
 		g.Data2,
+		4,
 		g.Data3,
+		4,
 		d4[:2],
+		12,
 		d4[2:],
 	)
 }
@@ -234,4 +239,4 @@ func (l *LocalizedText) UpdateMask() {
 	}
 }
 
-type XmlElement string
+type XMLElement string

--- a/ua/decode.go
+++ b/ua/decode.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"reflect"
 	"time"
+
+	"github.com/gopcua/opcua/errors"
 )
 
 var (
@@ -86,7 +88,7 @@ func decode(b []byte, val reflect.Value, name string) (n int, err error) {
 		case reflect.Struct:
 			return decodeStruct(b, val, name)
 		default:
-			return 0, fmt.Errorf("unsupported type %s", val.Type())
+			return 0, errors.Errorf("unsupported type %s", val.Type())
 		}
 	}
 	return buf.Pos(), buf.Error()
@@ -128,7 +130,7 @@ func decodeSlice(b []byte, val reflect.Value, name string) (int, error) {
 	}
 
 	if n > math.MaxInt32 {
-		return buf.Pos(), fmt.Errorf("array too large: %d", n)
+		return buf.Pos(), errors.Errorf("array too large: %d", n)
 	}
 
 	// elemType is the type of the slice elements

--- a/ua/encode.go
+++ b/ua/encode.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gopcua/opcua/debug"
+	"github.com/gopcua/opcua/errors"
 )
 
 // debugCodec enables printing of debug messages in the opcua codec.
@@ -83,7 +84,7 @@ func encode(val reflect.Value, name string) ([]byte, error) {
 		case reflect.Slice:
 			return writeSlice(val, name)
 		default:
-			return nil, fmt.Errorf("unsupported type: %s", val.Type())
+			return nil, errors.Errorf("unsupported type: %s", val.Type())
 		}
 	}
 	return buf.Bytes(), buf.Error()
@@ -112,7 +113,7 @@ func writeSlice(val reflect.Value, name string) ([]byte, error) {
 	}
 
 	if val.Len() > math.MaxInt32 {
-		return nil, fmt.Errorf("array too large")
+		return nil, errors.Errorf("array too large")
 	}
 
 	buf.WriteUint32(uint32(val.Len()))

--- a/ua/enums.go
+++ b/ua/enums.go
@@ -58,6 +58,7 @@ const (
 type TypeID byte
 
 const (
+	TypeIDNull            TypeID = 0 // not part of specification but some servers (e.g. Prosys) return it anyway
 	TypeIDBoolean         TypeID = 1
 	TypeIDSByte           TypeID = 2
 	TypeIDByte            TypeID = 3

--- a/ua/expanded_node_id.go
+++ b/ua/expanded_node_id.go
@@ -15,6 +15,10 @@ type ExpandedNodeID struct {
 	ServerIndex  uint32
 }
 
+func (a ExpandedNodeID) String() string {
+	return a.NodeID.String()
+}
+
 // NewExpandedNodeID creates a new ExpandedNodeID.
 func NewExpandedNodeID(hasURI, hasIndex bool, nodeID *NodeID, uri string, idx uint32) *ExpandedNodeID {
 	e := &ExpandedNodeID{

--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -5,8 +5,7 @@
 package ua
 
 import (
-	"fmt"
-
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 )
 
@@ -82,7 +81,7 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 	}
 
 	if e.EncodingMask == ExtensionObjectXML {
-		e.Value = new(XmlElement)
+		e.Value = new(XMLElement)
 		body.ReadStruct(e.Value)
 		return buf.Pos(), body.Error()
 	}
@@ -90,7 +89,7 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 	typeID := e.TypeID.NodeID.String()
 	e.Value = eotypes.New(typeID)
 	if e.Value == nil {
-		return buf.Pos(), fmt.Errorf("invalid extension object with id %s", typeID)
+		return buf.Pos(), errors.Errorf("invalid extension object with id %s", typeID)
 	}
 
 	body.ReadStruct(e.Value)
@@ -121,7 +120,7 @@ func (e *ExtensionObject) Encode() ([]byte, error) {
 func (e *ExtensionObject) UpdateMask() {
 	if e.Value == nil {
 		e.EncodingMask = ExtensionObjectEmpty
-	} else if _, ok := e.Value.(*XmlElement); ok {
+	} else if _, ok := e.Value.(*XMLElement); ok {
 		e.EncodingMask = ExtensionObjectXML
 	} else {
 		e.EncodingMask = ExtensionObjectBinary

--- a/ua/extobjs_gen.go
+++ b/ua/extobjs_gen.go
@@ -8,6 +8,16 @@ package ua
 
 import "time"
 
+type Request interface {
+	Header() *RequestHeader
+	SetHeader(*RequestHeader)
+}
+
+type Response interface {
+	Header() *ResponseHeader
+	SetHeader(*ResponseHeader)
+}
+
 type KeyValuePair struct {
 	Key   *QualifiedName
 	Value *Variant
@@ -621,6 +631,14 @@ type ServiceFault struct {
 	ResponseHeader *ResponseHeader
 }
 
+func (t *ServiceFault) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *ServiceFault) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type SessionlessInvokeRequestType struct {
 	URIsVersion   []uint32
 	NamespaceURIs []string
@@ -642,9 +660,25 @@ type FindServersRequest struct {
 	ServerURIs    []string
 }
 
+func (t *FindServersRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *FindServersRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type FindServersResponse struct {
 	ResponseHeader *ResponseHeader
 	Servers        []*ApplicationDescription
+}
+
+func (t *FindServersResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *FindServersResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type ServerOnNetwork struct {
@@ -661,10 +695,26 @@ type FindServersOnNetworkRequest struct {
 	ServerCapabilityFilter []string
 }
 
+func (t *FindServersOnNetworkRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *FindServersOnNetworkRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type FindServersOnNetworkResponse struct {
 	ResponseHeader       *ResponseHeader
 	LastCounterResetTime time.Time
 	Servers              []*ServerOnNetwork
+}
+
+func (t *FindServersOnNetworkResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *FindServersOnNetworkResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type UserTokenPolicy struct {
@@ -693,9 +743,25 @@ type GetEndpointsRequest struct {
 	ProfileURIs   []string
 }
 
+func (t *GetEndpointsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *GetEndpointsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type GetEndpointsResponse struct {
 	ResponseHeader *ResponseHeader
 	Endpoints      []*EndpointDescription
+}
+
+func (t *GetEndpointsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *GetEndpointsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type RegisteredServer struct {
@@ -714,8 +780,24 @@ type RegisterServerRequest struct {
 	Server        *RegisteredServer
 }
 
+func (t *RegisterServerRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *RegisterServerRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type RegisterServerResponse struct {
 	ResponseHeader *ResponseHeader
+}
+
+func (t *RegisterServerResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *RegisterServerResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type MdnsDiscoveryConfiguration struct {
@@ -729,10 +811,26 @@ type RegisterServer2Request struct {
 	DiscoveryConfiguration []*ExtensionObject
 }
 
+func (t *RegisterServer2Request) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *RegisterServer2Request) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type RegisterServer2Response struct {
 	ResponseHeader       *ResponseHeader
 	ConfigurationResults []StatusCode
 	DiagnosticInfos      []*DiagnosticInfo
+}
+
+func (t *RegisterServer2Response) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *RegisterServer2Response) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type ChannelSecurityToken struct {
@@ -751,6 +849,14 @@ type OpenSecureChannelRequest struct {
 	RequestedLifetime     uint32
 }
 
+func (t *OpenSecureChannelRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *OpenSecureChannelRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type OpenSecureChannelResponse struct {
 	ResponseHeader        *ResponseHeader
 	ServerProtocolVersion uint32
@@ -758,12 +864,36 @@ type OpenSecureChannelResponse struct {
 	ServerNonce           []byte
 }
 
+func (t *OpenSecureChannelResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *OpenSecureChannelResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type CloseSecureChannelRequest struct {
 	RequestHeader *RequestHeader
 }
 
+func (t *CloseSecureChannelRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CloseSecureChannelRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CloseSecureChannelResponse struct {
 	ResponseHeader *ResponseHeader
+}
+
+func (t *CloseSecureChannelResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CloseSecureChannelResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type SignedSoftwareCertificate struct {
@@ -788,6 +918,14 @@ type CreateSessionRequest struct {
 	MaxResponseMessageSize  uint32
 }
 
+func (t *CreateSessionRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CreateSessionRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CreateSessionResponse struct {
 	ResponseHeader             *ResponseHeader
 	SessionID                  *NodeID
@@ -799,6 +937,14 @@ type CreateSessionResponse struct {
 	ServerSoftwareCertificates []*SignedSoftwareCertificate
 	ServerSignature            *SignatureData
 	MaxRequestMessageSize      uint32
+}
+
+func (t *CreateSessionResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CreateSessionResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type UserIdentityToken struct {
@@ -836,6 +982,14 @@ type ActivateSessionRequest struct {
 	UserTokenSignature         *SignatureData
 }
 
+func (t *ActivateSessionRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *ActivateSessionRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type ActivateSessionResponse struct {
 	ResponseHeader  *ResponseHeader
 	ServerNonce     []byte
@@ -843,13 +997,37 @@ type ActivateSessionResponse struct {
 	DiagnosticInfos []*DiagnosticInfo
 }
 
+func (t *ActivateSessionResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *ActivateSessionResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type CloseSessionRequest struct {
 	RequestHeader       *RequestHeader
 	DeleteSubscriptions bool
 }
 
+func (t *CloseSessionRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CloseSessionRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CloseSessionResponse struct {
 	ResponseHeader *ResponseHeader
+}
+
+func (t *CloseSessionResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CloseSessionResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type CancelRequest struct {
@@ -857,9 +1035,25 @@ type CancelRequest struct {
 	RequestHandle uint32
 }
 
+func (t *CancelRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CancelRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CancelResponse struct {
 	ResponseHeader *ResponseHeader
 	CancelCount    uint32
+}
+
+func (t *CancelResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CancelResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type NodeAttributes struct {
@@ -991,10 +1185,26 @@ type AddNodesRequest struct {
 	NodesToAdd    []*AddNodesItem
 }
 
+func (t *AddNodesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *AddNodesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type AddNodesResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*AddNodesResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *AddNodesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *AddNodesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type AddReferencesItem struct {
@@ -1011,10 +1221,26 @@ type AddReferencesRequest struct {
 	ReferencesToAdd []*AddReferencesItem
 }
 
+func (t *AddReferencesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *AddReferencesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type AddReferencesResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *AddReferencesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *AddReferencesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type DeleteNodesItem struct {
@@ -1027,10 +1253,26 @@ type DeleteNodesRequest struct {
 	NodesToDelete []*DeleteNodesItem
 }
 
+func (t *DeleteNodesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *DeleteNodesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type DeleteNodesResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *DeleteNodesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *DeleteNodesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type DeleteReferencesItem struct {
@@ -1046,10 +1288,26 @@ type DeleteReferencesRequest struct {
 	ReferencesToDelete []*DeleteReferencesItem
 }
 
+func (t *DeleteReferencesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *DeleteReferencesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type DeleteReferencesResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *DeleteReferencesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *DeleteReferencesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type ViewDescription struct {
@@ -1090,10 +1348,26 @@ type BrowseRequest struct {
 	NodesToBrowse                 []*BrowseDescription
 }
 
+func (t *BrowseRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *BrowseRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type BrowseResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*BrowseResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *BrowseResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *BrowseResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type BrowseNextRequest struct {
@@ -1102,10 +1376,26 @@ type BrowseNextRequest struct {
 	ContinuationPoints        [][]byte
 }
 
+func (t *BrowseNextRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *BrowseNextRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type BrowseNextResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*BrowseResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *BrowseNextResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *BrowseNextResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type RelativePathElement struct {
@@ -1139,10 +1429,26 @@ type TranslateBrowsePathsToNodeIDsRequest struct {
 	BrowsePaths   []*BrowsePath
 }
 
+func (t *TranslateBrowsePathsToNodeIDsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *TranslateBrowsePathsToNodeIDsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type TranslateBrowsePathsToNodeIDsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*BrowsePathResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *TranslateBrowsePathsToNodeIDsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *TranslateBrowsePathsToNodeIDsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type RegisterNodesRequest struct {
@@ -1150,9 +1456,25 @@ type RegisterNodesRequest struct {
 	NodesToRegister []*NodeID
 }
 
+func (t *RegisterNodesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *RegisterNodesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type RegisterNodesResponse struct {
 	ResponseHeader    *ResponseHeader
 	RegisteredNodeIDs []*NodeID
+}
+
+func (t *RegisterNodesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *RegisterNodesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type UnregisterNodesRequest struct {
@@ -1160,8 +1482,24 @@ type UnregisterNodesRequest struct {
 	NodesToUnregister []*NodeID
 }
 
+func (t *UnregisterNodesRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *UnregisterNodesRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type UnregisterNodesResponse struct {
 	ResponseHeader *ResponseHeader
+}
+
+func (t *UnregisterNodesResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *UnregisterNodesResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type EndpointConfiguration struct {
@@ -1259,6 +1597,14 @@ type QueryFirstRequest struct {
 	MaxReferencesToReturn uint32
 }
 
+func (t *QueryFirstRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *QueryFirstRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type QueryFirstResponse struct {
 	ResponseHeader    *ResponseHeader
 	QueryDataSets     []*QueryDataSet
@@ -1268,16 +1614,40 @@ type QueryFirstResponse struct {
 	FilterResult      *ContentFilterResult
 }
 
+func (t *QueryFirstResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *QueryFirstResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type QueryNextRequest struct {
 	RequestHeader            *RequestHeader
 	ReleaseContinuationPoint bool
 	ContinuationPoint        []byte
 }
 
+func (t *QueryNextRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *QueryNextRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type QueryNextResponse struct {
 	ResponseHeader           *ResponseHeader
 	QueryDataSets            []*QueryDataSet
 	RevisedContinuationPoint []byte
+}
+
+func (t *QueryNextResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *QueryNextResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type ReadValueID struct {
@@ -1294,10 +1664,26 @@ type ReadRequest struct {
 	NodesToRead        []*ReadValueID
 }
 
+func (t *ReadRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *ReadRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type ReadResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*DataValue
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *ReadResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *ReadResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type HistoryReadValueID struct {
@@ -1368,10 +1754,26 @@ type HistoryReadRequest struct {
 	NodesToRead               []*HistoryReadValueID
 }
 
+func (t *HistoryReadRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *HistoryReadRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type HistoryReadResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*HistoryReadResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *HistoryReadResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *HistoryReadResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type WriteValue struct {
@@ -1386,10 +1788,26 @@ type WriteRequest struct {
 	NodesToWrite  []*WriteValue
 }
 
+func (t *WriteRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *WriteRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type WriteResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *WriteResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *WriteResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type HistoryUpdateDetails struct {
@@ -1443,10 +1861,26 @@ type HistoryUpdateRequest struct {
 	HistoryUpdateDetails []*ExtensionObject
 }
 
+func (t *HistoryUpdateRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *HistoryUpdateRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type HistoryUpdateResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*HistoryUpdateResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *HistoryUpdateResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *HistoryUpdateResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type CallMethodRequest struct {
@@ -1467,10 +1901,26 @@ type CallRequest struct {
 	MethodsToCall []*CallMethodRequest
 }
 
+func (t *CallRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CallRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CallResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*CallMethodResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *CallResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CallResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type DataChangeFilter struct {
@@ -1540,10 +1990,26 @@ type CreateMonitoredItemsRequest struct {
 	ItemsToCreate      []*MonitoredItemCreateRequest
 }
 
+func (t *CreateMonitoredItemsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CreateMonitoredItemsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CreateMonitoredItemsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*MonitoredItemCreateResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *CreateMonitoredItemsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CreateMonitoredItemsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type MonitoredItemModifyRequest struct {
@@ -1565,10 +2031,26 @@ type ModifyMonitoredItemsRequest struct {
 	ItemsToModify      []*MonitoredItemModifyRequest
 }
 
+func (t *ModifyMonitoredItemsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *ModifyMonitoredItemsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type ModifyMonitoredItemsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*MonitoredItemModifyResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *ModifyMonitoredItemsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *ModifyMonitoredItemsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type SetMonitoringModeRequest struct {
@@ -1578,10 +2060,26 @@ type SetMonitoringModeRequest struct {
 	MonitoredItemIDs []uint32
 }
 
+func (t *SetMonitoringModeRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *SetMonitoringModeRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type SetMonitoringModeResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *SetMonitoringModeResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *SetMonitoringModeResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type SetTriggeringRequest struct {
@@ -1592,6 +2090,14 @@ type SetTriggeringRequest struct {
 	LinksToRemove    []uint32
 }
 
+func (t *SetTriggeringRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *SetTriggeringRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type SetTriggeringResponse struct {
 	ResponseHeader        *ResponseHeader
 	AddResults            []StatusCode
@@ -1600,16 +2106,40 @@ type SetTriggeringResponse struct {
 	RemoveDiagnosticInfos []*DiagnosticInfo
 }
 
+func (t *SetTriggeringResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *SetTriggeringResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type DeleteMonitoredItemsRequest struct {
 	RequestHeader    *RequestHeader
 	SubscriptionID   uint32
 	MonitoredItemIDs []uint32
 }
 
+func (t *DeleteMonitoredItemsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *DeleteMonitoredItemsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type DeleteMonitoredItemsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *DeleteMonitoredItemsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *DeleteMonitoredItemsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type CreateSubscriptionRequest struct {
@@ -1622,12 +2152,28 @@ type CreateSubscriptionRequest struct {
 	Priority                    uint8
 }
 
+func (t *CreateSubscriptionRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *CreateSubscriptionRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type CreateSubscriptionResponse struct {
 	ResponseHeader            *ResponseHeader
 	SubscriptionID            uint32
 	RevisedPublishingInterval float64
 	RevisedLifetimeCount      uint32
 	RevisedMaxKeepAliveCount  uint32
+}
+
+func (t *CreateSubscriptionResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *CreateSubscriptionResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type ModifySubscriptionRequest struct {
@@ -1640,11 +2186,27 @@ type ModifySubscriptionRequest struct {
 	Priority                    uint8
 }
 
+func (t *ModifySubscriptionRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *ModifySubscriptionRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type ModifySubscriptionResponse struct {
 	ResponseHeader            *ResponseHeader
 	RevisedPublishingInterval float64
 	RevisedLifetimeCount      uint32
 	RevisedMaxKeepAliveCount  uint32
+}
+
+func (t *ModifySubscriptionResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *ModifySubscriptionResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type SetPublishingModeRequest struct {
@@ -1653,10 +2215,26 @@ type SetPublishingModeRequest struct {
 	SubscriptionIDs   []uint32
 }
 
+func (t *SetPublishingModeRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *SetPublishingModeRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type SetPublishingModeResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *SetPublishingModeResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *SetPublishingModeResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type NotificationMessage struct {
@@ -1703,6 +2281,14 @@ type PublishRequest struct {
 	SubscriptionAcknowledgements []*SubscriptionAcknowledgement
 }
 
+func (t *PublishRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *PublishRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type PublishResponse struct {
 	ResponseHeader           *ResponseHeader
 	SubscriptionID           uint32
@@ -1713,15 +2299,39 @@ type PublishResponse struct {
 	DiagnosticInfos          []*DiagnosticInfo
 }
 
+func (t *PublishResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *PublishResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
+}
+
 type RepublishRequest struct {
 	RequestHeader            *RequestHeader
 	SubscriptionID           uint32
 	RetransmitSequenceNumber uint32
 }
 
+func (t *RepublishRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *RepublishRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type RepublishResponse struct {
 	ResponseHeader      *ResponseHeader
 	NotificationMessage *NotificationMessage
+}
+
+func (t *RepublishResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *RepublishResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type TransferResult struct {
@@ -1735,10 +2345,26 @@ type TransferSubscriptionsRequest struct {
 	SendInitialValues bool
 }
 
+func (t *TransferSubscriptionsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *TransferSubscriptionsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type TransferSubscriptionsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []*TransferResult
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *TransferSubscriptionsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *TransferSubscriptionsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type DeleteSubscriptionsRequest struct {
@@ -1746,10 +2372,26 @@ type DeleteSubscriptionsRequest struct {
 	SubscriptionIDs []uint32
 }
 
+func (t *DeleteSubscriptionsRequest) Header() *RequestHeader {
+	return t.RequestHeader
+}
+
+func (t *DeleteSubscriptionsRequest) SetHeader(h *RequestHeader) {
+	t.RequestHeader = h
+}
+
 type DeleteSubscriptionsResponse struct {
 	ResponseHeader  *ResponseHeader
 	Results         []StatusCode
 	DiagnosticInfos []*DiagnosticInfo
+}
+
+func (t *DeleteSubscriptionsResponse) Header() *ResponseHeader {
+	return t.ResponseHeader
+}
+
+func (t *DeleteSubscriptionsResponse) SetHeader(h *ResponseHeader) {
+	t.ResponseHeader = h
 }
 
 type BuildInfo struct {

--- a/ua/node_id.go
+++ b/ua/node_id.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/gopcua/opcua/errors"
 )
 
 // todo(fs): fix mask
@@ -92,30 +94,36 @@ func ParseNodeID(s string) (*NodeID, error) {
 		return NewTwoByteNodeID(0), nil
 	}
 
+	var nsval, idval string
+
 	p := strings.SplitN(s, ";", 2)
-	if len(p) < 2 {
-		return nil, fmt.Errorf("invalid node id: %s", s)
+	switch len(p) {
+	case 1:
+		nsval, idval = "ns=0", p[0]
+	case 2:
+		nsval, idval = p[0], p[1]
+	default:
+		return nil, errors.Errorf("invalid node id: %s", s)
 	}
-	nsval, idval := p[0], p[1]
 
 	// parse namespace
 	var ns uint16
 	switch {
 	case strings.HasPrefix(nsval, "nsu="):
-		return nil, fmt.Errorf("namespace urls are not supported: %s", s)
+		return nil, errors.Errorf("namespace urls are not supported: %s", s)
 
 	case strings.HasPrefix(nsval, "ns="):
 		n, err := strconv.Atoi(nsval[3:])
 		if err != nil {
-			return nil, fmt.Errorf("invalid namespace id: %s", s)
+			return nil, errors.Errorf("invalid namespace id: %s", s)
 		}
 		if n < 0 || n > math.MaxUint16 {
-			return nil, fmt.Errorf("namespace id out of range (0..65535): %s", s)
+			return nil, errors.Errorf("namespace id out of range (0..65535): %s", s)
 		}
 		ns = uint16(n)
 
 	default:
-		return nil, fmt.Errorf("invalid node id: %s", s)
+		return nil, errors.Errorf("invalid node id: %s", s)
 	}
 
 	// parse identifier
@@ -123,7 +131,7 @@ func ParseNodeID(s string) (*NodeID, error) {
 	case strings.HasPrefix(idval, "i="):
 		id, err := strconv.ParseUint(idval[2:], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid numeric id: %s", s)
+			return nil, errors.Errorf("invalid numeric id: %s", s)
 		}
 		switch {
 		case ns == 0 && id < 256:
@@ -133,7 +141,7 @@ func ParseNodeID(s string) (*NodeID, error) {
 		case id < math.MaxUint32:
 			return NewNumericNodeID(ns, uint32(id)), nil
 		default:
-			return nil, fmt.Errorf("numeric id out of range (0..2^32-1): %s", s)
+			return nil, errors.Errorf("numeric id out of range (0..2^32-1): %s", s)
 		}
 
 	case strings.HasPrefix(idval, "s="):
@@ -142,16 +150,19 @@ func ParseNodeID(s string) (*NodeID, error) {
 	case strings.HasPrefix(idval, "g="):
 		n := NewGUIDNodeID(ns, idval[2:])
 		if n == nil || n.StringID() == "" {
-			return nil, fmt.Errorf("invalid guid node id: %s", s)
+			return nil, errors.Errorf("invalid guid node id: %s", s)
 		}
 		return n, nil
 
 	case strings.HasPrefix(idval, "b="):
 		b, err := base64.StdEncoding.DecodeString(idval[2:])
 		if err != nil {
-			return nil, fmt.Errorf("invalid opaque node id: %s", s)
+			return nil, errors.Errorf("invalid opaque node id: %s", s)
 		}
 		return NewByteStringNodeID(ns, b), nil
+
+	case strings.HasPrefix(idval, "ns="):
+		return nil, errors.Errorf("invalid node id: %s", s)
 
 	default:
 		return NewStringNodeID(ns, idval), nil
@@ -201,20 +212,20 @@ func (n *NodeID) SetNamespace(v uint16) error {
 	switch n.Type() {
 	case NodeIDTypeTwoByte:
 		if v != 0 {
-			return fmt.Errorf("out of range [0..0]: %d", v)
+			return errors.Errorf("out of range [0..0]: %d", v)
 		}
 		return nil
 
 	case NodeIDTypeFourByte:
 		if max := uint16(math.MaxUint8); v > max {
-			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+			return errors.Errorf("out of range [0..%d]: %d", max, v)
 		}
 		n.ns = uint16(v)
 		return nil
 
 	default:
 		if max := uint16(math.MaxUint16); v > max {
-			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+			return errors.Errorf("out of range [0..%d]: %d", max, v)
 		}
 		n.ns = uint16(v)
 		return nil
@@ -234,27 +245,27 @@ func (n *NodeID) SetIntID(v uint32) error {
 	switch n.Type() {
 	case NodeIDTypeTwoByte:
 		if max := uint32(math.MaxUint8); v > max {
-			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+			return errors.Errorf("out of range [0..%d]: %d", max, v)
 		}
 		n.nid = uint32(v)
 		return nil
 
 	case NodeIDTypeFourByte:
 		if max := uint32(math.MaxUint16); v > max {
-			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+			return errors.Errorf("out of range [0..%d]: %d", max, v)
 		}
 		n.nid = uint32(v)
 		return nil
 
 	case NodeIDTypeNumeric:
 		if max := uint32(math.MaxUint32); v > max {
-			return fmt.Errorf("out of range [0..%d]: %d", max, v)
+			return errors.Errorf("out of range [0..%d]: %d", max, v)
 		}
 		n.nid = uint32(v)
 		return nil
 
 	default:
-		return fmt.Errorf("incompatible node id type")
+		return errors.Errorf("incompatible node id type")
 	}
 }
 
@@ -299,7 +310,7 @@ func (n *NodeID) SetStringID(v string) error {
 		return nil
 
 	default:
-		return fmt.Errorf("incompatible node id type")
+		return errors.Errorf("incompatible node id type")
 	}
 }
 
@@ -378,7 +389,7 @@ func (n *NodeID) Decode(b []byte) (int, error) {
 		return buf.Pos(), buf.Error()
 
 	default:
-		return 0, fmt.Errorf("invalid node id type %v", typ)
+		return 0, errors.Errorf("invalid node id type %v", typ)
 	}
 }
 
@@ -402,7 +413,7 @@ func (n *NodeID) Encode() ([]byte, error) {
 		buf.WriteUint16(n.ns)
 		buf.WriteByteString(n.bid)
 	default:
-		return nil, fmt.Errorf("invalid node id type %v", n.Type())
+		return nil, errors.Errorf("invalid node id type %v", n.Type())
 	}
 	return buf.Bytes(), buf.Error()
 }

--- a/ua/typereg.go
+++ b/ua/typereg.go
@@ -5,9 +5,10 @@
 package ua
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
+
+	"github.com/gopcua/opcua/errors"
 )
 
 // TypeRegistry provides a registry for Go types.
@@ -68,7 +69,7 @@ func (r *TypeRegistry) Register(id string, v interface{}) error {
 	typ := reflect.TypeOf(v)
 
 	if r.types[id] != nil {
-		return fmt.Errorf("%s is already registered", id)
+		return errors.Errorf("%s is already registered", id)
 	}
 	r.types[id] = typ
 

--- a/ua/variant_test.go
+++ b/ua/variant_test.go
@@ -169,8 +169,8 @@ func TestVariant(t *testing.T) {
 			},
 		},
 		{
-			Name:   "XmlElement",
-			Struct: MustVariant(XmlElement("abc")),
+			Name:   "XMLElement",
+			Struct: MustVariant(XMLElement("abc")),
 			Bytes: []byte{
 				// variant encoding mask
 				0x10,

--- a/uacp/endpoint.go
+++ b/uacp/endpoint.go
@@ -5,9 +5,10 @@
 package uacp
 
 import (
-	"fmt"
 	"net"
 	"strings"
+
+	"github.com/gopcua/opcua/errors"
 )
 
 // ResolveEndpoint returns network type, address, and error splitted from EndpointURL.
@@ -16,7 +17,7 @@ import (
 func ResolveEndpoint(endpoint string) (network string, addr *net.TCPAddr, err error) {
 	elems := strings.Split(endpoint, "/")
 	if elems[0] != "opc.tcp:" {
-		return "", nil, fmt.Errorf("invalid endpoint %s", endpoint)
+		return "", nil, errors.Errorf("invalid endpoint %s", endpoint)
 	}
 
 	addrString := elems[2]
@@ -28,7 +29,7 @@ func ResolveEndpoint(endpoint string) (network string, addr *net.TCPAddr, err er
 	addr, err = net.ResolveTCPAddr(network, addrString)
 	switch err.(type) {
 	case *net.DNSError:
-		return "", nil, fmt.Errorf("could not resolve address %s", addrString)
+		return "", nil, errors.Errorf("could not resolve address %s", addrString)
 	}
 	return
 }

--- a/uacp/endpoint_test.go
+++ b/uacp/endpoint_test.go
@@ -47,13 +47,13 @@ func TestResolveEndpoint(t *testing.T) {
 			"tcp://10.0.0.1:4840/foo/bar",
 			"",
 			nil,
-			"invalid endpoint tcp://10.0.0.1:4840/foo/bar",
+			"opcua: invalid endpoint tcp://10.0.0.1:4840/foo/bar",
 		},
 		{ // Invalid, bad formatted schema
-			"opc.tcp:/10.0.0.1:4840/foo/bar",
+			"opc.tcp:/10.0.0.1:4840/foo1337bar/baz",
 			"",
 			nil,
-			"could not resolve address foo:4840",
+			"opcua: could not resolve address foo1337bar:4840",
 		},
 	}
 

--- a/uacp/uacp.go
+++ b/uacp/uacp.go
@@ -5,8 +5,7 @@
 package uacp
 
 import (
-	"fmt"
-
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -49,7 +48,7 @@ func (h *Header) Decode(b []byte) (int, error) {
 func (h *Header) Encode() ([]byte, error) {
 	buf := ua.NewBuffer(nil)
 	if len(h.MessageType) != 3 {
-		return nil, fmt.Errorf("invalid message type: %q", h.MessageType)
+		return nil, errors.Errorf("invalid message type: %q", h.MessageType)
 	}
 	buf.Write([]byte(h.MessageType))
 	buf.WriteByte(h.ChunkType)

--- a/uapolicy/crypto_aes.go
+++ b/uapolicy/crypto_aes.go
@@ -3,7 +3,7 @@ package uapolicy
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 )
 
 const (

--- a/uapolicy/crypto_hmac.go
+++ b/uapolicy/crypto_hmac.go
@@ -3,7 +3,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/hmac"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 )
 
 type HMAC struct {

--- a/uapolicy/policyAes128Sha256RsaOaep.go
+++ b/uapolicy/policyAes128Sha256RsaOaep.go
@@ -7,7 +7,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/rsa"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 	"fmt"
 
 	// Force compilation of required hashing algorithms, although we don't directly use the packages

--- a/uapolicy/policyAes256Sha256RsaPss.go
+++ b/uapolicy/policyAes256Sha256RsaPss.go
@@ -7,7 +7,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/rsa"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 	"fmt"
 
 	// Force compilation of required hashing algorithms, although we don't directly use the packages

--- a/uapolicy/policyBasic128Rsa15.go
+++ b/uapolicy/policyBasic128Rsa15.go
@@ -7,7 +7,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/rsa"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 	"fmt"
 
 	// Force compilation of required hashing algorithms, although we don't directly use the packages

--- a/uapolicy/policyBasic256.go
+++ b/uapolicy/policyBasic256.go
@@ -7,7 +7,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/rsa"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 	"fmt"
 
 	// Force compilation of required hashing algorithms, although we don't directly use the packages

--- a/uapolicy/policyBasic256Sha256.go
+++ b/uapolicy/policyBasic256Sha256.go
@@ -7,7 +7,7 @@ package uapolicy
 import (
 	"crypto"
 	"crypto/rsa"
-	"errors"
+	"github.com/gopcua/opcua/errors"
 	"fmt"
 
 	// Force compilation of required hashing algorithms, although we don't directly use the packages

--- a/uapolicy/securitypolicy.go
+++ b/uapolicy/securitypolicy.go
@@ -9,9 +9,9 @@ package uapolicy
 
 import (
 	"crypto/rsa"
-	"errors"
-	"fmt"
 	"sort"
+
+	"github.com/gopcua/opcua/errors"
 
 	"github.com/gopcua/opcua/ua"
 )
@@ -31,7 +31,7 @@ func SupportedPolicies() []string {
 func Asymmetric(uri string, localKey *rsa.PrivateKey, remoteKey *rsa.PublicKey) (*EncryptionAlgorithm, error) {
 	p, ok := policies[uri]
 	if !ok {
-		return nil, fmt.Errorf("unsupported security policy %s", uri)
+		return nil, errors.Errorf("unsupported security policy %s", uri)
 	}
 
 	return p.asymmetric(localKey, remoteKey)
@@ -41,7 +41,7 @@ func Asymmetric(uri string, localKey *rsa.PrivateKey, remoteKey *rsa.PublicKey) 
 func Symmetric(uri string, localNonce, remoteNonce []byte) (*EncryptionAlgorithm, error) {
 	p, ok := policies[uri]
 	if !ok {
-		return nil, fmt.Errorf("unsupported security policy %s", uri)
+		return nil, errors.Errorf("unsupported security policy %s", uri)
 	}
 
 	if uri != ua.SecurityPolicyURINone && (localNonce == nil || remoteNonce == nil) {

--- a/uasc/header.go
+++ b/uasc/header.go
@@ -7,6 +7,7 @@ package uasc
 import (
 	"fmt"
 
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -53,7 +54,7 @@ func (h *Header) Decode(b []byte) (int, error) {
 func (h *Header) Encode() ([]byte, error) {
 	buf := ua.NewBuffer(nil)
 	if len(h.MessageType) != 3 {
-		return nil, fmt.Errorf("invalid message type: %q", h.MessageType)
+		return nil, errors.Errorf("invalid message type: %q", h.MessageType)
 	}
 	buf.Write([]byte(h.MessageType))
 	buf.WriteByte(h.ChunkType)

--- a/uasc/message.go
+++ b/uasc/message.go
@@ -5,8 +5,7 @@
 package uasc
 
 import (
-	"fmt"
-
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 )
@@ -34,7 +33,7 @@ func (m *MessageHeader) Decode(b []byte) (int, error) {
 		buf.ReadStruct(m.SymmetricSecurityHeader)
 
 	default:
-		return buf.Pos(), fmt.Errorf("invalid message type %q", m.Header.MessageType)
+		return buf.Pos(), errors.Errorf("invalid message type %q", m.Header.MessageType)
 	}
 
 	// Sequence header could be encrypted, defer decoding until after decryption
@@ -176,7 +175,7 @@ func (m *Message) Encode() ([]byte, error) {
 	case "CLO", "MSG":
 		body.WriteStruct(m.SymmetricSecurityHeader)
 	default:
-		return nil, fmt.Errorf("invalid message type %q", m.Header.MessageType)
+		return nil, errors.Errorf("invalid message type %q", m.Header.MessageType)
 	}
 	body.WriteStruct(m.SequenceHeader)
 	body.WriteStruct(m.TypeID)

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -1,0 +1,135 @@
+package uasc
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func TestNewRequestMessage(t *testing.T) {
+	fixedTime := func() time.Time { return time.Date(2019, 1, 1, 12, 13, 14, 0, time.UTC) }
+	tests := []struct {
+		name      string
+		sechan    *SecureChannel
+		req       ua.Request
+		authToken *ua.NodeID
+		timeout   time.Duration
+		m         *Message
+	}{
+		{
+			name: "first-request",
+			sechan: &SecureChannel{
+				cfg:    &Config{},
+				reqhdr: &ua.RequestHeader{},
+				time:   fixedTime,
+			},
+			req: &ua.ReadRequest{},
+			m: &Message{
+				MessageHeader: &MessageHeader{
+					Header: &Header{
+						MessageType: MessageTypeMessage,
+						ChunkType:   ChunkTypeFinal,
+					},
+					SymmetricSecurityHeader: &SymmetricSecurityHeader{},
+					SequenceHeader: &SequenceHeader{
+						SequenceNumber: 1,
+						RequestID:      1,
+					},
+				},
+				TypeID: ua.NewFourByteExpandedNodeID(0, id.ReadRequest_Encoding_DefaultBinary),
+				Service: &ua.ReadRequest{
+					RequestHeader: &ua.RequestHeader{
+						AuthenticationToken: ua.NewTwoByteNodeID(0),
+						Timestamp:           fixedTime(),
+						RequestHandle:       1,
+					},
+				},
+			},
+		},
+		{
+			name: "subsequent-request",
+			sechan: &SecureChannel{
+				cfg: &Config{
+					SequenceNumber: 777,
+					RequestID:      555,
+				},
+				reqhdr: &ua.RequestHeader{
+					RequestHandle: 444,
+				},
+				time: fixedTime,
+			},
+			req: &ua.ReadRequest{},
+			m: &Message{
+				MessageHeader: &MessageHeader{
+					Header: &Header{
+						MessageType: MessageTypeMessage,
+						ChunkType:   ChunkTypeFinal,
+					},
+					SymmetricSecurityHeader: &SymmetricSecurityHeader{},
+					SequenceHeader: &SequenceHeader{
+						SequenceNumber: 778,
+						RequestID:      556,
+					},
+				},
+				TypeID: ua.NewFourByteExpandedNodeID(0, id.ReadRequest_Encoding_DefaultBinary),
+				Service: &ua.ReadRequest{
+					RequestHeader: &ua.RequestHeader{
+						AuthenticationToken: ua.NewTwoByteNodeID(0),
+						Timestamp:           fixedTime(),
+						RequestHandle:       445,
+					},
+				},
+			},
+		},
+		{
+			name: "counter-rollover",
+			sechan: &SecureChannel{
+				cfg: &Config{
+					SequenceNumber: math.MaxUint32 - 1023,
+					RequestID:      math.MaxUint32,
+				},
+				reqhdr: &ua.RequestHeader{
+					RequestHandle: math.MaxUint32,
+				},
+				time: fixedTime,
+			},
+			req: &ua.ReadRequest{},
+			m: &Message{
+				MessageHeader: &MessageHeader{
+					Header: &Header{
+						MessageType: MessageTypeMessage,
+						ChunkType:   ChunkTypeFinal,
+					},
+					SymmetricSecurityHeader: &SymmetricSecurityHeader{},
+					SequenceHeader: &SequenceHeader{
+						SequenceNumber: 1,
+						RequestID:      1,
+					},
+				},
+				TypeID: ua.NewFourByteExpandedNodeID(0, id.ReadRequest_Encoding_DefaultBinary),
+				Service: &ua.ReadRequest{
+					RequestHeader: &ua.RequestHeader{
+						AuthenticationToken: ua.NewTwoByteNodeID(0),
+						Timestamp:           fixedTime(),
+						RequestHandle:       1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := tt.sechan.newRequestMessage(tt.req, tt.authToken, tt.timeout)
+			if err != nil {
+				t.Fatalf("got err %v want nil", err)
+			}
+			verify.Values(t, "", m, tt.m)
+		})
+	}
+}

--- a/uatest/method_server.py
+++ b/uatest/method_server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from opcua import ua, Server
+
+def even(parent, variant):
+    print("even method call with parameters: ", variant.Value)
+    ret = (variant.Value % 2 == 0)
+    print("even", type(ret))
+    return [ua.Variant(ret, ua.VariantType.Boolean)]
+
+def square(parent, variant):
+    print("square method call with parameters: ", variant.Value)
+    variant.Value *= variant.Value
+    return [variant]
+
+if __name__ == "__main__":
+    server = Server()
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/")
+
+    ns = server.register_namespace("http://gopcua.com/")
+    main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
+    fnEven = main.add_method(ua.NodeId("even", ns), "even", even, [ua.VariantType.Int64], [ua.VariantType.Boolean])
+    fnSquare = main.add_method(ua.NodeId("square", ns), "square", square, [ua.VariantType.Int64], [ua.VariantType.Int64])
+
+    server.start()

--- a/uatest/method_test.go
+++ b/uatest/method_test.go
@@ -1,0 +1,54 @@
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func TestCallMethod(t *testing.T) {
+	tests := []struct {
+		req *ua.CallMethodRequest
+		out []*ua.Variant
+	}{
+		{
+			req: &ua.CallMethodRequest{
+				ObjectID: ua.NewStringNodeID(2, "main"),
+				MethodID: ua.NewStringNodeID(2, "even"),
+				InputArguments: []*ua.Variant{
+					ua.MustVariant(int64(12)),
+				},
+			},
+			out: []*ua.Variant{ua.MustVariant(true)},
+		},
+	}
+
+	srv := NewServer("method_server.py")
+	defer srv.Close()
+
+	c := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.req.ObjectID.String(), func(t *testing.T) {
+			resp, err := c.Call(tt.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := resp.StatusCode, ua.StatusOK; got != want {
+				t.Fatalf("got status %v want %v", got, want)
+			}
+			if got, want := resp.OutputArguments, tt.out; !verify.Values(t, "", got, want) {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/uatest/rw_server.py
+++ b/uatest/rw_server.py
@@ -1,18 +1,12 @@
 #!/usr/bin/env python3
 
-import logging
 from opcua import ua, Server
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.WARN)
-
     server = Server()
-    server.set_endpoint("opc.tcp://0.0.0.0:4840/gopcua/server/")
-    server.set_server_name("OPC/UA server Read/Write tests")
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/")
 
-    uri = "http://gopcua.com/"
-    ns = server.register_namespace(uri)
-
+    ns = server.register_namespace("http://gopcua.com/")
     main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
     roBool = main.add_variable(ua.NodeId("ro_bool", ns), "ro_bool", True, ua.VariantType.Boolean)
     rwBool = main.add_variable(ua.NodeId("rw_bool", ns), "rw_bool", True, ua.VariantType.Boolean)

--- a/uatest/server.go
+++ b/uatest/server.go
@@ -3,7 +3,6 @@
 package uatest
 
 import (
-	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -64,12 +64,12 @@ func (s *Server) Run() error {
 		c.Close()
 		return nil
 	}
-	return fmt.Errorf("timeout")
+	return errors.Errorf("timeout")
 }
 
 func (s *Server) Close() error {
 	if s.cmd == nil {
-		return fmt.Errorf("not running")
+		return errors.Errorf("not running")
 	}
 	go func() { s.cmd.Process.Kill() }()
 	return s.cmd.Wait()


### PR DESCRIPTION
Add new `opcua/errors` package with wrappers for `fmt.Errorf` and `errors.New`.

Fixes: https://github.com/gopcua/opcua/issues/253