### PR TITLE
Fix always schedule renewal of security token

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -597,10 +597,8 @@ func (s *SecureChannel) handleOpenSecureChannelResponse(resp *ua.OpenSecureChann
 
 	debug.Printf("received security token: channelID=%d tokenID=%d createdAt=%s lifetime=%s", instance.secureChannelID, instance.securityTokenID, instance.createdAt.Format(time.RFC3339), instance.revisedLifetime)
 
-	if s.cfg.SecurityMode != ua.MessageSecurityModeNone {
-		go s.scheduleRenewal(instance)
-		go s.scheduleExpiration(instance)
-	}
+	go s.scheduleRenewal(instance)
+	go s.scheduleExpiration(instance)
 
 	return
 }


### PR DESCRIPTION
Fix for issue https://github.com/gopcua/opcua/issues/392

Link to reason in OPC-UA documentation in comment in the issue.

We've also taken a look at the [C library for OPC-UA](https://github.com/open62541/open62541) and found no check for MessageSecurityMode.

[renewSecureChannel](https://github.com/open62541/open62541/blob/1c364d24d0aa635d0def3fe46078bb5526fb8f0f/src/client/ua_client_connect.c#L478)
[function call 1](https://github.com/open62541/open62541/blob/1c364d24d0aa635d0def3fe46078bb5526fb8f0f/src/client/ua_client.c#L200)
[function call 2](https://github.com/open62541/open62541/blob/1c364d24d0aa635d0def3fe46078bb5526fb8f0f/src/client/ua_client.c#L701)