### PR TITLE
uacp.Dial use context for dial

### DIFF
--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -40,7 +40,8 @@ func Dial(ctx context.Context, endpoint string) (*Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := net.DialTCP(network, nil, raddr)
+	var dialer net.Dialer
+	c, err := dialer.DialContext(ctx, network, raddr.String())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use `net.Dialer{}.DialContext` instead of `net.DialTCP`. This allows the dial to be canceled by the caller, or by the use of context with a timeout.

Fixes https://github.com/gopcua/opcua/issues/327