### PR TITLE
refactor/tweak SubscriptionParameters usage

### DIFF
--- a/client.go
+++ b/client.go
@@ -583,7 +583,7 @@ func (c *Client) UnregisterNodes(req *ua.UnregisterNodesRequest) (*ua.Unregister
 // Subscribe creates a Subscription with given parameters. Parameters that have not been set
 // (have zero values) are overwritten with default values.
 // See opcua.DefaultSubscription* constants
-func (c *Client) Subscribe(params *SubscriptionParameters) (*Subscription, error) {
+func (c *Client) Subscribe(params *SubscriptionParameters, notifyCh chan *PublishNotificationData) (*Subscription, error) {
 	if params == nil {
 		params = &SubscriptionParameters{}
 	}
@@ -613,9 +613,10 @@ func (c *Client) Subscribe(params *SubscriptionParameters) (*Subscription, error
 		time.Duration(res.RevisedPublishingInterval) * time.Millisecond,
 		res.RevisedLifetimeCount,
 		res.RevisedMaxKeepAliveCount,
-		params.Notifs,
+		notifyCh,
 		c,
 	}
+
 	c.subMux.Lock()
 	if sub.SubscriptionID == 0 || c.subscriptions[sub.SubscriptionID] != nil {
 		// this should not happen and is usually indicative of a server bug

--- a/subscription.go
+++ b/subscription.go
@@ -34,7 +34,6 @@ type SubscriptionParameters struct {
 	MaxKeepAliveCount          uint32
 	MaxNotificationsPerPublish uint32
 	Priority                   uint8
-	Notifs                     chan *PublishNotificationData
 }
 
 func NewMonitoredItemCreateRequestWithDefaults(nodeID *ua.NodeID, attributeID ua.AttributeID, clientHandle uint32) *ua.MonitoredItemCreateRequest {
@@ -241,8 +240,5 @@ func (p *SubscriptionParameters) setDefaults() {
 		// made only to allow for a one-liner change of default priority should a need arise
 		// and to explicitly expose the default priority as a constant
 		p.Priority = DefaultSubscriptionPriority
-	}
-	if p.Notifs == nil {
-		p.Notifs = make(chan *PublishNotificationData)
 	}
 }


### PR DESCRIPTION
* Exposes `opcua.SubscriptionParameters` to the monitor function
* Separates notification channel from `SubscriptionParameters`

Fixes #320 