### PR TITLE
Adding Strateos logo to users section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The `gopcua` project is sponsored by the following organizations by supporting t
 ### Users
 
 We would also like to list organizations which use `gopcua` in production. Please open a PR to include your logo below.
+<p align="left">
+   <a href="https://strateos.com">
+      <img alt="strtaeos" width="10%" src="https://avatars1.githubusercontent.com/u/50255519?s=400&u=3c18028de0bd1a28b604d34d6b239d7a593a7e49&v=4">
+   </a>
+   </p>
 
 ## Disclaimer
 


### PR DESCRIPTION
We're using gopcua in production to monitor laboratory equipment.  Great library! Very easy to use.

We've written a Prometheus exporter that uses gopcua and is just now getting open-sourced: 
https://github.com/open-strateos/opcua_exporter

Feel free to move around/resize the logo if you want.
