### PR TITLE
fix policyURI=="" when secure channel's policy=none

### DIFF
--- a/uasc/secure_channel_crypto.go
+++ b/uasc/secure_channel_crypto.go
@@ -65,13 +65,13 @@ func (s *SecureChannel) VerifySessionSignature(cert, nonce, signature []byte) er
 
 // EncryptUserPassword issues a new signature for the client to send in ActivateSessionRequest
 func (s *SecureChannel) EncryptUserPassword(policyURI, password string, cert, nonce []byte) ([]byte, string, error) {
-	if policyURI == ua.SecurityPolicyURINone {
-		return []byte(password), "", nil
-	}
-
 	// If the User ID Token's policy was null, then default to the secure channel's policy
 	if policyURI == "" {
 		policyURI = s.cfg.SecurityPolicyURI
+	}
+
+	if policyURI == ua.SecurityPolicyURINone {
+		return []byte(password), "", nil
 	}
 
 	remoteX509Cert, err := x509.ParseCertificate(cert)


### PR DESCRIPTION
Signed-off-by: lcw2 <wmy_lcw@163.com>
when secure channel's policy = none and policyURI =="", it would happen errors.