### PR TITLE
Feature/reconnect recreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The current set of supported services is only for the high-level client.
 |                             | ModifySubscription            |           |              |
 |                             | SetPublishingMode             |           |              |
 |                             | Publish                       | Yes       |              |
-|                             | Republish                     |           |              |
+|                             | Republish                     | Yes       |              |
 |                             | DeleteSubscriptions           | Yes       |              |
 |                             | TransferSubscriptions         |           |              |
 

--- a/client.go
+++ b/client.go
@@ -417,10 +417,10 @@ func (c *Client) repairSession() error {
 func (c *Client) SubscriptionIDs() []uint32 {
 	subscriptionIDs := []uint32{}
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	for key := range c.subscriptions {
 		subscriptionIDs = append(subscriptionIDs, key)
 	}
-	c.subMux.Unlock()
 	return subscriptionIDs
 }
 
@@ -877,22 +877,21 @@ func (c *Client) Subscribe(params *SubscriptionParameters) (*Subscription, error
 		c,
 	}
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	if sub.SubscriptionID == 0 || c.subscriptions[sub.SubscriptionID] != nil {
 		// this should not happen and is usually indicative of a server bug
 		// see: Part 4 Section 5.13.2.2, Table 88 – CreateSubscription Service Parameters
-		c.subMux.Unlock()
 		return nil, ua.StatusBadSubscriptionIDInvalid
 	}
 	c.subscriptions[sub.SubscriptionID] = sub
-	c.subMux.Unlock()
 
 	return sub, nil
 }
 
 func (c *Client) forgetSubscription(subID uint32) {
 	c.subMux.Lock()
+	defer c.subMux.Unlock()
 	delete(c.subscriptions, subID)
-	c.subMux.Unlock()
 }
 
 func (c *Client) notifySubscriptionsOfError(ctx context.Context, res *ua.PublishResponse, err error) {

--- a/client.go
+++ b/client.go
@@ -904,15 +904,16 @@ func (c *Client) Subscribe(params *SubscriptionParameters) (*Subscription, error
 	}
 
 	sub := &Subscription{
-		res.SubscriptionID,
-		time.Duration(res.RevisedPublishingInterval) * time.Millisecond,
-		res.RevisedLifetimeCount,
-		res.RevisedMaxKeepAliveCount,
-		params.Notifs,
-		0,
-		make(chan bool, 1),
-		c,
+		SubscriptionID:            res.SubscriptionID,
+		RevisedPublishingInterval: time.Duration(res.RevisedPublishingInterval) * time.Millisecond,
+		RevisedLifetimeCount:      res.RevisedLifetimeCount,
+		RevisedMaxKeepAliveCount:  res.RevisedMaxKeepAliveCount,
+		Notifs:                    params.Notifs,
+		lastSequenceNumber:        0,
+		c:                         c,
 	}
+	sub.cond = sync.NewCond(&sub.mux)
+
 	c.subMux.Lock()
 	defer c.subMux.Unlock()
 	if sub.SubscriptionID == 0 || c.subscriptions[sub.SubscriptionID] != nil {

--- a/client.go
+++ b/client.go
@@ -160,10 +160,7 @@ func (c *Client) Connect(ctx context.Context) (err error) {
 }
 
 func (c *Client) sessionIsClosed() bool {
-	if c.Session() != nil {
-		return false
-	}
-	return true
+	return c.Session() != nil
 }
 
 // Dial establishes a secure channel.
@@ -305,7 +302,7 @@ func (c *Client) monitorChannel(ctx context.Context) {
 										// todo: recreate server certificate
 										// state = reconnectStateSechanDisconnected
 
-										errors.Errorf("Recreating server certificate is not implemented yet, reconnection aborted")
+										debug.Printf("Recreating server certificate is not implemented yet, reconnection aborted")
 										state.Store(reconnectStateAborted)
 
 									case reconnectStateReconnected:

--- a/client.go
+++ b/client.go
@@ -243,9 +243,12 @@ func (c *Client) monitorChannel(ctx context.Context) {
 						case sechanRecreated:
 							// Restart sechan Receive
 							exit = true
-						case sechanDisconnected, waitnRetry, badCertificate, sechanReconnected:
-							// Loop until sechanRecreated or aborted
 						}
+						// Loop for the following state
+						// sechanDisconnected
+						// sechanReconnected
+						// badCertificate
+						// waitnRetry
 					}
 
 					// Ignore all errors and restart receiving

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ func DefaultClientConfig() *uasc.Config {
 		SecurityMode:      ua.MessageSecurityModeNone,
 		Lifetime:          uint32(time.Hour / time.Millisecond),
 		RequestTimeout:    10 * time.Second,
+		AutoReconnect:     true,
 	}
 }
 
@@ -72,6 +73,12 @@ func ApplicationName(s string) Option {
 func ApplicationURI(s string) Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		sc.ClientDescription.ApplicationURI = s
+	}
+}
+
+func AutoReconnect(b bool) Option {
+	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+		c.AutoReconnect = b
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -76,6 +76,7 @@ func ApplicationURI(s string) Option {
 	}
 }
 
+// AutoReconnect sets the auto reconnect state of the secure channel.
 func AutoReconnect(b bool) Option {
 	return func(c *uasc.Config, sc *uasc.SessionConfig) {
 		c.AutoReconnect = b

--- a/subscription.go
+++ b/subscription.go
@@ -114,35 +114,6 @@ func (s *Subscription) Unmonitor(monitoredItemIDs ...uint32) (*ua.DeleteMonitore
 	return res, err
 }
 
-func (s *Subscription) republish(req *ua.RepublishRequest) (*ua.RepublishResponse, error) {
-	var res *ua.RepublishResponse
-	err := s.c.sechan.SendRequest(req, s.c.Session().resp.AuthenticationToken, func(v interface{}) error {
-		if err := safeAssign(v, &res); err != nil {
-			return err
-		}
-		if res.ResponseHeader.ServiceResult != ua.StatusOK {
-			return errors.Errorf(res.ResponseHeader.ServiceResult.Error())
-		}
-		return nil
-	})
-	return res, err
-}
-
-func (s *Subscription) publish(acks []*ua.SubscriptionAcknowledgement) (*ua.PublishResponse, error) {
-	if acks == nil {
-		acks = []*ua.SubscriptionAcknowledgement{}
-	}
-	req := &ua.PublishRequest{
-		SubscriptionAcknowledgements: acks,
-	}
-
-	var res *ua.PublishResponse
-	err := s.c.sendWithTimeout(req, s.publishTimeout(), func(v interface{}) error {
-		return safeAssign(v, &res)
-	})
-	return res, err
-}
-
 func (s *Subscription) publishTimeout() time.Duration {
 	timeout := time.Duration(s.RevisedMaxKeepAliveCount) * s.RevisedPublishingInterval // expected keepalive interval
 	if timeout > uasc.MaxTimeout {
@@ -192,7 +163,7 @@ func (s *Subscription) Run(ctx context.Context) {
 		default:
 			// send the next publish request
 			// note that res contains data even if an error was returned
-			res, err := s.publish(acks)
+			res, err := s.c.PublishWithTimeout(acks, s.publishTimeout())
 			switch {
 			case err == ua.StatusBadSequenceNumberUnknown:
 				// At least one ack has been submitted repeatedly

--- a/subscription.go
+++ b/subscription.go
@@ -130,23 +130,23 @@ func (s *Subscription) publishTimeout() time.Duration {
 
 // Resume the subscription after being suspended
 func (s *Subscription) Resume() {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	if !s.suspend {
 		return
 	}
-	s.mux.Lock()
-	defer s.mux.Unlock()
 	s.suspend = false
 	s.cond.Broadcast()
 }
 
 // Suspend make the subscription wait until Resume
 func (s *Subscription) Suspend() {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	if s.suspend {
 		return
 	}
-	s.mux.Lock()
 	s.suspend = true
-	defer s.mux.Unlock()
 	s.cond.Broadcast()
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -125,8 +125,7 @@ func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredI
 	}
 
 	// store Monitored items
-	size := len(items)
-	monitoredItems := make([]*MonitoredItem, size, size)
+	monitoredItems := make([]*MonitoredItem, len(items))
 	for i, item := range items {
 		result := res.Results[i]
 

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -74,6 +74,13 @@ type Config struct {
 	// transport layer error.
 	SecurityTokenID uint32
 
+	// Autoreconnect will make sure that once communication is restored,
+	// the old session is used whenever possible and that Susbcription data is not missed.
+	// You may choose to use AutoReconnect (true by default) or do it manually.
+	// AutoReconnect will make the UaClient to try to reconnect to the server every second,
+	// once the communication is broken. If you do it manually, you must be prepared to do it until it succeeds.
+	AutoReconnect bool
+
 	// Lifetime is the requested lifetime, in milliseconds, for the new SecurityToken when the
 	// SecureChannel works as client. It specifies when the Client expects to renew the SecureChannel
 	// by calling the OpenSecureChannel Service again. If a SecureChannel is not renewed, then all

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -89,10 +89,13 @@ func NewSecureChannel(endpoint string, c *uacp.Conn, cfg *Config) (*SecureChanne
 		cfg.SecurityMode = ua.MessageSecurityModeNone
 	}
 
+	// make a copy of the config to avoid altering the geniune one
+	newCfg := *cfg
+
 	return &SecureChannel{
 		EndpointURL: endpoint,
 		c:           c,
-		cfg:         cfg,
+		cfg:         &newCfg,
 		reqhdr: &ua.RequestHeader{
 			TimeoutHint:      uint32(cfg.RequestTimeout / time.Millisecond),
 			AdditionalHeader: ua.NewExtensionObject(nil),


### PR DESCRIPTION
Hello,

Same as PL #302 - rebased from latested version of PL #299
 
This one add the possibilty to dynamically recreate the session and/or the subscription.

![image](https://user-images.githubusercontent.com/25567035/72877619-999dcb80-3cf9-11ea-8b85-f5712b794499.png)

~~<s> Keep alive (send a heartbeat if no value come from subscriptions) </s>~~ No longer needed since PL #308
~~<s> Publish Pool (multiple pending publish request to allow the server to respond in burst mode) </s>~~ Misunderstanding publish pool isn't meant for burst server reponse

> Spec 1.03 part 4 5.13.5 Publish
 [..] in high latency networks, the Client may wish to pipeline Publish requests to ensure cyclic reporting from the Server. Pipe-lining involves sending more than one Publish request for each Subscription before receiving a response. For example, if the network introduces a delay between the Client and the Server of 5 seconds and the publishing interval for a Subscription is one second, then the Client will have to issue Publish requests every second instead of waiting for a response to be received before sending the next request.
