### PR TITLE
ua: add support for encoding null variants

### DIFF
--- a/ua/variant.go
+++ b/ua/variant.go
@@ -112,6 +112,11 @@ func (m *Variant) Decode(b []byte) (int, error) {
 	buf := NewBuffer(b)
 	m.mask = buf.ReadByte()
 
+	// a null value specifies that no other fields are encoded
+	if m.Type() == TypeIDNull {
+		return buf.Pos(), buf.Error()
+	}
+
 	// check the type
 	typ, ok := variantTypeIDToType[m.Type()]
 	if !ok {
@@ -302,8 +307,12 @@ func (m *Variant) decodeValue(buf *Buffer) interface{} {
 // Encode implements the codec interface.
 func (m *Variant) Encode() ([]byte, error) {
 	buf := NewBuffer(nil)
-
 	buf.WriteByte(m.mask)
+
+	// a null value specifies that no other fields are encoded
+	if m.Type() == TypeIDNull {
+		return buf.Bytes(), buf.Error()
+	}
 
 	if m.Has(VariantArrayValues) {
 		buf.WriteInt32(m.arrayLength)
@@ -395,6 +404,11 @@ var errUnbalancedSlice = errors.New("unbalanced multi-dimensional array")
 // sliceDim determines the element type, dimensions and the total length
 // of a one or multi-dimensional slice.
 func sliceDim(v reflect.Value) (typ reflect.Type, dim []int32, count int32, err error) {
+	// null type
+	if v.Kind() == reflect.Invalid {
+		return nil, nil, 0, nil
+	}
+
 	// ByteString is its own type
 	if v.Type() == reflect.TypeOf([]byte{}) {
 		return v.Type(), nil, 1, nil

--- a/ua/variant_test.go
+++ b/ua/variant_test.go
@@ -18,6 +18,11 @@ import (
 func TestVariant(t *testing.T) {
 	cases := []CodecTestCase{
 		{
+			Name:   "null",
+			Struct: MustVariant(nil),
+			Bytes:  []byte{0x0},
+		},
+		{
 			Name:   "boolean",
 			Struct: MustVariant(false),
 			Bytes: []byte{
@@ -614,6 +619,13 @@ func TestSet(t *testing.T) {
 		err error
 	}{
 		{
+			v: nil,
+			va: &Variant{
+				mask:  byte(TypeIDNull),
+				value: nil,
+			},
+		},
+		{
 			v: []byte{0xca, 0xfe},
 			va: &Variant{
 				mask:  byte(TypeIDByteString),
@@ -693,6 +705,13 @@ func TestSliceDim(t *testing.T) {
 		err error
 	}{
 		// happy flows
+		{
+			v:   nil,
+			et:  nil,
+			dim: nil,
+			len: 0,
+			err: nil,
+		},
 		{
 			v:   "a",
 			et:  reflect.TypeOf(""),


### PR DESCRIPTION
Follow-up to https://github.com/gopcua/opcua/pull/284, add a codec test case for a variant with a value of zero and ensure that it can be encoded without yielding a run-time panic.

What do you think @kung-foo, @magiconair?