### PR TITLE
Set the NodeID to the ExtensionObjects to the correct value #444

### DIFF
--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -127,6 +127,9 @@ func ExtensionObjectTypeID(v interface{}) *ExpandedNodeID {
 	case *ServerStatusDataType:
 		return NewFourByteExpandedNodeID(0, id.ServerStatusDataType_Encoding_DefaultBinary)
 	default:
+		if id := eotypes.Lookup(v); id != nil {
+			return &ExpandedNodeID{NodeID: id}
+		}
 		return NewTwoByteExpandedNodeID(0)
 	}
 }

--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -15,7 +15,7 @@ var eotypes = NewTypeRegistry()
 // RegisterExtensionObject registers a new extension object type.
 // It panics if the type or the id is already registered.
 func RegisterExtensionObject(typeID *NodeID, v interface{}) {
-	if err := eotypes.Register(typeID.String(), v); err != nil {
+	if err := eotypes.Register(typeID, v); err != nil {
 		panic("Extension object " + err.Error())
 	}
 }
@@ -73,7 +73,7 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 		return buf.Pos(), body.Error()
 	}
 
-	typeID := e.TypeID.NodeID.String()
+	typeID := e.TypeID.NodeID
 	e.Value = eotypes.New(typeID)
 	if e.Value == nil {
 		return buf.Pos(), errors.Errorf("invalid extension object with id %s", typeID)

--- a/ua/node_id.go
+++ b/ua/node_id.go
@@ -80,6 +80,17 @@ func NewByteStringNodeID(ns uint16, id []byte) *NodeID {
 	}
 }
 
+// MustParseNodeID returns a node id from a string definition
+// if it is parseable by ParseNodeID. Otherwise, the function
+// panics.
+func MustParseNodeID(s string) *NodeID {
+	id, err := ParseNodeID(s)
+	if err != nil {
+		panic(err.Error())
+	}
+	return id
+}
+
 // ParseNodeID returns a node id from a string definition of the format
 // 'ns=<namespace>;{s,i,b,g}=<identifier>'.
 //
@@ -89,7 +100,6 @@ func NewByteStringNodeID(ns uint16, id []byte) *NodeID {
 // and id value is returned.
 //
 // Namespace URLs 'nsu=' are not supported since they require a lookup.
-//
 func ParseNodeID(s string) (*NodeID, error) {
 	if s == "" {
 		return NewTwoByteNodeID(0), nil

--- a/ua/typereg.go
+++ b/ua/typereg.go
@@ -21,7 +21,7 @@ import (
 //
 // The implementation is safe for concurrent use.
 type TypeRegistry struct {
-	mu    sync.RWMutex
+	mu    sync.Mutex
 	types map[string]reflect.Type
 	ids   map[reflect.Type]string
 }
@@ -37,44 +37,60 @@ func NewTypeRegistry() *TypeRegistry {
 // New returns a new instance of the type with the given id.
 //
 // If the id is not known the function returns nil.
-func (r *TypeRegistry) New(id string) interface{} {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+//
+// New panics if id is nil.
+func (r *TypeRegistry) New(id *NodeID) interface{} {
+	if id == nil {
+		panic("opcua: missing id in call to TypeRegistry.New")
+	}
 
-	typ, ok := r.types[id]
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	typ, ok := r.types[id.String()]
 	if !ok {
 		return nil
 	}
 	return reflect.New(typ.Elem()).Interface()
 }
 
-// Lookup returns the id of the type of v or an empty string if
+// Lookup returns the id of the type of v or nil if
 // the type is not registered.
 //
 // If the type was registered multiple times the first
 // registered id for this type is returned.
-func (r *TypeRegistry) Lookup(v interface{}) string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.ids[reflect.TypeOf(v)]
+func (r *TypeRegistry) Lookup(v interface{}) *NodeID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.ids[reflect.TypeOf(v)]; ok {
+		return MustParseNodeID(id)
+	}
+	return nil
 }
 
 // Register adds a new type to the registry.
 //
 // If the id is already registered the function returns an error.
-func (r *TypeRegistry) Register(id string, v interface{}) error {
+//
+// Register panics if id is nil.
+func (r *TypeRegistry) Register(id *NodeID, v interface{}) error {
+	if id == nil {
+		panic("opcua: missing id in call to TypeRegistry.Register")
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	typ := reflect.TypeOf(v)
+	ids := id.String()
 
-	if r.types[id] != nil {
+	if r.types[ids] != nil {
 		return errors.Errorf("%s is already registered", id)
 	}
-	r.types[id] = typ
+	r.types[ids] = typ
 
 	if _, exists := r.ids[typ]; !exists {
-		r.ids[typ] = id
+		r.ids[typ] = ids
 	}
 	return nil
 }

--- a/uatest/method_server.py
+++ b/uatest/method_server.py
@@ -16,7 +16,7 @@ def square(parent, variant):
 def sum_of_squares(parent, variant):
     # print("sum_of_square methos call with parameter: ", variant.Value)
     ret = 3*3 + 8*8
-    return [ua.Variant(ret, ua.VariantType.Boolean)]
+    return [ua.Variant(ret, ua.VariantType.Int64)]
 
 if __name__ == "__main__":
     server = Server()

--- a/uatest/method_server.py
+++ b/uatest/method_server.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python3
 
 from opcua import ua, Server
+from opcua.ua import uatypes
+
+class Complex(uatypes.FrozenClass):
+    ua_types = [
+        ('i', 'Int64'),
+        ('j', 'Int64'),
+    ]
+
+    def __init__(self):
+        self.i = 0
+        self.j = 0
+        self._freeze = True
+
+    def __str__(self):
+        return 'Complex(' + 'i:' + str(self.i) + ', ' + \
+               'j:' + str(self.j) + ')'
+
+    __repr__ = __str__
 
 def even(parent, variant):
     print("even method call with parameters: ", variant.Value)
@@ -14,17 +32,17 @@ def square(parent, variant):
     return [variant]
 
 def sum_of_squares(parent, variant):
-    # print("sum_of_square methos call with parameter: ", variant.Value)
-    ret = 3*3 + 8*8
+    v = variant.Value # type is extension object "Complex"
+    print("sum_of_square methos call with parameter: ", v)
+    ret = v.i*v.i + v.j*v.j
     return [ua.Variant(ret, ua.VariantType.Int64)]
 
 if __name__ == "__main__":
     server = Server()
-    server.create_custom_data_type(2, "ComplexType", description="A complex type")
-
     server.set_endpoint("opc.tcp://0.0.0.0:4840/")
 
     ns = server.register_namespace("http://gopcua.com/")
+    uatypes.register_extension_object('Complex', ua.NodeId("ComplexType", ns), Complex)
     main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
     fnEven = main.add_method(ua.NodeId("even", ns), "even", even, [ua.VariantType.Int64], [ua.VariantType.Boolean])
     fnSquare = main.add_method(ua.NodeId("square", ns), "square", square, [ua.VariantType.Int64], [ua.VariantType.Int64])

--- a/uatest/method_server.py
+++ b/uatest/method_server.py
@@ -13,13 +13,21 @@ def square(parent, variant):
     variant.Value *= variant.Value
     return [variant]
 
+def sum_of_squares(parent, variant):
+    # print("sum_of_square methos call with parameter: ", variant.Value)
+    ret = 3*3 + 8*8
+    return [ua.Variant(ret, ua.VariantType.Boolean)]
+
 if __name__ == "__main__":
     server = Server()
+    server.create_custom_data_type(2, "ComplexType", description="A complex type")
+
     server.set_endpoint("opc.tcp://0.0.0.0:4840/")
 
     ns = server.register_namespace("http://gopcua.com/")
     main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
     fnEven = main.add_method(ua.NodeId("even", ns), "even", even, [ua.VariantType.Int64], [ua.VariantType.Boolean])
     fnSquare = main.add_method(ua.NodeId("square", ns), "square", square, [ua.VariantType.Int64], [ua.VariantType.Int64])
+    fnSumOfSquare = main.add_method(ua.NodeId("sumOfSquare", ns), "sumOfSquare", sum_of_squares, [ua.VariantType.ExtensionObject], [ua.VariantType.Int64])
 
     server.start()

--- a/uatest/method_test.go
+++ b/uatest/method_test.go
@@ -26,6 +26,16 @@ func TestCallMethod(t *testing.T) {
 			},
 			out: []*ua.Variant{ua.MustVariant(true)},
 		},
+		{
+			req: &ua.CallMethodRequest{
+				ObjectID: ua.NewStringNodeID(2, "main"),
+				MethodID: ua.NewStringNodeID(2, "square"),
+				InputArguments: []*ua.Variant{
+					ua.MustVariant(int64(3)),
+				},
+			},
+			out: []*ua.Variant{ua.MustVariant(int64(9))},
+		},
 	}
 
 	srv := NewServer("method_server.py")

--- a/uatest/method_test.go
+++ b/uatest/method_test.go
@@ -11,7 +11,14 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
+type Complex struct {
+	i int
+	j int
+}
+
 func TestCallMethod(t *testing.T) {
+	ua.RegisterExtensionObject(ua.NewStringNodeID(2, "ComplexType"), new(Complex))
+
 	tests := []struct {
 		req *ua.CallMethodRequest
 		out []*ua.Variant
@@ -35,6 +42,16 @@ func TestCallMethod(t *testing.T) {
 				},
 			},
 			out: []*ua.Variant{ua.MustVariant(int64(9))},
+		},
+		{
+			req: &ua.CallMethodRequest{
+				ObjectID: ua.NewStringNodeID(2, "main"),
+				MethodID: ua.NewStringNodeID(2, "sumOfSquare"),
+				InputArguments: []*ua.Variant{
+					ua.MustVariant(ua.NewExtensionObject(&Complex{3, 8})),
+				},
+			},
+			out: []*ua.Variant{ua.MustVariant(int64(9 + 64))},
 		},
 	}
 

--- a/uatest/method_test.go
+++ b/uatest/method_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 type Complex struct {
-	i int
-	j int
+	i, j int64
 }
 
 func TestCallMethod(t *testing.T) {


### PR DESCRIPTION
The NodeID of the ExtensionObjects was set to a default, zero, value.
Even in cases where the type was actually registered by the library.