### PR TITLE
Support different RSA key sizes between client and server

### DIFF
--- a/uapolicy/policyAes128Sha256RsaOaep.go
+++ b/uapolicy/policyAes128Sha256RsaOaep.go
@@ -66,15 +66,16 @@ func newAes128Sha256RsaOaepSymmetric(localNonce []byte, remoteNonce []byte) (*En
 	remoteKeys := generateKeys(remoteHmac, localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	return &EncryptionAlgorithm{
-		blockSize:           AESBlockSize,
-		plainttextBlockSize: AESBlockSize - AESMinPadding,
-		encrypt:             &AES{KeyLength: 128, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES128-CBC
-		decrypt:             &AES{KeyLength: 128, IV: localKeys.iv, Secret: localKeys.encryption},   // AES128-CBC
-		signature:           &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
-		verifySignature:     &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
-		signatureLength:     256 / 8,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#aes128-cbc",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
+		blockSize:             AESBlockSize,
+		plainttextBlockSize:   AESBlockSize - AESMinPadding,
+		encrypt:               &AES{KeyLength: 128, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES128-CBC
+		decrypt:               &AES{KeyLength: 128, IV: localKeys.iv, Secret: localKeys.encryption},   // AES128-CBC
+		signature:             &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
+		verifySignature:       &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
+		signatureLength:       256 / 8,
+		remoteSignatureLength: 256 / 8,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#aes128-cbc",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
 	}, nil
 }
 
@@ -105,15 +106,16 @@ func newAes128Sha256RsaOaepAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.P
 	}
 
 	return &EncryptionAlgorithm{
-		blockSize:           remoteKeySize,
-		plainttextBlockSize: remoteKeySize - RSAOAEPMinPaddingSHA1,
-		encrypt:             &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},    // RSA-OAEP-SHA1
-		decrypt:             &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},    // RSA-OAEP-SHA1
-		signature:           &PKCS1v15{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-PKCS15-SHA2-256
-		verifySignature:     &PKCS1v15{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-PKCS15-SHA2-256
-		nonceLength:         nonceLength,
-		signatureLength:     localKeySize,
-		encryptionURI:       "http://opcfoundation.org/ua/security/rsa-oaep-sha1",
-		signatureURI:        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+		blockSize:             remoteKeySize,
+		plainttextBlockSize:   remoteKeySize - RSAOAEPMinPaddingSHA1,
+		encrypt:               &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},    // RSA-OAEP-SHA1
+		decrypt:               &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},    // RSA-OAEP-SHA1
+		signature:             &PKCS1v15{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-PKCS15-SHA2-256
+		verifySignature:       &PKCS1v15{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-PKCS15-SHA2-256
+		nonceLength:           nonceLength,
+		signatureLength:       localKeySize,
+		remoteSignatureLength: remoteKeySize,
+		encryptionURI:         "http://opcfoundation.org/ua/security/rsa-oaep-sha1",
+		signatureURI:          "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
 	}, nil
 }

--- a/uapolicy/policyAes256Sha256RsaPss.go
+++ b/uapolicy/policyAes256Sha256RsaPss.go
@@ -70,15 +70,16 @@ func newAes256Sha256RsaPssSymmetric(localNonce []byte, remoteNonce []byte) (*Enc
 	remoteKeys := generateKeys(remoteHmac, localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	return &EncryptionAlgorithm{
-		blockSize:           AESBlockSize,
-		plainttextBlockSize: AESBlockSize - AESMinPadding,
-		encrypt:             &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
-		decrypt:             &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
-		signature:           &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
-		verifySignature:     &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
-		signatureLength:     256 / 8,
-		encryptionURI:       "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
+		blockSize:             AESBlockSize,
+		plainttextBlockSize:   AESBlockSize - AESMinPadding,
+		encrypt:               &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
+		decrypt:               &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
+		signature:             &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
+		verifySignature:       &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
+		signatureLength:       256 / 8,
+		remoteSignatureLength: 256 / 8,
+		encryptionURI:         "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
 	}, nil
 }
 
@@ -109,15 +110,16 @@ func newAes256Sha256RsaPssAsymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Pu
 	}
 
 	return &EncryptionAlgorithm{
-		blockSize:           remoteKeySize,
-		plainttextBlockSize: remoteKeySize - RSAOAEPMinPaddingSHA256,
-		encrypt:             &RSAOAEP{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-OAEP-SHA256
-		decrypt:             &RSAOAEP{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-OAEP-SHA256
-		signature:           &RSAPSS{Hash: crypto.SHA256, PrivateKey: localKey},  // RSA-PSS-SHA2-256
-		verifySignature:     &RSAPSS{Hash: crypto.SHA256, PublicKey: remoteKey},  // RSA-PSS-SHA2-256
-		nonceLength:         nonceLength,
-		signatureLength:     localKeySize,
-		encryptionURI:       "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256",
-		signatureURI:        "http://opcfoundation.org/UA/security/rsa-pss-sha2-256",
+		blockSize:             remoteKeySize,
+		plainttextBlockSize:   remoteKeySize - RSAOAEPMinPaddingSHA256,
+		encrypt:               &RSAOAEP{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-OAEP-SHA256
+		decrypt:               &RSAOAEP{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-OAEP-SHA256
+		signature:             &RSAPSS{Hash: crypto.SHA256, PrivateKey: localKey},  // RSA-PSS-SHA2-256
+		verifySignature:       &RSAPSS{Hash: crypto.SHA256, PublicKey: remoteKey},  // RSA-PSS-SHA2-256
+		nonceLength:           nonceLength,
+		signatureLength:       localKeySize,
+		remoteSignatureLength: remoteKeySize,
+		encryptionURI:         "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256",
+		signatureURI:          "http://opcfoundation.org/UA/security/rsa-pss-sha2-256",
 	}, nil
 }

--- a/uapolicy/policyBasic128Rsa15.go
+++ b/uapolicy/policyBasic128Rsa15.go
@@ -55,15 +55,16 @@ func newBasic128Rsa15Symmetric(localNonce []byte, remoteNonce []byte) (*Encrypti
 	remoteKeys := generateKeys(remoteHmac, localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	return &EncryptionAlgorithm{
-		blockSize:           AESBlockSize,
-		plainttextBlockSize: AESBlockSize - AESMinPadding,
-		encrypt:             &AES{KeyLength: 128, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES128-CBC
-		decrypt:             &AES{KeyLength: 128, IV: localKeys.iv, Secret: localKeys.encryption},   // AES128-CBC
-		signature:           &HMAC{Hash: crypto.SHA1, Secret: remoteKeys.signing},                   // HMAC-SHA1
-		verifySignature:     &HMAC{Hash: crypto.SHA1, Secret: localKeys.signing},                    // HMAC-SHA1
-		signatureLength:     160 / 8,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#aes128-cbc",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
+		blockSize:             AESBlockSize,
+		plainttextBlockSize:   AESBlockSize - AESMinPadding,
+		encrypt:               &AES{KeyLength: 128, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES128-CBC
+		decrypt:               &AES{KeyLength: 128, IV: localKeys.iv, Secret: localKeys.encryption},   // AES128-CBC
+		signature:             &HMAC{Hash: crypto.SHA1, Secret: remoteKeys.signing},                   // HMAC-SHA1
+		verifySignature:       &HMAC{Hash: crypto.SHA1, Secret: localKeys.signing},                    // HMAC-SHA1
+		signatureLength:       160 / 8,
+		remoteSignatureLength: 160 / 8,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#aes128-cbc",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
 	}, nil
 }
 
@@ -94,15 +95,16 @@ func newBasic128Rsa15Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.PublicK
 	}
 
 	return &EncryptionAlgorithm{
-		blockSize:           remoteKeySize,
-		plainttextBlockSize: remoteKeySize - PKCS1v15MinPadding,
-		encrypt:             &PKCS1v15{PublicKey: remoteKey},                    // RSA-SHA15+KWRSA15
-		decrypt:             &PKCS1v15{PrivateKey: localKey},                    // RSA-SHA15+KWRSA15
-		signature:           &PKCS1v15{Hash: crypto.SHA1, PrivateKey: localKey}, // RSA-SHA1
-		verifySignature:     &PKCS1v15{Hash: crypto.SHA1, PublicKey: remoteKey}, // RSA-SHA1
-		nonceLength:         nonceLength,
-		signatureLength:     localKeySize,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#rsa-1_5",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+		blockSize:             remoteKeySize,
+		plainttextBlockSize:   remoteKeySize - PKCS1v15MinPadding,
+		encrypt:               &PKCS1v15{PublicKey: remoteKey},                    // RSA-SHA15+KWRSA15
+		decrypt:               &PKCS1v15{PrivateKey: localKey},                    // RSA-SHA15+KWRSA15
+		signature:             &PKCS1v15{Hash: crypto.SHA1, PrivateKey: localKey}, // RSA-SHA1
+		verifySignature:       &PKCS1v15{Hash: crypto.SHA1, PublicKey: remoteKey}, // RSA-SHA1
+		nonceLength:           nonceLength,
+		signatureLength:       localKeySize,
+		remoteSignatureLength: remoteKeySize,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#rsa-1_5",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
 	}, nil
 }

--- a/uapolicy/policyBasic256.go
+++ b/uapolicy/policyBasic256.go
@@ -54,15 +54,16 @@ func newBasic256Symmetric(localNonce []byte, remoteNonce []byte) (*EncryptionAlg
 	remoteKeys := generateKeys(remoteHmac, localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	return &EncryptionAlgorithm{
-		blockSize:           AESBlockSize,
-		plainttextBlockSize: AESBlockSize - AESMinPadding,
-		encrypt:             &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
-		decrypt:             &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
-		signature:           &HMAC{Hash: crypto.SHA1, Secret: remoteKeys.signing},                   // HMAC-SHA1
-		verifySignature:     &HMAC{Hash: crypto.SHA1, Secret: localKeys.signing},                    // HMAC-SHA1
-		signatureLength:     160 / 8,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
+		blockSize:             AESBlockSize,
+		plainttextBlockSize:   AESBlockSize - AESMinPadding,
+		encrypt:               &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
+		decrypt:               &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
+		signature:             &HMAC{Hash: crypto.SHA1, Secret: remoteKeys.signing},                   // HMAC-SHA1
+		verifySignature:       &HMAC{Hash: crypto.SHA1, Secret: localKeys.signing},                    // HMAC-SHA1
+		signatureLength:       160 / 8,
+		remoteSignatureLength: 160 / 8,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
 	}, nil
 }
 
@@ -93,15 +94,16 @@ func newBasic256Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.PublicKey) (
 	}
 
 	return &EncryptionAlgorithm{
-		blockSize:           remoteKeySize,
-		plainttextBlockSize: remoteKeySize - RSAOAEPMinPaddingSHA1,
-		encrypt:             &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},  // RSA-OAEP
-		decrypt:             &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},  // RSA-OAEP
-		signature:           &PKCS1v15{Hash: crypto.SHA1, PrivateKey: localKey}, // RSA-SHA1
-		verifySignature:     &PKCS1v15{Hash: crypto.SHA1, PublicKey: remoteKey}, // RSA-SHA1
-		nonceLength:         nonceLength,
-		signatureLength:     localKeySize,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#rsa-oaep",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+		blockSize:             remoteKeySize,
+		plainttextBlockSize:   remoteKeySize - RSAOAEPMinPaddingSHA1,
+		encrypt:               &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},  // RSA-OAEP
+		decrypt:               &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},  // RSA-OAEP
+		signature:             &PKCS1v15{Hash: crypto.SHA1, PrivateKey: localKey}, // RSA-SHA1
+		verifySignature:       &PKCS1v15{Hash: crypto.SHA1, PublicKey: remoteKey}, // RSA-SHA1
+		nonceLength:           nonceLength,
+		signatureLength:       localKeySize,
+		remoteSignatureLength: remoteKeySize,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#rsa-oaep",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
 	}, nil
 }

--- a/uapolicy/policyBasic256Sha256.go
+++ b/uapolicy/policyBasic256Sha256.go
@@ -68,15 +68,16 @@ func newBasic256Rsa256Symmetric(localNonce []byte, remoteNonce []byte) (*Encrypt
 	remoteKeys := generateKeys(remoteHmac, localNonce, signatureKeyLength, encryptionKeyLength, encryptionBlockSize)
 
 	return &EncryptionAlgorithm{
-		blockSize:           AESBlockSize,
-		plainttextBlockSize: AESBlockSize - AESMinPadding,
-		encrypt:             &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
-		decrypt:             &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
-		signature:           &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
-		verifySignature:     &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
-		signatureLength:     256 / 8,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
-		signatureURI:        "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
+		blockSize:             AESBlockSize,
+		plainttextBlockSize:   AESBlockSize - AESMinPadding,
+		encrypt:               &AES{KeyLength: 256, IV: remoteKeys.iv, Secret: remoteKeys.encryption}, // AES256-CBC
+		decrypt:               &AES{KeyLength: 256, IV: localKeys.iv, Secret: localKeys.encryption},   // AES256-CBC
+		signature:             &HMAC{Hash: crypto.SHA256, Secret: remoteKeys.signing},                 // HMAC-SHA2-256
+		verifySignature:       &HMAC{Hash: crypto.SHA256, Secret: localKeys.signing},                  // HMAC-SHA2-256
+		signatureLength:       256 / 8,
+		remoteSignatureLength: 256 / 8,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+		signatureURI:          "http://www.w3.org/2000/09/xmldsig#hmac-sha256",
 	}, nil
 }
 
@@ -106,15 +107,16 @@ func newBasic256Rsa256Asymmetric(localKey *rsa.PrivateKey, remoteKey *rsa.Public
 	}
 
 	return &EncryptionAlgorithm{
-		blockSize:           remoteKeySize,
-		plainttextBlockSize: remoteKeySize - RSAOAEPMinPaddingSHA1,
-		encrypt:             &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},    // RSA-OAEP
-		decrypt:             &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},    // RSA-OAEP
-		signature:           &PKCS1v15{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-PKCS15-SHA2-256
-		verifySignature:     &PKCS1v15{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-PKCS15-SHA2-256
-		nonceLength:         nonceLength,
-		signatureLength:     localKeySize,
-		encryptionURI:       "http://www.w3.org/2001/04/xmlenc#rsa-oaep",
-		signatureURI:        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+		blockSize:             remoteKeySize,
+		plainttextBlockSize:   remoteKeySize - RSAOAEPMinPaddingSHA1,
+		encrypt:               &RSAOAEP{Hash: crypto.SHA1, PublicKey: remoteKey},    // RSA-OAEP
+		decrypt:               &RSAOAEP{Hash: crypto.SHA1, PrivateKey: localKey},    // RSA-OAEP
+		signature:             &PKCS1v15{Hash: crypto.SHA256, PrivateKey: localKey}, // RSA-PKCS15-SHA2-256
+		verifySignature:       &PKCS1v15{Hash: crypto.SHA256, PublicKey: remoteKey}, // RSA-PKCS15-SHA2-256
+		nonceLength:           nonceLength,
+		signatureLength:       localKeySize,
+		remoteSignatureLength: remoteKeySize,
+		encryptionURI:         "http://www.w3.org/2001/04/xmlenc#rsa-oaep",
+		signatureURI:          "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
 	}, nil
 }

--- a/uapolicy/policyNone.go
+++ b/uapolicy/policyNone.go
@@ -27,24 +27,26 @@ SecurityPolicy_None_Limits 		DerivedSignatureKeyLength: 0
 */
 func newNoneAsymmetric(*rsa.PrivateKey, *rsa.PublicKey) (*EncryptionAlgorithm, error) {
 	return &EncryptionAlgorithm{
-		blockSize:           NoneBlockSize,
-		plainttextBlockSize: NoneBlockSize - NoneMinPadding,
-		encrypt:             &None{},
-		decrypt:             &None{},
-		signature:           &None{},
-		verifySignature:     &None{},
-		signatureLength:     0,
+		blockSize:             NoneBlockSize,
+		plainttextBlockSize:   NoneBlockSize - NoneMinPadding,
+		encrypt:               &None{},
+		decrypt:               &None{},
+		signature:             &None{},
+		verifySignature:       &None{},
+		signatureLength:       0,
+		remoteSignatureLength: 0,
 	}, nil
 }
 
 func newNoneSymmetric([]byte, []byte) (*EncryptionAlgorithm, error) {
 	return &EncryptionAlgorithm{
-		blockSize:           NoneBlockSize,
-		plainttextBlockSize: NoneBlockSize - NoneMinPadding,
-		encrypt:             &None{},
-		decrypt:             &None{},
-		signature:           &None{},
-		verifySignature:     &None{},
-		signatureLength:     0,
+		blockSize:             NoneBlockSize,
+		plainttextBlockSize:   NoneBlockSize - NoneMinPadding,
+		encrypt:               &None{},
+		decrypt:               &None{},
+		signature:             &None{},
+		verifySignature:       &None{},
+		signatureLength:       0,
+		remoteSignatureLength: 0,
 	}, nil
 }

--- a/uapolicy/securitypolicy.go
+++ b/uapolicy/securitypolicy.go
@@ -62,16 +62,17 @@ func Symmetric(uri string, localNonce, remoteNonce []byte) (*EncryptionAlgorithm
 // The zero value of this struct will use SecurityPolicy#None although
 // using in this manner is discouraged for readability
 type EncryptionAlgorithm struct {
-	blockSize           int
-	plainttextBlockSize int
-	decrypt             interface{ Decrypt([]byte) ([]byte, error) }
-	encrypt             interface{ Encrypt([]byte) ([]byte, error) }
-	signature           interface{ Signature([]byte) ([]byte, error) }
-	verifySignature     interface{ Verify([]byte, []byte) error }
-	nonceLength         int
-	signatureLength     int
-	encryptionURI       string
-	signatureURI        string
+	blockSize             int
+	plainttextBlockSize   int
+	decrypt               interface{ Decrypt([]byte) ([]byte, error) }
+	encrypt               interface{ Encrypt([]byte) ([]byte, error) }
+	signature             interface{ Signature([]byte) ([]byte, error) }
+	verifySignature       interface{ Verify([]byte, []byte) error }
+	nonceLength           int
+	signatureLength       int
+	remoteSignatureLength int
+	encryptionURI         string
+	signatureURI          string
 }
 
 // BlockSize returns the underlying encryption algorithm's blocksize.
@@ -127,9 +128,14 @@ func (e *EncryptionAlgorithm) VerifySignature(message, signature []byte) error {
 	return e.verifySignature.Verify(message, signature)
 }
 
-// SignatureLength returns the length in bytes for the signature algorithm
+// SignatureLength returns the length in bytes for outgoing signatures.
 func (e *EncryptionAlgorithm) SignatureLength() int {
 	return e.signatureLength
+}
+
+// RemoteSignatureLength returns the length in bytes for incoming signatures.
+func (e *EncryptionAlgorithm) RemoteSignatureLength() int {
+	return e.remoteSignatureLength
 }
 
 // NonceLength returns the recommended nonce length in bytes for the security policy

--- a/uasc/secure_channel_crypto.go
+++ b/uasc/secure_channel_crypto.go
@@ -95,8 +95,8 @@ func (s *SecureChannel) verifyAndDecrypt(m *MessageChunk, b []byte) ([]byte, err
 		b = append(b[:headerLength], p...)
 	}
 
-	signature := b[len(b)-s.enc.SignatureLength():]
-	messageToVerify := b[:len(b)-s.enc.SignatureLength()]
+	signature := b[len(b)-s.enc.RemoteSignatureLength():]
+	messageToVerify := b[:len(b)-s.enc.RemoteSignatureLength()]
 
 	if err = s.enc.VerifySignature(messageToVerify, signature); err != nil {
 		return nil, ua.StatusBadSecurityChecksFailed


### PR DESCRIPTION
I'm connecting to a KepWare server using the older security settings ("Basic256" or "Basic128Rsa15"). I used the `examples/crypto/` sample to generate my certificate with 2048 and found the server has a 1024 bit certificate. The connection kept failing until I changed my client certificate to 1024 bits, which lead me to this issue. These changes got me working with mismatched key sizes.

I added a new `remoteSignatureLength` field to the `EncryptionAlgorithm` struct, mirroring the `signatureLength` field, and used it in the `verifyAndDecrypt` function. The `signAndEncrypt` function was left unchanged.