### PR TITLE
disable error handling of publish ACKs

### DIFF
--- a/client.go
+++ b/client.go
@@ -690,21 +690,21 @@ func (c *Client) notifySubscription(ctx context.Context, response *ua.PublishRes
 	}
 
 	// Check for errors
-	status := ua.StatusOK
-	for _, res := range response.Results {
-		if res != ua.StatusOK {
-			status = res
-			break
-		}
-	}
+	// status := ua.StatusOK
+	// for _, res := range response.Results {
+	// 	if res != ua.StatusOK {
+	// 		status = res
+	// 		break
+	// 	}
+	// }
 
-	if status != ua.StatusOK {
-		sub.sendNotification(ctx, &PublishNotificationData{
-			SubscriptionID: response.SubscriptionID,
-			Error:          status,
-		})
-		return
-	}
+	// if status != ua.StatusOK {
+	// 	sub.sendNotification(ctx, &PublishNotificationData{
+	// 		SubscriptionID: response.SubscriptionID,
+	// 		Error:          status,
+	// 	})
+	// 	return
+	// }
 
 	if response.NotificationMessage == nil {
 		sub.sendNotification(ctx, &PublishNotificationData{


### PR DESCRIPTION
The result status codes in the publish response are not related
to the notification message data but to the acknowledgements sent
in the previous PublishRequest.

It looks like the Siemens PLC is sending us sequence number that
we have ackknowledged in the previous request and then responds
with a bad sequence number error for one of the sequence numbers
we've acknowledged.

This is correct but not according to spec since the PLC should only
send us packets that have not been ack'ed and the that list should
be compiled *after* processing the PublishRequest with our sequence
numbers.

In any case, there is no correlation between the results and the
notification data so we should not check these errors here at all.

Fixes #337 