### PR TITLE
Add support for registered reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The current set of supported services is only for the high-level client.
 | View Service Set            | Browse                        | Started   |              |
 |                             | BrowseNext                    | Started   |              |
 |                             | TranslateBrowsePathsToNodeIds |           |              |
-|                             | RegisterNodes                 |           |              |
-|                             | UnregisterNodes               |           |              |
+|                             | RegisterNodes                 | Yes       |              |
+|                             | UnregisterNodes               | Yes       |              |
 | Query Service Set           | QueryFirst                    |           |              |
 |                             | QueryNext                     |           |              |
 | Attribute Service Set       | Read                          | Yes       |              |

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ The current set of supported services is only for the high-level client.
 |                             | AddReferences                 |           |              |
 |                             | DeleteNodes                   |           |              |
 |                             | DeleteReferences              |           |              |
-| View Service Set            | Browse                        | Started   |              |
-|                             | BrowseNext                    | Started   |              |
+| View Service Set            | Browse                        | Yes       |              |
+|                             | BrowseNext                    | Yes       |              |
 |                             | TranslateBrowsePathsToNodeIds |           |              |
 |                             | RegisterNodes                 | Yes       |              |
 |                             | UnregisterNodes               | Yes       |              |

--- a/client.go
+++ b/client.go
@@ -548,12 +548,7 @@ func (c *Client) Call(req *ua.CallMethodRequest) (*ua.CallMethodResult, error) {
 func (c *Client) BrowseNext(req *ua.BrowseNextRequest) (*ua.BrowseNextResponse, error) {
 	var res *ua.BrowseNextResponse
 	err := c.Send(req, func(v interface{}) error {
-		r, ok := v.(*ua.BrowseNextResponse)
-		if !ok {
-			return errors.Errorf("invalid response: %T", v)
-		}
-		res = r
-		return nil
+		return safeAssign(v, &res)
 	})
 	return res, err
 }

--- a/client.go
+++ b/client.go
@@ -558,6 +558,36 @@ func (c *Client) BrowseNext(req *ua.BrowseNextRequest) (*ua.BrowseNextResponse, 
 	return res, err
 }
 
+// RegisterNodes registers node ids for more efficient reads.
+// Part 4, Section 5.8.5
+func (c *Client) RegisterNodes(req *ua.RegisterNodesRequest) (*ua.RegisterNodesResponse, error) {
+	var res *ua.RegisterNodesResponse
+	err := c.Send(req, func(v interface{}) error {
+		r, ok := v.(*ua.RegisterNodesResponse)
+		if !ok {
+			return errors.Errorf("invalid response: %T", v)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}
+
+// UnregisterNodes unregisters node ids previously registered with RegisterNodes.
+// Part 4, Section 5.8.5
+func (c *Client) UnregisterNodes(req *ua.UnregisterNodesRequest) (*ua.UnregisterNodesResponse, error) {
+	var res *ua.UnregisterNodesResponse
+	err := c.Send(req, func(v interface{}) error {
+		r, ok := v.(*ua.UnregisterNodesResponse)
+		if !ok {
+			return errors.Errorf("invalid response: %T", v)
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}
+
 // Subscribe creates a Subscription with given parameters. Parameters that have not been set
 // (have zero values) are overwritten with default values.
 // See opcua.DefaultSubscription* constants

--- a/client.go
+++ b/client.go
@@ -563,27 +563,17 @@ func (c *Client) BrowseNext(req *ua.BrowseNextRequest) (*ua.BrowseNextResponse, 
 func (c *Client) RegisterNodes(req *ua.RegisterNodesRequest) (*ua.RegisterNodesResponse, error) {
 	var res *ua.RegisterNodesResponse
 	err := c.Send(req, func(v interface{}) error {
-		r, ok := v.(*ua.RegisterNodesResponse)
-		if !ok {
-			return errors.Errorf("invalid response: %T", v)
-		}
-		res = r
-		return nil
+		return safeAssign(v, &res)
 	})
 	return res, err
 }
 
 // UnregisterNodes unregisters node ids previously registered with RegisterNodes.
-// Part 4, Section 5.8.5
+// Part 4, Section 5.8.6
 func (c *Client) UnregisterNodes(req *ua.UnregisterNodesRequest) (*ua.UnregisterNodesResponse, error) {
 	var res *ua.UnregisterNodesResponse
 	err := c.Send(req, func(v interface{}) error {
-		r, ok := v.(*ua.UnregisterNodesResponse)
-		if !ok {
-			return errors.Errorf("invalid response: %T", v)
-		}
-		res = r
-		return nil
+		return safeAssign(v, &res)
 	})
 	return res, err
 }


### PR DESCRIPTION
Add `RegisterNodes` and `UnregisterNodes` to the client to register
node ids for more efficient read operations.

Part 4, Section 5.8.5, 5.8.6

Fixes #256