### PR TITLE
ua: ensure variant array dimensions are greater than zero

### DIFF
--- a/ua/variant.go
+++ b/ua/variant.go
@@ -44,7 +44,7 @@ type Variant struct {
 	// field.
 	arrayLength int32
 
-	// arrayDimensionsLength is the numer of dimensions.
+	// arrayDimensionsLength is the number of dimensions.
 	// This field is only present if the 'array dimensions' flag
 	// is set.
 	arrayDimensionsLength int32
@@ -147,7 +147,7 @@ func (m *Variant) Decode(b []byte) (int, error) {
 		m.arrayDimensions = make([]int32, m.arrayDimensionsLength)
 		for i := 0; i < int(m.arrayDimensionsLength); i++ {
 			m.arrayDimensions[i] = buf.ReadInt32()
-			if m.arrayDimensions[i] < 0 {
+			if m.arrayDimensions[i] < 1 {
 				return buf.Pos(), StatusBadEncodingLimitsExceeded
 			}
 		}

--- a/ua/variant_test.go
+++ b/ua/variant_test.go
@@ -259,7 +259,7 @@ func TestVariant(t *testing.T) {
 			},
 		},
 		{
-			Name: "ExtensionObjeject",
+			Name: "ExtensionObject",
 			Struct: MustVariant(NewExtensionObject(
 				&AnonymousIdentityToken{PolicyID: "anonymous"},
 			)),
@@ -277,7 +277,7 @@ func TestVariant(t *testing.T) {
 			},
 		},
 		{
-			Name: "ExtensionObjeject - ServerStatusDataType",
+			Name: "ExtensionObject - ServerStatusDataType",
 			Struct: MustVariant(NewExtensionObject(
 				&ServerStatusDataType{
 					StartTime:   time.Date(2019, 3, 29, 19, 45, 3, 816525000, time.UTC), // Mar 29, 2019 20:45:03.816525000 CET
@@ -574,9 +574,9 @@ func TestArray(t *testing.T) {
 			// array values
 			0x01, 0x00, 0x00, 0x00,
 			0x01, 0x00, 0x00, 0x00,
-			// array dimesions length
+			// array dimensions length
 			0xff, 0xff, 0xff, 0xff, // -1
-			// array dimesions
+			// array dimensions
 			0x01, 0x00, 0x00, 0x00,
 			0x01, 0x00, 0x00, 0x00,
 		}
@@ -595,9 +595,9 @@ func TestArray(t *testing.T) {
 			// array values
 			0x01, 0x00, 0x00, 0x00,
 			0x01, 0x00, 0x00, 0x00,
-			// array dimesions length
+			// array dimensions length
 			0x02, 0x00, 0x00, 0x00,
-			// array dimesions
+			// array dimensions
 			0x01, 0x00, 0x00, 0x00,
 			0xff, 0xff, 0xff, 0xff, // -1
 		}

--- a/ua/variant_test.go
+++ b/ua/variant_test.go
@@ -450,27 +450,6 @@ func TestVariant(t *testing.T) {
 				0x01, 0x00, 0x00, 0x00,
 			},
 		},
-		{
-			Name: "[0][0][0]uint32",
-			Struct: MustVariant([][][]uint32{
-				{{}, {}},
-				{{}, {}},
-				{{}, {}},
-			}),
-			Bytes: []byte{
-				// variant encoding mask
-				0xc7,
-				// array length
-				0x00, 0x00, 0x00, 0x00,
-				// array values
-				// array dimensions length
-				0x03, 0x00, 0x00, 0x00,
-				// array dimensions
-				0x03, 0x00, 0x00, 0x00,
-				0x02, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00,
-			},
-		},
 	}
 	RunCodecTest(t, cases)
 }
@@ -603,6 +582,25 @@ func TestArray(t *testing.T) {
 		}
 
 		_, err := Decode(b, MustVariant([]uint32{0}))
+		if got, want := err, StatusBadEncodingLimitsExceeded; !errors.Equal(got, want) {
+			t.Fatalf("got error %#v want %#v", got, want)
+		}
+	})
+	t.Run("dimensions zero", func(t *testing.T) {
+		b := []byte{
+			// variant encoding mask
+			0xc7,
+			// array length
+			0x00, 0x00, 0x00, 0x00,
+			// array values
+			// array dimensions length
+			0x02, 0x00, 0x00, 0x00,
+			// array dimensions
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		}
+
+		_, err := Decode(b, MustVariant([][]uint32{{}, {}}))
 		if got, want := err, StatusBadEncodingLimitsExceeded; !errors.Equal(got, want) {
 			t.Fatalf("got error %#v want %#v", got, want)
 		}


### PR DESCRIPTION
According to the [reference](https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.2/#5.2.2.16), all dimensions shall be specified and shall be greater than zero. So if any dimension is less than 1, return an error.

Fixes https://github.com/gopcua/opcua/issues/362, because it will ensure that the code bails before trying to split a multi-dimensional array.

What do you think @magiconair?