### PR TITLE
fixing 2 issues causing disconnections

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -597,10 +597,8 @@ func (s *SecureChannel) handleOpenSecureChannelResponse(resp *ua.OpenSecureChann
 
 	debug.Printf("received security token: channelID=%d tokenID=%d createdAt=%s lifetime=%s", instance.secureChannelID, instance.securityTokenID, instance.createdAt.Format(time.RFC3339), instance.revisedLifetime)
 
-	if s.cfg.SecurityMode != ua.MessageSecurityModeNone {
-		go s.scheduleRenewal(instance)
-		go s.scheduleExpiration(instance)
-	}
+	go s.scheduleRenewal(instance)
+	go s.scheduleExpiration(instance)
 
 	return
 }

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -768,26 +768,22 @@ func (s *SecureChannel) sendAsyncWithTimeout(
 ) (<-chan *response, error) {
 
 	instance.Lock()
+	defer instance.Unlock()
 
 	m, err := instance.newRequestMessage(req, reqID, authToken, timeout)
 	if err != nil {
-		instance.Unlock()
 		return nil, err
 	}
 
 	b, err := m.Encode()
 	if err != nil {
-		instance.Unlock()
 		return nil, err
 	}
 
 	b, err = instance.signAndEncrypt(m, b)
 	if err != nil {
-		instance.Unlock()
 		return nil, err
 	}
-
-	instance.Unlock()
 
 	var resp chan *response
 


### PR DESCRIPTION
Fix #395 & #396:

395 was causing out of sync errors - fix is to expand critical section and include the actual send along with seq number advance
396 was causing a session to expire if using a channel w/o security. Fix: schedule renew disregard the fact that security mode is "no security" 