### PR TITLE
Handle implied ns=0

### DIFF
--- a/ua/node_id.go
+++ b/ua/node_id.go
@@ -92,11 +92,17 @@ func ParseNodeID(s string) (*NodeID, error) {
 		return NewTwoByteNodeID(0), nil
 	}
 
+	var nsval, idval string
+
 	p := strings.SplitN(s, ";", 2)
-	if len(p) < 2 {
+	switch len(p) {
+	case 1:
+		nsval, idval = "ns=0", p[0]
+	case 2:
+		nsval, idval = p[0], p[1]
+	default:
 		return nil, fmt.Errorf("invalid node id: %s", s)
 	}
-	nsval, idval := p[0], p[1]
 
 	// parse namespace
 	var ns uint16
@@ -152,6 +158,9 @@ func ParseNodeID(s string) (*NodeID, error) {
 			return nil, fmt.Errorf("invalid opaque node id: %s", s)
 		}
 		return NewByteStringNodeID(ns, b), nil
+
+	case strings.HasPrefix(idval, "ns="):
+		return nil, fmt.Errorf("invalid node id: %s", s)
 
 	default:
 		return NewStringNodeID(ns, idval), nil

--- a/ua/node_id_test.go
+++ b/ua/node_id_test.go
@@ -121,6 +121,8 @@ func TestParseNodeID(t *testing.T) {
 		// happy flows
 		{s: "", n: NewTwoByteNodeID(0)},
 		{s: "ns=0;i=1", n: NewTwoByteNodeID(1)},
+		{s: "i=1", n: NewTwoByteNodeID(1)},
+		{s: "i=2253", n: NewFourByteNodeID(0, 2253)},
 		{s: "ns=1;i=2", n: NewFourByteNodeID(1, 2)},
 		{s: "ns=256;i=2", n: NewNumericNodeID(256, 2)},
 		{s: "ns=1;i=65536", n: NewNumericNodeID(1, 65536)},
@@ -131,7 +133,7 @@ func TestParseNodeID(t *testing.T) {
 		{s: "ns=1;a", n: NewStringNodeID(1, "a")},
 
 		// error flows
-		{s: "i=1", err: errors.New("invalid node id: i=1")},
+		{s: "ns=0", err: errors.New("invalid node id: ns=0")},
 		{s: "nsu=abc;i=1", err: errors.New("namespace urls are not supported: nsu=abc;i=1")},
 		{s: "ns=65536;i=1", err: errors.New("namespace id out of range (0..65535): ns=65536;i=1")},
 		{s: "ns=abc;i=1", err: errors.New("invalid namespace id: ns=abc;i=1")},


### PR DESCRIPTION
Fixes #285 

Note: `ParseNodeID` is still quite brittle. Things like whitespace and ordering will cause it to not parse. 