### PR TITLE
fix(client): fix nil pointer in sendWithTimeout() after connection interrupt

### DIFF
--- a/client.go
+++ b/client.go
@@ -223,16 +223,16 @@ func (c *Client) monitorChannel(ctx context.Context) {
 
 // Close closes the session and the secure channel.
 func (c *Client) Close() error {
+	if c.sechan == nil {
+		return ua.StatusBadServerNotConnected
+	}
 	// try to close the session but ignore any error
 	// so that we close the underlying channel and connection.
 	_ = c.CloseSession()
 	if c.cancelMonitor != nil {
 		c.cancelMonitor()
 	}
-	if c.sechan != nil {
-		return c.sechan.Close()
-	}
-	return io.EOF
+	return c.sechan.Close()
 }
 
 var errNotConnected = errors.New("not connected")

--- a/client.go
+++ b/client.go
@@ -229,8 +229,10 @@ func (c *Client) Close() error {
 	if c.cancelMonitor != nil {
 		c.cancelMonitor()
 	}
-
-	return c.sechan.Close()
+	if c.sechan != nil {
+		return c.sechan.Close()
+	}
+	return io.EOF
 }
 
 var errNotConnected = errors.New("not connected")

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,15 @@
+package opcua
+
+import (
+	"github.com/gopcua/opcua/ua"
+	"github.com/pascaldekloe/goe/verify"
+	"testing"
+)
+
+func TestClient_Send_DoesNotPanicWhenDisconnected(t *testing.T) {
+	c := NewClient("opc.tcp://example.com:4840")
+	err := c.Send(&ua.ReadRequest{}, func(i interface{}) error {
+		return nil
+	})
+	verify.Values(t, "", err, ua.StatusBadServerNotConnected)
+}


### PR DESCRIPTION
- add check that sechan is not nil in `sendWithTimeout()`
- add some more nil checks where potential for nil pointer exists
- replace free text error "secure channel not connected" with appropriate standard error `StatusBadServerNotConnected`

closes #350