### PR TITLE
Feature/reconnect recreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The current set of supported services is only for the high-level client.
 |                             | ModifySubscription            |           |              |
 |                             | SetPublishingMode             |           |              |
 |                             | Publish                       | Yes       |              |
-|                             | Republish                     |           |              |
+|                             | Republish                     | Yes       |              |
 |                             | DeleteSubscriptions           | Yes       |              |
 |                             | TransferSubscriptions         |           |              |
 

--- a/client.go
+++ b/client.go
@@ -417,10 +417,10 @@ func (c *Client) repairSession() error {
 func (c *Client) SubscriptionIDs() []uint32 {
 	subscriptionIDs := []uint32{}
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	for key := range c.subscriptions {
 		subscriptionIDs = append(subscriptionIDs, key)
 	}
-	c.subMux.Unlock()
 	return subscriptionIDs
 }
 
@@ -877,22 +877,21 @@ func (c *Client) Subscribe(params *SubscriptionParameters) (*Subscription, error
 		c,
 	}
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	if sub.SubscriptionID == 0 || c.subscriptions[sub.SubscriptionID] != nil {
 		// this should not happen and is usually indicative of a server bug
 		// see: Part 4 Section 5.13.2.2, Table 88 – CreateSubscription Service Parameters
-		c.subMux.Unlock()
 		return nil, ua.StatusBadSubscriptionIDInvalid
 	}
 	c.subscriptions[sub.SubscriptionID] = sub
-	c.subMux.Unlock()
 
 	return sub, nil
 }
 
 func (c *Client) forgetSubscription(subID uint32) {
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	delete(c.subscriptions, subID)
-	c.subMux.Unlock()
 }
 
 func (c *Client) notifySubscriptionsOfError(ctx context.Context, res *ua.PublishResponse, err error) {

--- a/client.go
+++ b/client.go
@@ -160,10 +160,7 @@ func (c *Client) Connect(ctx context.Context) (err error) {
 }
 
 func (c *Client) sessionIsClosed() bool {
-	if c.Session() != nil {
-		return false
-	}
-	return true
+	return c.Session() != nil
 }
 
 // Dial establishes a secure channel.
@@ -305,7 +302,7 @@ func (c *Client) monitorChannel(ctx context.Context) {
 										// todo: recreate server certificate
 										// state = reconnectStateSechanDisconnected
 
-										errors.Errorf("Recreating server certificate is not implemented yet, reconnection aborted")
+										debug.Printf("Recreating server certificate is not implemented yet, reconnection aborted")
 										state.Store(reconnectStateAborted)
 
 									case reconnectStateReconnected:

--- a/client.go
+++ b/client.go
@@ -243,9 +243,12 @@ func (c *Client) monitorChannel(ctx context.Context) {
 						case sechanRecreated:
 							// Restart sechan Receive
 							exit = true
-						case sechanDisconnected, waitnRetry, badCertificate, sechanReconnected:
-							// Loop until sechanRecreated or aborted
 						}
+						// Loop for the following state
+						// sechanDisconnected
+						// sechanReconnected
+						// badCertificate
+						// waitnRetry
 					}
 
 					// Ignore all errors and restart receiving

--- a/client.go
+++ b/client.go
@@ -390,7 +390,7 @@ func (c *Client) recreateSecureChannel(ctx context.Context) (*uasc.SecureChannel
 	return sechan, conn, nil
 }
 
-// repairSession repair the current session after being disconnected
+// repairSession repair or recreate the current session after being disconnected
 func (c *Client) repairSession() error {
 
 	s := c.Session()
@@ -401,16 +401,92 @@ func (c *Client) repairSession() error {
 
 	debug.Printf("Trying to reactivate existing session")
 
-	err := c.ActivateSession(s)
-	if err != nil {
-		return errors.Errorf("Session reactivation failed")
+	if err := c.ActivateSession(s); err == nil {
+
+		debug.Printf("Existing session reactivated trying to repair subscriptions")
+		if err := c.repairSubscriptions(); err != nil {
+			_ = c.Close()
+			return err
+		}
+		debug.Printf("Subscriptions repaired")
+		return nil
 	}
-	debug.Printf("Existing session reactivated trying to repair subscriptions")
-	if err := c.repairSubscriptions(); err != nil {
+
+	debug.Printf("Session reactivation failed, recreating new session")
+	if err := c.repairSessionByRecreatingNewSession(); err != nil {
+		return errors.Errorf("Session reactivation failed :", err.Error())
+	}
+
+	if err := c.ActivateSession(s); err != nil {
+		_ = c.Close()
 		return err
 	}
-	debug.Printf("Subscriptions repaired")
+
+	debug.Printf("Trying to transfert existing subscriptions")
+	subIDs := c.SubscriptionIDs()
+	debug.Printf("Session subscriptionCount = %d", len(subIDs))
+
+	res, err := c.transferSubscriptions(subIDs)
+	subsToRecreate := []uint32{}
+	subsToRepair := []uint32{}
+
+	if err != nil {
+		debug.Printf("Transfert subscriptions has failed, %s", err.Error())
+		subsToRecreate = subIDs
+	} else {
+		for id := range res.Results {
+			transferResult := res.Results[id]
+			if transferResult.StatusCode == ua.StatusBadSubscriptionIDInvalid {
+				debug.Printf("Warning suscription (id: %d), should be recreated", id)
+				subsToRecreate = append(subsToRecreate, subIDs[id])
+			} else {
+				debug.Printf(
+					"Subscription (id: %d) can be repaired and available",
+					transferResult.AvailableSequenceNumbers[id],
+				)
+				subsToRepair = append(subsToRepair, subIDs[id])
+			}
+		}
+	}
+
+	if len(subsToRecreate) > 0 {
+		if err := c.repairSubscriptionsByRecreatingNewSubscriptions(subIDs); err != nil {
+			return err
+		}
+	}
+	if len(subsToRepair) > 0 {
+		if err := c.repairSubscriptions(subsToRepair...); err != nil {
+			return err
+		}
+	}
+
+	debug.Printf("Transfer subscriptions done")
 	return nil
+}
+
+// repairSessionByRecreatingNewSession create a new session
+// with the same parameters to replace the previous one
+func (c *Client) repairSessionByRecreatingNewSession() error {
+	// todo: Implement
+	return nil
+}
+
+// transferSubscriptions ask the server to transfert given subscriptions
+// of the previous session to the current
+func (c *Client) transferSubscriptions(subIDs []uint32) (*ua.TransferSubscriptionsResponse, error) {
+	req := &ua.TransferSubscriptionsRequest{
+		SubscriptionIDs:   subIDs,
+		SendInitialValues: false,
+	}
+	var res *ua.TransferSubscriptionsResponse
+
+	err := c.Send(req, func(v interface{}) error {
+		if err := safeAssign(v, &res); err != nil {
+			return err
+		}
+		return nil
+	})
+	return res, err
 }
 
 // SubscriptionIDs gets a list of subscriptionIDs
@@ -445,6 +521,13 @@ func (c *Client) repairSubscriptions(subscriptionIDs ...uint32) error {
 		}
 	}
 
+	return nil
+}
+
+// repairSubscriptionsByRecreatingNewSubscriptions create a new subscription
+// with the same parameters to replace the previous one
+func (c *Client) repairSubscriptionsByRecreatingNewSubscriptions(subIDs []uint32) error {
+	// todo: implement
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ func DefaultClientConfig() *uasc.Config {
 		SecurityMode:      ua.MessageSecurityModeNone,
 		Lifetime:          uint32(time.Hour / time.Millisecond),
 		RequestTimeout:    10 * time.Second,
+		AutoReconnect:     true,
 	}
 }
 
@@ -72,6 +73,12 @@ func ApplicationName(s string) Option {
 func ApplicationURI(s string) Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		sc.ClientDescription.ApplicationURI = s
+	}
+}
+
+func AutoReconnect(b bool) Option {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		c.AutoReconnect = b
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -76,6 +76,7 @@ func ApplicationURI(s string) Option {
 	}
 }
 
+// AutoReconnect sets the auto reconnect state of the secure channel.
 func AutoReconnect(b bool) Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.AutoReconnect = b

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -31,7 +31,7 @@ func main() {
 
 	// add an arbitrary timeout to demonstrate how to stop a subscription
 	// with a context.
-	d := 30 * time.Second
+	d := 3000 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), d)
 	defer cancel()
 
@@ -47,6 +47,7 @@ func main() {
 	fmt.Println("*", ep.SecurityPolicyURI, ep.SecurityMode)
 
 	opts := []opcua.Option{
+		opcua.Lifetime(time.Second * 60),
 		opcua.SecurityPolicy(*policy),
 		opcua.SecurityModeString(*mode),
 		opcua.CertificateFile(*certFile),

--- a/subscription.go
+++ b/subscription.go
@@ -127,8 +127,7 @@ func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredI
 	}
 
 	// store Monitored items
-	size := len(items)
-	monitoredItems := make([]*MonitoredItem, size, size)
+	monitoredItems := make([]*MonitoredItem, len(items))
 	for i, item := range items {
 		result := res.Results[i]
 

--- a/subscription.go
+++ b/subscription.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
@@ -18,6 +19,10 @@ const (
 	DefaultSubscriptionPriority                   = 0
 )
 
+const (
+	terminatedSubscriptionID uint32 = 0xC0CAC01B
+)
+
 type Subscription struct {
 	SubscriptionID            uint32
 	RevisedPublishingInterval time.Duration
@@ -25,6 +30,8 @@ type Subscription struct {
 	RevisedMaxKeepAliveCount  uint32
 	Notifs                    chan *PublishNotificationData
 	lastSequenceNumber        uint32
+	monitoredItems            []*MonitoredItem
+	params                    *SubscriptionParameters
 	running                   chan bool
 	c                         *Client
 }
@@ -36,6 +43,15 @@ type SubscriptionParameters struct {
 	MaxNotificationsPerPublish uint32
 	Priority                   uint8
 	Notifs                     chan *PublishNotificationData
+}
+
+type MonitoredItem struct {
+	MonitoredItemID           uint32
+	ItemToMonitor             *ua.ReadValueID
+	MonitoringParameters      *ua.MonitoringParameters
+	MonitoringMode            ua.MonitoringMode
+	TimestampsToReturn        ua.TimestampsToReturn
+	monitoredItemCreateResult *ua.MonitoredItemCreateResult
 }
 
 func NewMonitoredItemCreateRequestWithDefaults(nodeID *ua.NodeID, attributeID ua.AttributeID, clientHandle uint32) *ua.MonitoredItemCreateRequest {
@@ -99,6 +115,34 @@ func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredI
 	err := s.c.Send(req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, result := range res.Results {
+		if status := result.StatusCode; status != ua.StatusOK {
+			return nil, status
+		}
+	}
+
+	// store Monitored items
+	size := len(items)
+	monitoredItems := make([]*MonitoredItem, size, size)
+	for i, item := range items {
+		result := res.Results[i]
+
+		monitoredItems[i] = &MonitoredItem{
+			MonitoredItemID:           result.MonitoredItemID,
+			ItemToMonitor:             item.ItemToMonitor,
+			MonitoringParameters:      item.RequestedParameters,
+			MonitoringMode:            item.MonitoringMode,
+			TimestampsToReturn:        ts,
+			monitoredItemCreateResult: result,
+		}
+	}
+
+	s.monitoredItems = append(s.monitoredItems, monitoredItems...)
 	return res, err
 }
 
@@ -202,6 +246,17 @@ func (s *Subscription) Run(ctx context.Context) {
 			case err == ua.StatusBadNoSubscription:
 				// All subscriptions have been deleted, but the publishing loop is still running
 				// The user will stop the loop or create subscriptions at his discretion
+			case err == ua.StatusBadSessionClosed || err == ua.StatusBadSessionIDInvalid:
+				// The session is no longer opened on the server side
+
+				if s.c.cfg.AutoReconnect {
+					if err := s.c.repairSession(); err != nil {
+						return
+					}
+					acks = make([]*ua.SubscriptionAcknowledgement, 0)
+					continue
+				}
+
 			case err != nil:
 				// irrecoverable error
 				s.c.notifySubscriptionsOfError(ctx, res, err)
@@ -287,4 +342,94 @@ func (p *SubscriptionParameters) setDefaults() {
 	if p.Notifs == nil {
 		p.Notifs = make(chan *PublishNotificationData)
 	}
+}
+
+// recreateSubscriptionAndMonitoredItem recreate a new subscription base of a previous subscription
+// parameters
+func (s *Subscription) recreateSubscriptionAndMonitoredItem() error {
+	if s.SubscriptionID == terminatedSubscriptionID {
+		debug.Printf("Subscription is not in a valid state")
+		return nil
+	}
+
+	params := s.params
+	s.c.forgetSubscription(s.SubscriptionID)
+
+	subReq := &ua.CreateSubscriptionRequest{
+		RequestedPublishingInterval: float64(params.Interval / time.Millisecond),
+		RequestedLifetimeCount:      params.LifetimeCount,
+		RequestedMaxKeepAliveCount:  params.MaxKeepAliveCount,
+		PublishingEnabled:           true,
+		MaxNotificationsPerPublish:  params.MaxNotificationsPerPublish,
+		Priority:                    params.Priority,
+	}
+
+	var subRes *ua.CreateSubscriptionResponse
+	err := s.c.Send(subReq, func(v interface{}) error {
+		return safeAssign(v, &subRes)
+	})
+	if err != nil {
+		return err
+	}
+	if status := subRes.ResponseHeader.ServiceResult; status != ua.StatusOK {
+		return status
+	}
+
+	s.SubscriptionID = subRes.SubscriptionID
+	s.RevisedPublishingInterval = time.Duration(subRes.RevisedPublishingInterval) * time.Millisecond
+	s.RevisedLifetimeCount = subRes.RevisedLifetimeCount
+	s.RevisedMaxKeepAliveCount = subRes.RevisedMaxKeepAliveCount
+	s.lastSequenceNumber = 0
+
+	if err := s.c.registerSubscription(s); err != nil {
+		return err
+	}
+
+	// Sort by timestamp to return
+	itemsByTs := make(map[ua.TimestampsToReturn][]*ua.MonitoredItemCreateRequest)
+	for _, m := range s.monitoredItems {
+
+		if _, ok := itemsByTs[m.TimestampsToReturn]; !ok {
+			itemsByTs[m.TimestampsToReturn] = []*ua.MonitoredItemCreateRequest{}
+		}
+
+		itemsByTs[m.TimestampsToReturn] = append(
+			itemsByTs[m.TimestampsToReturn],
+			&ua.MonitoredItemCreateRequest{
+				ItemToMonitor:       m.ItemToMonitor,
+				MonitoringMode:      m.MonitoringMode,
+				RequestedParameters: m.MonitoringParameters,
+			},
+		)
+	}
+
+	for ts, items := range itemsByTs {
+
+		monReq := &ua.CreateMonitoredItemsRequest{
+			SubscriptionID:     s.SubscriptionID,
+			TimestampsToReturn: ts,
+			ItemsToCreate:      items,
+		}
+
+		var monRes *ua.CreateMonitoredItemsResponse
+		err = s.c.Send(monReq, func(v interface{}) error {
+			return safeAssign(v, &monRes)
+		})
+		if err != nil {
+			return err
+		}
+		for _, result := range monRes.Results {
+			if status := result.StatusCode; status != ua.StatusOK {
+				return status
+			}
+		}
+
+		for i, m := range s.monitoredItems {
+			result := monRes.Results[i]
+			m.MonitoredItemID = result.MonitoredItemID
+			m.monitoredItemCreateResult = result
+		}
+	}
+
+	return nil
 }

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -74,6 +74,13 @@ type Config struct {
 	// transport layer error.
 	SecurityTokenID uint32
 
+	// Autoreconnect will make sure that once communication is restored,
+	// the old session is used whenever possible and that Susbcription data is not missed.
+	// You may choose to use AutoReconnect (true by default) or do it manually.
+	// AutoReconnect will make the UaClient to try to reconnect to the server every second,
+	// once the communication is broken. If you do it manually, you must be prepared to do it until it succeeds.
+	AutoReconnect bool
+
 	// Lifetime is the requested lifetime, in milliseconds, for the new SecurityToken when the
 	// SecureChannel works as client. It specifies when the Client expects to renew the SecureChannel
 	// by calling the OpenSecureChannel Service again. If a SecureChannel is not renewed, then all

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -89,10 +89,13 @@ func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChanne
 		cfg.SecurityMode = ua.MessageSecurityModeNone
 	}
 
+	// make a copy of the config to avoid altering the geniune one
+	newCfg := *cfg
+
 	return &SecureChannel{
 		EndpointURL: endpoint,
 		c:           c,
-		cfg:         cfg,
+		cfg:         &newCfg,
 		reqhdr: &ua.RequestHeader{
 			TimeoutHint:      uint32(cfg.RequestTimeout / time.Millisecond),
 			AdditionalHeader: ua.NewExtensionObject(nil),


### PR DESCRIPTION
Hello,

In addition to the previous PL #299, this one add the possibilty to dynamically recreate the session and/or the subscription.
![reconnection_patern_recreate](https://user-images.githubusercontent.com/25567035/68862480-c926cb00-06ed-11ea-8941-4f7d5788138c.png)
I plan to implement two additional PR:
 - Keep alive _(send a heartbeat if no value come from subscriptions)_
 - Publish Pool _(multiple pending publish request to allow the server to respond in burst mode)_
