### PR TITLE
chore: move connection state from Config to SecureChannel

### DIFF
--- a/client.go
+++ b/client.go
@@ -718,7 +718,7 @@ func (c *Client) HistoryReadRawModified(nodes []*ua.HistoryReadValueID, details 
 }
 
 func (c *Client) scheduleRenewingToken(ctx context.Context) {
-	timer := time.NewTimer(time.Duration(0.75*float64(c.cfg.Lifetime)) * time.Millisecond) // 0.75 is from Part 4, Section 5.5.2.1
+	timer := time.NewTimer(time.Duration(0.75*float64(c.sechan.Lifetime())) * time.Millisecond) // 0.75 is from Part 4, Section 5.5.2.1
 
 	go func() {
 		select {

--- a/config.go
+++ b/config.go
@@ -99,7 +99,7 @@ func ProductURI(s string) Option {
 // RandomRequestID assigns a random initial request id.
 func RandomRequestID() Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.RequestID = uint32(rand.Int31())
+		c.RequestIDSeed = uint32(rand.Int31())
 	}
 }
 

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -13,15 +13,6 @@ import (
 
 // Config represents a configuration which UASC client/server has in common.
 type Config struct {
-	// SecureChannelID is a unique identifier for the SecureChannel assigned by the Server.
-	// If a Server receives a SecureChannelId which it does not recognize it shall return an
-	// appropriate transport layer error.
-	//
-	// When a Server starts the first SecureChannelId used should be a value that is likely to
-	// be unique after each restart. This ensures that a Server restart does not cause
-	// previously connected Clients to accidentally ‘reuse’ SecureChannels that did not belong
-	// to them.
-	SecureChannelID uint32
 
 	// SecurityPolicyURI is the URI of the Security Policy used to secure the Message.
 	// This field is encoded as a UTF-8 string without a null terminator.
@@ -54,25 +45,14 @@ type Config struct {
 	// Used to encrypt the message chunks in the OpenSecureChannel phase.
 	RemoteCertificate []byte
 
-	// SequenceNumber is a monotonically increasing sequence number assigned by the sender to each
-	// MessageChunk sent over the SecureChannel.
-	SequenceNumber uint32
-
-	// RequestID is an identifier assigned by the Client to OPC UA request Message. All MessageChunks
-	// for the request and the associated response use the same identifier
-	RequestID uint32
+	// RequestIDSeed is the initial value for RequestID counter in each new SecureChannel
+	RequestIDSeed uint32
 
 	// SecurityMode is The type of security to apply to the messages. The type MessageSecurityMode
 	// is defined in 7.15.
 	// A SecureChannel may have to be created even if the securityMode is NONE. The exact behaviour
 	// depends on the mapping used and is described in the Part 6.
 	SecurityMode ua.MessageSecurityMode
-
-	// SecurityTokenID is a unique identifier for the SecureChannel SecurityToken used to secure the Message.
-	// This identifier is returned by the Server in an OpenSecureChannel response Message.
-	// If a Server receives a TokenId which it does not recognize it shall return an appropriate
-	// transport layer error.
-	SecurityTokenID uint32
 
 	// Lifetime is the requested lifetime, in milliseconds, for the new SecurityToken when the
 	// SecureChannel works as client. It specifies when the Client expects to renew the SecureChannel

--- a/uasc/message_test.go
+++ b/uasc/message_test.go
@@ -18,14 +18,15 @@ func TestMessage(t *testing.T) {
 		{
 			Name: "OPN",
 			Struct: func() interface{} {
-				m := (&SecureChannel{
+				s := &SecureChannel{
 					cfg: &Config{
 						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
 					},
 					requestID:       1,
 					sequenceNumber:  1,
 					securityTokenID: 0,
-				}).newMessage(
+				}
+				m := s.newMessage(
 					&ua.OpenSecureChannelRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),
@@ -112,14 +113,15 @@ func TestMessage(t *testing.T) {
 		}, {
 			Name: "MSG",
 			Struct: func() interface{} {
-				m := (&SecureChannel{
+				s := &SecureChannel{
 					cfg: &Config{
 						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
 					},
 					requestID:       1,
 					sequenceNumber:  1,
 					securityTokenID: 0,
-				}).newMessage(
+				}
+				m := s.newMessage(
 					&ua.GetEndpointsRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),
@@ -179,14 +181,15 @@ func TestMessage(t *testing.T) {
 		}, {
 			Name: "CLO",
 			Struct: func() interface{} {
-				m := (&SecureChannel{
+				s := &SecureChannel{
 					cfg: &Config{
 						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
 					},
 					requestID:       1,
 					sequenceNumber:  1,
 					securityTokenID: 0,
-				}).newMessage(
+				}
+				m := s.newMessage(
 					&ua.CloseSecureChannelRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),

--- a/uasc/message_test.go
+++ b/uasc/message_test.go
@@ -18,7 +18,14 @@ func TestMessage(t *testing.T) {
 		{
 			Name: "OPN",
 			Struct: func() interface{} {
-				m := NewMessage(
+				m := (&SecureChannel{
+					cfg: &Config{
+						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
+					},
+					requestID:       1,
+					sequenceNumber:  1,
+					securityTokenID: 0,
+				}).newMessage(
 					&ua.OpenSecureChannelRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),
@@ -33,13 +40,6 @@ func TestMessage(t *testing.T) {
 						RequestedLifetime:     6000000,
 					},
 					id.OpenSecureChannelRequest_Encoding_DefaultBinary,
-					&Config{
-						SecureChannelID:   0,
-						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
-						RequestID:         1,
-						SequenceNumber:    1,
-						SecurityTokenID:   0,
-					},
 				)
 
 				// set message size manually, since it is computed in Encode
@@ -112,7 +112,14 @@ func TestMessage(t *testing.T) {
 		}, {
 			Name: "MSG",
 			Struct: func() interface{} {
-				m := NewMessage(
+				m := (&SecureChannel{
+					cfg: &Config{
+						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
+					},
+					requestID:       1,
+					sequenceNumber:  1,
+					securityTokenID: 0,
+				}).newMessage(
 					&ua.GetEndpointsRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),
@@ -124,13 +131,6 @@ func TestMessage(t *testing.T) {
 						EndpointURL: "opc.tcp://wow.its.easy:11111/UA/Server",
 					},
 					id.GetEndpointsRequest_Encoding_DefaultBinary,
-					&Config{
-						SecureChannelID:   0,
-						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
-						RequestID:         1,
-						SequenceNumber:    1,
-						SecurityTokenID:   0,
-					},
 				)
 
 				// set message size manually, since it is computed in Encode
@@ -179,7 +179,14 @@ func TestMessage(t *testing.T) {
 		}, {
 			Name: "CLO",
 			Struct: func() interface{} {
-				m := NewMessage(
+				m := (&SecureChannel{
+					cfg: &Config{
+						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
+					},
+					requestID:       1,
+					sequenceNumber:  1,
+					securityTokenID: 0,
+				}).newMessage(
 					&ua.CloseSecureChannelRequest{
 						RequestHeader: &ua.RequestHeader{
 							AuthenticationToken: ua.NewTwoByteNodeID(0),
@@ -190,13 +197,6 @@ func TestMessage(t *testing.T) {
 						},
 					},
 					id.CloseSecureChannelRequest_Encoding_DefaultBinary,
-					&Config{
-						SecureChannelID:   0,
-						SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
-						RequestID:         1,
-						SequenceNumber:    1,
-						SecurityTokenID:   0,
-					},
 				)
 
 				// set message size manually, since it is computed in Encode

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -71,7 +71,7 @@ type SecureChannel struct {
 	// may be calculated by adding the lifetime to the createdAt time.
 	lifetime uint32
 
-	// SecureChannelID is a unique identifier for the SecureChannel assigned by the Server.
+	// secureChannelID is a unique identifier for the SecureChannel assigned by the Server.
 	// If a Server receives a SecureChannelId which it does not recognize it shall return an
 	// appropriate transport layer error.
 	//
@@ -81,15 +81,15 @@ type SecureChannel struct {
 	// to them.
 	secureChannelID uint32
 
-	// SequenceNumber is a monotonically increasing sequence number assigned by the sender to each
+	// sequenceNumber is a monotonically increasing sequence number assigned by the sender to each
 	// MessageChunk sent over the SecureChannel.
 	sequenceNumber uint32
 
-	// RequestID is an identifier assigned by the Client to OPC UA request Message. All MessageChunks
+	// requestID is an identifier assigned by the Client to OPC UA request Message. All MessageChunks
 	// for the request and the associated response use the same identifier
 	requestID uint32
 
-	// SecurityTokenID is a unique identifier for the SecureChannel SecurityToken used to secure the Message.
+	// securityTokenID is a unique identifier for the SecureChannel SecurityToken used to secure the Message.
 	// This identifier is returned by the Server in an OpenSecureChannel response Message.
 	// If a Server receives a TokenId which it does not recognize it shall return an appropriate
 	// transport layer error.

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/errors"
+	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uacp"
 	"github.com/gopcua/opcua/uapolicy"
@@ -38,6 +39,16 @@ type Response struct {
 }
 
 type SecureChannel struct {
+	// SecureChannelID is a unique identifier for the SecureChannel assigned by the Server.
+	// If a Server receives a SecureChannelId which it does not recognize it shall return an
+	// appropriate transport layer error.
+	//
+	// When a Server starts the first SecureChannelId used should be a value that is likely to
+	// be unique after each restart. This ensures that a Server restart does not cause
+	// previously connected Clients to accidentally ‘reuse’ SecureChannels that did not belong
+	// to them.
+	secureChannelID uint32
+
 	EndpointURL string
 
 	// c is the uacp connection.
@@ -65,6 +76,24 @@ type SecureChannel struct {
 
 	// time returns the current time. When not set it defaults to time.Now().
 	time func() time.Time
+
+	// The lifetime of the SecurityToken in milliseconds. The UTC expiration time for the token
+	// may be calculated by adding the lifetime to the createdAt time.
+	lifetime uint32
+
+	// SequenceNumber is a monotonically increasing sequence number assigned by the sender to each
+	// MessageChunk sent over the SecureChannel.
+	sequenceNumber uint32
+
+	// RequestID is an identifier assigned by the Client to OPC UA request Message. All MessageChunks
+	// for the request and the associated response use the same identifier
+	requestID uint32
+
+	// SecurityTokenID is a unique identifier for the SecureChannel SecurityToken used to secure the Message.
+	// This identifier is returned by the Server in an OpenSecureChannel response Message.
+	// If a Server receives a TokenId which it does not recognize it shall return an appropriate
+	// transport layer error.
+	securityTokenID uint32
 }
 
 func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChannel, error) {
@@ -97,14 +126,19 @@ func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChanne
 			TimeoutHint:      uint32(cfg.RequestTimeout / time.Millisecond),
 			AdditionalHeader: ua.NewExtensionObject(nil),
 		},
-		state:   secureChannelCreated,
-		handler: make(map[uint32]chan Response),
-		chunks:  make(map[uint32][]*MessageChunk),
+		state:     secureChannelCreated,
+		handler:   make(map[uint32]chan Response),
+		chunks:    make(map[uint32][]*MessageChunk),
+		requestID: cfg.RequestIDSeed,
 	}, nil
 }
 
 func (s *SecureChannel) LocalEndpoint() string {
 	return s.EndpointURL
+}
+
+func (s *SecureChannel) Lifetime() uint32 {
+	return s.lifetime
 }
 
 func (s *SecureChannel) setState(n int32) {
@@ -196,6 +230,61 @@ func (s *SecureChannel) sendAsyncWithTimeout(req ua.Request, authToken *ua.NodeI
 	return resp, reqid, nil
 }
 
+// New creates a OPC UA Secure Conversation message.New
+// MessageType of UASC is determined depending on the type of service given as below.
+//
+// Service type: OpenSecureChannel => Message type: OPN.
+//
+// Service type: CloseSecureChannel => Message type: CLO.
+//
+// Service type: Others => Message type: MSG.
+//
+func (s *SecureChannel) newMessage(srv interface{}, typeID uint16) *Message {
+	switch typeID {
+	case id.OpenSecureChannelRequest_Encoding_DefaultBinary, id.OpenSecureChannelResponse_Encoding_DefaultBinary:
+		// Do not send the thumbprint for security mode None
+		// even if we have a certificate.
+		//
+		// See https://github.com/gopcua/opcua/issues/259
+		thumbprint := s.cfg.Thumbprint
+		if s.cfg.SecurityMode == ua.MessageSecurityModeNone {
+			thumbprint = nil
+		}
+
+		return &Message{
+			MessageHeader: &MessageHeader{
+				Header:                   NewHeader(MessageTypeOpenSecureChannel, ChunkTypeFinal, s.secureChannelID),
+				AsymmetricSecurityHeader: NewAsymmetricSecurityHeader(s.cfg.SecurityPolicyURI, s.cfg.Certificate, thumbprint),
+				SequenceHeader:           NewSequenceHeader(s.sequenceNumber, s.requestID),
+			},
+			TypeID:  ua.NewFourByteExpandedNodeID(0, typeID),
+			Service: srv,
+		}
+
+	case id.CloseSecureChannelRequest_Encoding_DefaultBinary, id.CloseSecureChannelResponse_Encoding_DefaultBinary:
+		return &Message{
+			MessageHeader: &MessageHeader{
+				Header:                  NewHeader(MessageTypeCloseSecureChannel, ChunkTypeFinal, s.secureChannelID),
+				SymmetricSecurityHeader: NewSymmetricSecurityHeader(s.securityTokenID),
+				SequenceHeader:          NewSequenceHeader(s.sequenceNumber, s.requestID),
+			},
+			TypeID:  ua.NewFourByteExpandedNodeID(0, typeID),
+			Service: srv,
+		}
+
+	default:
+		return &Message{
+			MessageHeader: &MessageHeader{
+				Header:                  NewHeader(MessageTypeMessage, ChunkTypeFinal, s.secureChannelID),
+				SymmetricSecurityHeader: NewSymmetricSecurityHeader(s.securityTokenID),
+				SequenceHeader:          NewSequenceHeader(s.sequenceNumber, s.requestID),
+			},
+			TypeID:  ua.NewFourByteExpandedNodeID(0, typeID),
+			Service: srv,
+		}
+	}
+}
+
 func (s *SecureChannel) newRequestMessage(req ua.Request, authToken *ua.NodeID, timeout time.Duration) (*Message, error) {
 	typeID := ua.ServiceTypeID(req)
 	if typeID == 0 {
@@ -205,13 +294,13 @@ func (s *SecureChannel) newRequestMessage(req ua.Request, authToken *ua.NodeID, 
 		authToken = ua.NewTwoByteNodeID(0)
 	}
 
-	s.cfg.SequenceNumber++
-	if s.cfg.SequenceNumber > math.MaxUint32-1023 {
-		s.cfg.SequenceNumber = 1
+	s.sequenceNumber++
+	if s.sequenceNumber > math.MaxUint32-1023 {
+		s.sequenceNumber = 1
 	}
-	s.cfg.RequestID++
-	if s.cfg.RequestID == 0 {
-		s.cfg.RequestID = 1
+	s.requestID++
+	if s.requestID == 0 {
+		s.requestID = 1
 	}
 	s.reqhdr.RequestHandle++
 	if s.reqhdr.RequestHandle == 0 {
@@ -226,7 +315,7 @@ func (s *SecureChannel) newRequestMessage(req ua.Request, authToken *ua.NodeID, 
 	req.SetHeader(s.reqhdr)
 
 	// encode the message
-	return NewMessage(req, typeID, s.cfg), nil
+	return s.newMessage(req, typeID), nil
 }
 
 // SendResponse sends a service response.
@@ -240,7 +329,7 @@ func (s *SecureChannel) SendResponse(req ua.Response) error {
 	}
 
 	// encode the message
-	m := NewMessage(req, typeID, s.cfg)
+	m := s.newMessage(req, typeID)
 	reqid := m.SequenceHeader.RequestID
 	b, err := m.Encode()
 	if err != nil {
@@ -311,7 +400,7 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 		}
 
 		s.cfg.SecurityPolicyURI = m.SecurityPolicyURI
-		s.cfg.RequestID = m.RequestID
+		s.requestID = m.RequestID
 
 		s.enc, err = uapolicy.Asymmetric(m.SecurityPolicyURI, s.cfg.LocalKey, remoteKey)
 		if err != nil {
@@ -344,9 +433,9 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 	}
 	m.Data = m.Data[n:]
 
-	if s.cfg.SecureChannelID == 0 {
-		s.cfg.SecureChannelID = h.SecureChannelID
-		debug.Printf("uasc %d/%d: set secure channel id to %d", s.c.ID(), m.SequenceHeader.RequestID, s.cfg.SecureChannelID)
+	if s.secureChannelID == 0 {
+		s.secureChannelID = h.SecureChannelID
+		debug.Printf("uasc %d/%d: set secure channel id to %d", s.c.ID(), m.SequenceHeader.RequestID, s.secureChannelID)
 	}
 
 	return m, nil
@@ -372,7 +461,7 @@ func (s *SecureChannel) Receive(ctx context.Context) Response {
 				s.notifyCallers(ctx, err)
 				return Response{
 					ReqID: reqid,
-					SCID:  s.cfg.SecureChannelID,
+					SCID:  s.secureChannelID,
 					V:     svc,
 					Err:   err,
 				}
@@ -385,7 +474,7 @@ func (s *SecureChannel) Receive(ctx context.Context) Response {
 
 			// Revert data race fix from #232 with an additional type check
 			if _, ok := svc.(ua.Request); ok {
-				s.cfg.RequestID = reqid
+				s.requestID = reqid
 			}
 
 			switch svc.(type) {
@@ -408,7 +497,7 @@ func (s *SecureChannel) Receive(ctx context.Context) Response {
 				debug.Printf("uasc %d/%d: no handler for %T, returning result to caller", s.c.ID(), reqid, svc)
 				return Response{
 					ReqID: reqid,
-					SCID:  s.cfg.SecureChannelID,
+					SCID:  s.secureChannelID,
 					V:     svc,
 					Err:   err,
 				}
@@ -419,7 +508,7 @@ func (s *SecureChannel) Receive(ctx context.Context) Response {
 				debug.Printf("sending %T to handler\n", svc)
 				r := Response{
 					ReqID: reqid,
-					SCID:  s.cfg.SecureChannelID,
+					SCID:  s.secureChannelID,
 					V:     svc,
 					Err:   err,
 				}
@@ -521,11 +610,11 @@ func (s *SecureChannel) receive(ctx context.Context) (uint32, interface{}, error
 func (s *SecureChannel) notifyCallers(ctx context.Context, err error) {
 	s.mu.Lock()
 	var reqids []uint32
-	for id := range s.handler {
-		reqids = append(reqids, id)
+	for rid := range s.handler {
+		reqids = append(reqids, rid)
 	}
-	for _, id := range reqids {
-		s.notifyCallerLock(ctx, id, nil, err)
+	for _, rid := range reqids {
+		s.notifyCallerLock(ctx, rid, nil, err)
 	}
 	s.mu.Unlock()
 }
@@ -550,7 +639,7 @@ func (s *SecureChannel) notifyCallerLock(ctx context.Context, reqid uint32, svc 
 	go func() {
 		r := Response{
 			ReqID: reqid,
-			SCID:  s.cfg.SecureChannelID,
+			SCID:  s.secureChannelID,
 			V:     svc,
 			Err:   err,
 		}
@@ -632,8 +721,8 @@ func (s *SecureChannel) openSecureChannel(requestType ua.SecurityTokenRequestTyp
 		if !ok {
 			return errors.Errorf("got %T, want OpenSecureChannelResponse", req)
 		}
-		s.cfg.SecurityTokenID = resp.SecurityToken.TokenID
-		s.cfg.Lifetime = resp.SecurityToken.RevisedLifetime
+		s.securityTokenID = resp.SecurityToken.TokenID
+		s.lifetime = resp.SecurityToken.RevisedLifetime
 		debug.Printf("received security token tokenID: %v, createdAt: %v, lifetime %v", resp.SecurityToken.TokenID, resp.SecurityToken.CreatedAt, resp.SecurityToken.RevisedLifetime)
 
 		s.enc, err = uapolicy.Symmetric(s.cfg.SecurityPolicyURI, nonce, resp.ServerNonce)
@@ -691,8 +780,8 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(svc interface{}) error {
 		},
 		ServerProtocolVersion: 0,
 		SecurityToken: &ua.ChannelSecurityToken{
-			ChannelID:       s.cfg.SecureChannelID,
-			TokenID:         s.cfg.SecurityTokenID,
+			ChannelID:       s.secureChannelID,
+			TokenID:         s.securityTokenID,
 			CreatedAt:       s.timeNow(),
 			RevisedLifetime: req.RequestedLifetime,
 		},

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -39,16 +39,6 @@ type Response struct {
 }
 
 type SecureChannel struct {
-	// SecureChannelID is a unique identifier for the SecureChannel assigned by the Server.
-	// If a Server receives a SecureChannelId which it does not recognize it shall return an
-	// appropriate transport layer error.
-	//
-	// When a Server starts the first SecureChannelId used should be a value that is likely to
-	// be unique after each restart. This ensures that a Server restart does not cause
-	// previously connected Clients to accidentally ‘reuse’ SecureChannels that did not belong
-	// to them.
-	secureChannelID uint32
-
 	EndpointURL string
 
 	// c is the uacp connection.
@@ -80,6 +70,16 @@ type SecureChannel struct {
 	// The lifetime of the SecurityToken in milliseconds. The UTC expiration time for the token
 	// may be calculated by adding the lifetime to the createdAt time.
 	lifetime uint32
+
+	// SecureChannelID is a unique identifier for the SecureChannel assigned by the Server.
+	// If a Server receives a SecureChannelId which it does not recognize it shall return an
+	// appropriate transport layer error.
+	//
+	// When a Server starts the first SecureChannelId used should be a value that is likely to
+	// be unique after each restart. This ensures that a Server restart does not cause
+	// previously connected Clients to accidentally ‘reuse’ SecureChannels that did not belong
+	// to them.
+	secureChannelID uint32
 
 	// SequenceNumber is a monotonically increasing sequence number assigned by the sender to each
 	// MessageChunk sent over the SecureChannel.

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -54,10 +54,9 @@ func TestNewRequestMessage(t *testing.T) {
 		{
 			name: "subsequent-request",
 			sechan: &SecureChannel{
-				cfg: &Config{
-					SequenceNumber: 777,
-					RequestID:      555,
-				},
+				cfg:            &Config{},
+				sequenceNumber: 777,
+				requestID:      555,
 				reqhdr: &ua.RequestHeader{
 					RequestHandle: 444,
 				},
@@ -89,10 +88,9 @@ func TestNewRequestMessage(t *testing.T) {
 		{
 			name: "counter-rollover",
 			sechan: &SecureChannel{
-				cfg: &Config{
-					SequenceNumber: math.MaxUint32 - 1023,
-					RequestID:      math.MaxUint32,
-				},
+				cfg:            &Config{},
+				sequenceNumber: math.MaxUint32 - 1023,
+				requestID:      math.MaxUint32,
 				reqhdr: &ua.RequestHeader{
 					RequestHandle: math.MaxUint32,
 				},


### PR DESCRIPTION
As [discussed](https://github.com/gopcua/opcua/pull/299#issuecomment-572923643), this moves connection state fields to unexported fields in `SecureChannel`