### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: gopuca
+on: [push]
+jobs:
+  test:
+    name: Test ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        go: ["1.13.x"]
+
+    steps:
+      - name: Setup Go ${{ matrix.go }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
+
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+          architecture: "x64"
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go mod download
+          make install-py-opcua
+
+      - name: Run Tests
+        run: make test integration

--- a/uatest/server.go
+++ b/uatest/server.go
@@ -46,7 +46,18 @@ func (s *Server) Run() error {
 		return err
 	}
 	path := filepath.Join(wd, s.Path)
-	s.cmd = exec.Command("python3", path)
+
+	py, err := exec.LookPath("python3")
+	if err != nil {
+		// fallback to python and hope it still points to a python3 version.
+		// the Windows python3 installer doesn't seem to create a `python3.exe`
+		py, err = exec.LookPath("python")
+		if err != nil {
+			return errors.Errorf("unable to find Python executable")
+		}
+	}
+
+	s.cmd = exec.Command(py, path)
 	s.Endpoint = "opc.tcp://127.0.0.1:4840"
 	s.Opts = []opcua.Option{opcua.SecurityMode(ua.MessageSecurityModeNone)}
 	if err := s.cmd.Start(); err != nil {
@@ -54,7 +65,7 @@ func (s *Server) Run() error {
 	}
 
 	// wait until endpoint is available
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		c, err := net.Dial("tcp", "127.0.0.1:4840")
 		if err != nil {


### PR DESCRIPTION
Fixes #292

Adds an initial GitHub action that will run `make test integration` on Windows and Ubuntu.

Repo will need to be configured to use this.

See example runs here: https://github.com/Intelecy/opcua/commit/08ce7e27a33cbf233fe8402dc27ddaa9a6ac928b/checks

Note: Windows will fail until #290 is merged.