### PR TITLE
browse: do not set timestamp for empty view

### DIFF
--- a/node.go
+++ b/node.go
@@ -6,7 +6,6 @@ package opcua
 
 import (
 	"strings"
-	"time"
 
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
@@ -184,8 +183,7 @@ func (n *Node) References(refType uint32, dir ua.BrowseDirection, mask ua.NodeCl
 
 	req := &ua.BrowseRequest{
 		View: &ua.ViewDescription{
-			ViewID:    ua.NewTwoByteNodeID(0),
-			Timestamp: time.Now(),
+			ViewID: ua.NewTwoByteNodeID(0),
 		},
 		RequestedMaxReferencesPerNode: 0,
 		NodesToBrowse:                 []*ua.BrowseDescription{desc},


### PR DESCRIPTION
To browse the full nodeset the client should use an empty (zero) ViewID
in the browse request. The server should probably ignore the timestamp
and/or version field but ABB 800xA does not return any nodes if the
ViewID is zero but the timestamp field is set.

This patch removes the timestamp field for the empty view.