### PR TITLE
Make dial timeout configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,8 +26,9 @@ import (
 )
 
 // GetEndpoints returns the available endpoint descriptions for the server.
-func GetEndpoints(ctx context.Context, endpoint string) ([]*ua.EndpointDescription, error) {
-	c := NewClient(endpoint, AutoReconnect(false))
+func GetEndpoints(ctx context.Context, endpoint string, opts ...Option) ([]*ua.EndpointDescription, error) {
+	opts = append(opts, AutoReconnect(false))
+	c := NewClient(endpoint, opts...)
 	if err := c.Dial(ctx); err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -464,7 +464,7 @@ func (c *Client) Dial(ctx context.Context) error {
 	}
 
 	var err error
-	c.conn, err = uacp.Dial(ctx, c.endpointURL)
+	c.conn, err = c.cfg.Dialer().Dial(ctx, c.endpointURL)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -87,11 +87,8 @@ type Client struct {
 	// endpointURL is the endpoint URL the client connects to.
 	endpointURL string
 
-	// cfg is the configuration for the secure channel.
-	cfg *uasc.Config
-
-	// sessionCfg is the configuration for the session.
-	sessionCfg *uasc.SessionConfig
+	// cfg is the configuration for the client.
+	cfg *Config
 
 	// conn is the open connection
 	conn *uacp.Conn
@@ -139,11 +136,10 @@ type Client struct {
 //
 // https://godoc.org/github.com/gopcua/opcua#Option
 func NewClient(endpoint string, opts ...Option) *Client {
-	cfg, sessionCfg := ApplyConfig(opts...)
+	cfg := ApplyConfig(opts...)
 	c := Client{
 		endpointURL: endpoint,
 		cfg:         cfg,
-		sessionCfg:  sessionCfg,
 		sechanErr:   make(chan error, 1),
 		subs:        make(map[uint32]*Subscription),
 		pausech:     make(chan struct{}, 2),
@@ -180,7 +176,7 @@ func (c *Client) Connect(ctx context.Context) (err error) {
 	if err := c.Dial(ctx); err != nil {
 		return err
 	}
-	s, err := c.CreateSession(c.sessionCfg)
+	s, err := c.CreateSession(c.cfg.session)
 	if err != nil {
 		_ = c.Close()
 		return err
@@ -228,7 +224,7 @@ func (c *Client) monitor(ctx context.Context) {
 			c.state.Store(Disconnected)
 			dlog.Print("disconnected")
 
-			if !c.cfg.AutoReconnect {
+			if !c.cfg.sechan.AutoReconnect {
 				// the connection is closed and should not be restored
 				action = abortReconnect
 				dlog.Print("auto-reconnect disabled")
@@ -315,7 +311,7 @@ func (c *Client) monitor(ctx context.Context) {
 								select {
 								case <-ctx.Done():
 									return
-								case <-time.After(c.cfg.ReconnectInterval):
+								case <-time.After(c.cfg.sechan.ReconnectInterval):
 									dlog.Printf("trying to recreate secure channel")
 									continue
 								}
@@ -352,7 +348,7 @@ func (c *Client) monitor(ctx context.Context) {
 						// create a new session to replace the previous one
 
 						dlog.Printf("trying to recreate session")
-						s, err := c.CreateSession(c.sessionCfg)
+						s, err := c.CreateSession(c.cfg.session)
 						if err != nil {
 							dlog.Printf("recreate session failed: %v", err)
 							action = createSecureChannel
@@ -473,7 +469,7 @@ func (c *Client) Dial(ctx context.Context) error {
 		return err
 	}
 
-	c.sechan, err = uasc.NewSecureChannel(c.endpointURL, c.conn, c.cfg, c.sechanErr)
+	c.sechan, err = uasc.NewSecureChannel(c.endpointURL, c.conn, c.cfg.sechan, c.sechanErr)
 	if err != nil {
 		_ = c.conn.Close()
 		return err
@@ -563,7 +559,7 @@ func (c *Client) CreateSession(cfg *uasc.SessionConfig) (*Session, error) {
 		EndpointURL:             c.endpointURL,
 		SessionName:             name,
 		ClientNonce:             nonce,
-		ClientCertificate:       c.cfg.Certificate,
+		ClientCertificate:       c.cfg.sechan.Certificate,
 		RequestedSessionTimeout: float64(cfg.SessionTimeout / time.Millisecond),
 	}
 
@@ -583,13 +579,13 @@ func (c *Client) CreateSession(cfg *uasc.SessionConfig) (*Session, error) {
 		}
 
 		// Ensure we have a valid identity token that the server will accept before trying to activate a session
-		if c.sessionCfg.UserIdentityToken == nil {
+		if c.cfg.session.UserIdentityToken == nil {
 			opt := AuthAnonymous()
-			opt(c.cfg, c.sessionCfg)
+			opt(c.cfg)
 
 			p := anonymousPolicyID(res.ServerEndpoints)
 			opt = AuthPolicyID(p)
-			opt(c.cfg, c.sessionCfg)
+			opt(c.cfg)
 		}
 
 		s = &Session{
@@ -731,7 +727,7 @@ func (c *Client) DetachSession() (*Session, error) {
 // the response. If the client has an active session it injects the
 // authentication token.
 func (c *Client) Send(req ua.Request, h func(interface{}) error) error {
-	return c.sendWithTimeout(req, c.cfg.RequestTimeout, h)
+	return c.sendWithTimeout(req, c.cfg.sechan.RequestTimeout, h)
 }
 
 // sendWithTimeout sends the request via the secure channel with a custom timeout and registers a handler for

--- a/client.go
+++ b/client.go
@@ -465,7 +465,8 @@ func (c *Client) Dial(ctx context.Context) error {
 	}
 
 	var err error
-	c.conn, err = c.cfg.Dialer().Dial(ctx, c.endpointURL)
+	var d = NewDialer(c.cfg)
+	c.conn, err = d.Dial(ctx, c.endpointURL)
 	if err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -54,7 +54,7 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 // Config contains all config options.
 type Config struct {
 	dialer      *uacp.Dialer
-	dialTimeout time.Duration
+	dialTimeout *time.Duration
 	sechan      *uasc.Config
 	session     *uasc.SessionConfig
 }
@@ -68,11 +68,8 @@ func NewDialer(cfg *Config) *uacp.Dialer {
 	if d.Dialer == nil {
 		d.Dialer = &net.Dialer{}
 	}
-	if cfg.dialTimeout > 0 {
-		d.Dialer.Timeout = cfg.dialTimeout
-	}
-	if d.Dialer.Timeout == 0 {
-		d.Dialer.Timeout = cfg.sechan.RequestTimeout
+	if cfg.dialTimeout != nil {
+		d.Dialer.Timeout = *cfg.dialTimeout
 	}
 	return d
 }
@@ -471,9 +468,9 @@ func Dialer(d *uacp.Dialer) Option {
 }
 
 // DialTimeout sets the timeout for establishing the UACP connection.
-// Defaults to the RequestTimeout.
+// Defaults to DefaultDialTimeout. Set to zero for no timeout.
 func DialTimeout(d time.Duration) Option {
 	return func(cfg *Config) {
-		cfg.dialTimeout = d
+		cfg.dialTimeout = &d
 	}
 }

--- a/config.go
+++ b/config.go
@@ -59,19 +59,20 @@ type Config struct {
 	session     *uasc.SessionConfig
 }
 
-func (c *Config) Dialer() *uacp.Dialer {
-	d := c.dialer
+// NewDialer creates a uacp.Dialer from the config options
+func NewDialer(cfg *Config) *uacp.Dialer {
+	d := cfg.dialer
 	if d == nil {
 		d = &uacp.Dialer{}
 	}
 	if d.Dialer == nil {
 		d.Dialer = &net.Dialer{}
 	}
-	if c.dialTimeout > 0 {
-		d.Dialer.Timeout = c.dialTimeout
+	if cfg.dialTimeout > 0 {
+		d.Dialer.Timeout = cfg.dialTimeout
 	}
 	if d.Dialer.Timeout == 0 {
-		d.Dialer.Timeout = c.sechan.RequestTimeout
+		d.Dialer.Timeout = cfg.sechan.RequestTimeout
 	}
 	return d
 }

--- a/config.go
+++ b/config.go
@@ -49,142 +49,150 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 	}
 }
 
+// Config contains all config options.
+type Config struct {
+	sechan  *uasc.Config
+	session *uasc.SessionConfig
+}
+
 // ApplyConfig applies the config options to the default configuration.
 // todo(fs): Can we find a better name?
-func ApplyConfig(opts ...Option) (*uasc.Config, *uasc.SessionConfig) {
-	c := DefaultClientConfig()
-	sc := DefaultSessionConfig()
-	for _, opt := range opts {
-		opt(c, sc)
+func ApplyConfig(opts ...Option) *Config {
+	cfg := &Config{
+		sechan:  DefaultClientConfig(),
+		session: DefaultSessionConfig(),
 	}
-	return c, sc
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
 }
 
 // Option is an option function type to modify the configuration.
-type Option func(*uasc.Config, *uasc.SessionConfig)
+type Option func(*Config)
 
 // ApplicationName sets the application name in the session configuration.
 func ApplicationName(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.ClientDescription.ApplicationName = ua.NewLocalizedText(s)
+	return func(cfg *Config) {
+		cfg.session.ClientDescription.ApplicationName = ua.NewLocalizedText(s)
 	}
 }
 
 // ApplicationURI sets the application uri in the session configuration.
 func ApplicationURI(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.ClientDescription.ApplicationURI = s
+	return func(cfg *Config) {
+		cfg.session.ClientDescription.ApplicationURI = s
 	}
 }
 
 // AutoReconnect sets the auto reconnect state of the secure channel.
 func AutoReconnect(b bool) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.AutoReconnect = b
+	return func(cfg *Config) {
+		cfg.sechan.AutoReconnect = b
 	}
 }
 
 // ReconnectInterval is interval duration between each reconnection attempt.
 func ReconnectInterval(d time.Duration) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.ReconnectInterval = d
+	return func(cfg *Config) {
+		cfg.sechan.ReconnectInterval = d
 	}
 }
 
 // Lifetime sets the lifetime of the secure channel in milliseconds.
 func Lifetime(d time.Duration) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.Lifetime = uint32(d / time.Millisecond)
+	return func(cfg *Config) {
+		cfg.sechan.Lifetime = uint32(d / time.Millisecond)
 	}
 }
 
 // Locales sets the locales in the session configuration.
 func Locales(locale ...string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.LocaleIDs = locale
+	return func(cfg *Config) {
+		cfg.session.LocaleIDs = locale
 	}
 }
 
 // ProductURI sets the product uri in the session configuration.
 func ProductURI(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.ClientDescription.ProductURI = s
+	return func(cfg *Config) {
+		cfg.session.ClientDescription.ProductURI = s
 	}
 }
 
 // RandomRequestID assigns a random initial request id.
 func RandomRequestID() Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.RequestIDSeed = uint32(rand.Int31())
+	return func(cfg *Config) {
+		cfg.sechan.RequestIDSeed = uint32(rand.Int31())
 	}
 }
 
 // RemoteCertificate sets the server certificate.
 func RemoteCertificate(cert []byte) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.RemoteCertificate = cert
+	return func(cfg *Config) {
+		cfg.sechan.RemoteCertificate = cert
 	}
 }
 
 // RemoteCertificateFile sets the server certificate from the file
 // in PEM or DER encoding.
 func RemoteCertificateFile(filename string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+	return func(cfg *Config) {
 		cert, err := loadCertificate(filename)
 		if err != nil {
 			log.Fatal(err)
 		}
-		c.RemoteCertificate = cert
+		cfg.sechan.RemoteCertificate = cert
 	}
 }
 
 // SecurityMode sets the security mode for the secure channel.
 func SecurityMode(m ua.MessageSecurityMode) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.SecurityMode = m
+	return func(cfg *Config) {
+		cfg.sechan.SecurityMode = m
 	}
 }
 
 // SecurityModeString sets the security mode for the secure channel.
 // Valid values are "None", "Sign", and "SignAndEncrypt".
 func SecurityModeString(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.SecurityMode = ua.MessageSecurityModeFromString(s)
+	return func(cfg *Config) {
+		cfg.sechan.SecurityMode = ua.MessageSecurityModeFromString(s)
 	}
 }
 
 // SecurityPolicy sets the security policy uri for the secure channel.
 func SecurityPolicy(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.SecurityPolicyURI = ua.FormatSecurityPolicyURI(s)
+	return func(cfg *Config) {
+		cfg.sechan.SecurityPolicyURI = ua.FormatSecurityPolicyURI(s)
 	}
 }
 
 // SessionName sets the name in the session configuration.
 func SessionName(s string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.SessionName = s
+	return func(cfg *Config) {
+		cfg.session.SessionName = s
 	}
 }
 
 // SessionTimeout sets the timeout in the session configuration.
 func SessionTimeout(d time.Duration) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		sc.SessionTimeout = d
+	return func(cfg *Config) {
+		cfg.session.SessionTimeout = d
 	}
 }
 
 // PrivateKey sets the RSA private key in the secure channel configuration.
 func PrivateKey(key *rsa.PrivateKey) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.LocalKey = key
+	return func(cfg *Config) {
+		cfg.sechan.LocalKey = key
 	}
 }
 
 // PrivateKeyFile sets the RSA private key in the secure channel configuration
 // from a PEM or DER encoded file.
 func PrivateKeyFile(filename string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+	return func(cfg *Config) {
 		if filename == "" {
 			return
 		}
@@ -192,7 +200,7 @@ func PrivateKeyFile(filename string) Option {
 		if err != nil {
 			log.Fatal(err)
 		}
-		c.LocalKey = key
+		cfg.sechan.LocalKey = key
 	}
 }
 
@@ -221,8 +229,8 @@ func loadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 // Certificate sets the client X509 certificate in the secure channel configuration.
 // It also detects and sets the ApplicationURI from the URI within the certificate.
 func Certificate(cert []byte) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		setCertificate(cert, c, sc)
+	return func(cfg *Config) {
+		setCertificate(cert, cfg)
 	}
 }
 
@@ -230,7 +238,7 @@ func Certificate(cert []byte) Option {
 // from the PEM or DER encoded file. It also detects and sets the ApplicationURI
 // from the URI within the certificate.
 func CertificateFile(filename string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
+	return func(cfg *Config) {
 		if filename == "" {
 			return
 		}
@@ -239,7 +247,7 @@ func CertificateFile(filename string) Option {
 		if err != nil {
 			log.Fatal(err)
 		}
-		setCertificate(cert, c, sc)
+		setCertificate(cert, cfg)
 	}
 }
 
@@ -260,8 +268,8 @@ func loadCertificate(filename string) ([]byte, error) {
 	return block.Bytes, nil
 }
 
-func setCertificate(cert []byte, c *uasc.Config, sc *uasc.SessionConfig) {
-	c.Certificate = cert
+func setCertificate(cert []byte, cfg *Config) {
+	cfg.sechan.Certificate = cert
 
 	// Extract the application URI from the certificate.
 	x509cert, err := x509.ParseCertificate(cert)
@@ -276,44 +284,44 @@ func setCertificate(cert []byte, c *uasc.Config, sc *uasc.SessionConfig) {
 	if appURI == "" {
 		return
 	}
-	sc.ClientDescription.ApplicationURI = appURI
+	cfg.session.ClientDescription.ApplicationURI = appURI
 }
 
 // SecurityFromEndpoint sets the server-related security parameters from
 // a chosen endpoint (received from GetEndpoints())
 func SecurityFromEndpoint(ep *ua.EndpointDescription, authType ua.UserTokenType) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.SecurityPolicyURI = ep.SecurityPolicyURI
-		c.SecurityMode = ep.SecurityMode
-		c.RemoteCertificate = ep.ServerCertificate
-		c.Thumbprint = uapolicy.Thumbprint(ep.ServerCertificate)
+	return func(cfg *Config) {
+		cfg.sechan.SecurityPolicyURI = ep.SecurityPolicyURI
+		cfg.sechan.SecurityMode = ep.SecurityMode
+		cfg.sechan.RemoteCertificate = ep.ServerCertificate
+		cfg.sechan.Thumbprint = uapolicy.Thumbprint(ep.ServerCertificate)
 
 		for _, t := range ep.UserIdentityTokens {
 			if t.TokenType != authType {
 				continue
 			}
 
-			if sc.UserIdentityToken == nil {
+			if cfg.session.UserIdentityToken == nil {
 				switch authType {
 				case ua.UserTokenTypeAnonymous:
-					sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
+					cfg.session.UserIdentityToken = &ua.AnonymousIdentityToken{}
 				case ua.UserTokenTypeUserName:
-					sc.UserIdentityToken = &ua.UserNameIdentityToken{}
+					cfg.session.UserIdentityToken = &ua.UserNameIdentityToken{}
 				case ua.UserTokenTypeCertificate:
-					sc.UserIdentityToken = &ua.X509IdentityToken{}
+					cfg.session.UserIdentityToken = &ua.X509IdentityToken{}
 				case ua.UserTokenTypeIssuedToken:
-					sc.UserIdentityToken = &ua.IssuedIdentityToken{}
+					cfg.session.UserIdentityToken = &ua.IssuedIdentityToken{}
 				}
 			}
 
-			setPolicyID(sc.UserIdentityToken, t.PolicyID)
-			sc.AuthPolicyURI = t.SecurityPolicyURI
+			setPolicyID(cfg.session.UserIdentityToken, t.PolicyID)
+			cfg.session.AuthPolicyURI = t.SecurityPolicyURI
 			return
 		}
 
-		if sc.UserIdentityToken == nil {
-			sc.UserIdentityToken = &ua.AnonymousIdentityToken{PolicyID: defaultAnonymousPolicyID}
-			sc.AuthPolicyURI = ua.SecurityPolicyURINone
+		if cfg.session.UserIdentityToken == nil {
+			cfg.session.UserIdentityToken = &ua.AnonymousIdentityToken{PolicyID: defaultAnonymousPolicyID}
+			cfg.session.AuthPolicyURI = ua.SecurityPolicyURINone
 		}
 	}
 }
@@ -338,12 +346,12 @@ func setPolicyID(t interface{}, policy string) {
 // todo(fs): AuthXXX methods since this approach requires context
 // todo(fs): and ordering?
 func AuthPolicyID(policy string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		if sc.UserIdentityToken == nil {
+	return func(cfg *Config) {
+		if cfg.session.UserIdentityToken == nil {
 			log.Printf("policy ID needs to be set after the policy type is chosen, no changes made.  Call SecurityFromEndpoint() or an AuthXXX() option first")
 			return
 		}
-		setPolicyID(sc.UserIdentityToken, policy)
+		setPolicyID(cfg.session.UserIdentityToken, policy)
 	}
 }
 
@@ -351,12 +359,12 @@ func AuthPolicyID(policy string) Option {
 // Note: PolicyID still needs to be set outside of this method, typically through
 // the SecurityFromEndpoint() Option
 func AuthAnonymous() Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		if sc.UserIdentityToken == nil {
-			sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
+	return func(cfg *Config) {
+		if cfg.session.UserIdentityToken == nil {
+			cfg.session.UserIdentityToken = &ua.AnonymousIdentityToken{}
 		}
 
-		_, ok := sc.UserIdentityToken.(*ua.AnonymousIdentityToken)
+		_, ok := cfg.session.UserIdentityToken.(*ua.AnonymousIdentityToken)
 		if !ok {
 			// todo(fs): should we Fatal here?
 			log.Printf("non-anonymous authentication already configured, ignoring")
@@ -369,12 +377,12 @@ func AuthAnonymous() Option {
 // Note: PolicyID still needs to be set outside of this method, typically through
 // the SecurityFromEndpoint() Option
 func AuthUsername(user, pass string) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		if sc.UserIdentityToken == nil {
-			sc.UserIdentityToken = &ua.UserNameIdentityToken{}
+	return func(cfg *Config) {
+		if cfg.session.UserIdentityToken == nil {
+			cfg.session.UserIdentityToken = &ua.UserNameIdentityToken{}
 		}
 
-		t, ok := sc.UserIdentityToken.(*ua.UserNameIdentityToken)
+		t, ok := cfg.session.UserIdentityToken.(*ua.UserNameIdentityToken)
 		if !ok {
 			// todo(fs): should we Fatal here?
 			log.Printf("non-username authentication already configured, ignoring")
@@ -382,7 +390,7 @@ func AuthUsername(user, pass string) Option {
 		}
 
 		t.UserName = user
-		sc.AuthPassword = pass
+		cfg.session.AuthPassword = pass
 	}
 }
 
@@ -390,12 +398,12 @@ func AuthUsername(user, pass string) Option {
 // Note: PolicyID still needs to be set outside of this method, typically through
 // the SecurityFromEndpoint() Option
 func AuthCertificate(cert []byte) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		if sc.UserIdentityToken == nil {
-			sc.UserIdentityToken = &ua.X509IdentityToken{}
+	return func(cfg *Config) {
+		if cfg.session.UserIdentityToken == nil {
+			cfg.session.UserIdentityToken = &ua.X509IdentityToken{}
 		}
 
-		t, ok := sc.UserIdentityToken.(*ua.X509IdentityToken)
+		t, ok := cfg.session.UserIdentityToken.(*ua.X509IdentityToken)
 		if !ok {
 			// todo(fs): should we Fatal here?
 			log.Printf("non-certificate authentication already configured, ignoring")
@@ -410,12 +418,12 @@ func AuthCertificate(cert []byte) Option {
 // Note: PolicyID still needs to be set outside of this method, typically through
 // the SecurityFromEndpoint() Option
 func AuthIssuedToken(tokenData []byte) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		if sc.UserIdentityToken == nil {
-			sc.UserIdentityToken = &ua.IssuedIdentityToken{}
+	return func(cfg *Config) {
+		if cfg.session.UserIdentityToken == nil {
+			cfg.session.UserIdentityToken = &ua.IssuedIdentityToken{}
 		}
 
-		t, ok := sc.UserIdentityToken.(*ua.IssuedIdentityToken)
+		t, ok := cfg.session.UserIdentityToken.(*ua.IssuedIdentityToken)
 		if !ok {
 			log.Printf("non-issued token authentication already configured, ignoring")
 			return
@@ -428,7 +436,7 @@ func AuthIssuedToken(tokenData []byte) Option {
 
 // RequestTimeout sets the timeout for all requests over SecureChannel
 func RequestTimeout(t time.Duration) Option {
-	return func(c *uasc.Config, sc *uasc.SessionConfig) {
-		c.RequestTimeout = t
+	return func(cfg *Config) {
+		cfg.sechan.RequestTimeout = t
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -153,192 +153,229 @@ func TestOptions(t *testing.T) {
 	tests := []struct {
 		name string
 		opt  Option
-		c    *uasc.Config
-		sc   *uasc.SessionConfig
+		cfg  *Config
 	}{
 		{
 			name: `ApplicationName("a")`,
 			opt:  ApplicationName("a"),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.ClientDescription.ApplicationName = ua.NewLocalizedText("a")
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.ClientDescription.ApplicationName = ua.NewLocalizedText("a")
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `ApplicationURI("a")`,
 			opt:  ApplicationURI("a"),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.ClientDescription.ApplicationURI = "a"
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.ClientDescription.ApplicationURI = "a"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `AuthAnonymous()`,
 			opt:  AuthAnonymous(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `AuthCertificate()`,
 			opt:  AuthCertificate(certDER),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.X509IdentityToken{
-					CertificateData: certDER,
-				}
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.X509IdentityToken{
+						CertificateData: certDER,
+					}
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `AuthIssuedToken()`,
 			opt:  AuthIssuedToken([]byte("a")),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.IssuedIdentityToken{
-					TokenData: []byte("a"),
-				}
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.IssuedIdentityToken{
+						TokenData: []byte("a"),
+					}
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `AuthUsername()`,
 			opt:  AuthUsername("user", "pass"),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.UserNameIdentityToken{
-					UserName: "user",
-				}
-				sc.AuthPassword = "pass"
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.UserNameIdentityToken{
+						UserName: "user",
+					}
+					sc.AuthPassword = "pass"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `Certificate`,
 			opt:  Certificate(certDER),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.Certificate = certDER
-				// todo(fs): test with cert that has a URI
-				// sc.ClientDescription.ApplicationURI = ...
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.Certificate = certDER
+					// todo(fs): test with cert that has a URI
+					// sc.ClientDescription.ApplicationURI = ...
+					return c
+				}(),
+			},
 		},
 		{
 			name: `CertificateFile("cert.der")`,
 			opt:  CertificateFile(certDERFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.Certificate = certDER
-				// todo(fs): test with cert that has a URI
-				// sc.ClientDescription.ApplicationURI = ...
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.Certificate = certDER
+					// todo(fs): test with cert that has a URI
+					// sc.ClientDescription.ApplicationURI = ...
+					return c
+				}(),
+			},
 		},
 		{
 			name: `CertificateFile("cert.pem")`,
 			opt:  CertificateFile(certPEMFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.Certificate = certDER
-				// todo(fs): test with cert that has a URI
-				// sc.ClientDescription.ApplicationURI = ...
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.Certificate = certDER
+					// todo(fs): test with cert that has a URI
+					// sc.ClientDescription.ApplicationURI = ...
+					return c
+				}(),
+			},
 		},
 		{
 			name: `Lifetime(10ms)`,
 			opt:  Lifetime(10 * time.Millisecond),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.Lifetime = 10
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.Lifetime = 10
+					return c
+				}(),
+			},
 		},
 		{
 			name: `Locales("en-us", "de-de")`,
 			opt:  Locales("en-us", "de-de"),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.LocaleIDs = []string{"en-us", "de-de"}
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.LocaleIDs = []string{"en-us", "de-de"}
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `PrivateKey()`,
 			opt:  PrivateKey(cert.PrivateKey.(*rsa.PrivateKey)),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
+					return c
+				}(),
+			},
 		},
 		{
 			name: `PrivateKeyFile("key.der")`,
 			opt:  PrivateKeyFile(keyDERFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
+					return c
+				}(),
+			},
 		},
 		{
 			name: `PrivateKeyFile("key.pem")`,
 			opt:  PrivateKeyFile(keyPEMFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.LocalKey = cert.PrivateKey.(*rsa.PrivateKey)
+					return c
+				}(),
+			},
 		},
 		{
 			name: `ProductURI("a")`,
 			opt:  ProductURI("a"),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.ClientDescription.ProductURI = "a"
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.ClientDescription.ProductURI = "a"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `RemoteCertificate`,
 			opt:  RemoteCertificate(certDER),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.RemoteCertificate = certDER
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.RemoteCertificate = certDER
+					return c
+				}(),
+			},
 		},
 		{
 			name: `RemoteCertificateFile("cert.der")`,
 			opt:  RemoteCertificateFile(certDERFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.RemoteCertificate = certDER
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.RemoteCertificate = certDER
+					return c
+				}(),
+			},
 		},
 		{
 			name: `RemoteCertificateFile("cert.pem")`,
 			opt:  RemoteCertificateFile(certPEMFile),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.RemoteCertificate = certDER
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.RemoteCertificate = certDER
+					return c
+				}(),
+			},
 		},
 		{
 			name: `RequestTimeout(5s)`,
 			opt:  RequestTimeout(5 * time.Second),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.RequestTimeout = 5 * time.Second
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.RequestTimeout = 5 * time.Second
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityFromEndpoint(no-match)`,
@@ -347,219 +384,250 @@ func TestOptions(t *testing.T) {
 				SecurityMode:      5,
 				ServerCertificate: certDER,
 			}, 0),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = "a"
-				c.SecurityMode = 5
-				c.RemoteCertificate = certDER
-				c.Thumbprint = uapolicy.Thumbprint(certDER)
-				return c
-			}(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.AnonymousIdentityToken{
-					PolicyID: defaultAnonymousPolicyID,
-				}
-				sc.AuthPolicyURI = ua.SecurityPolicyURINone
-				return sc
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "a"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.AnonymousIdentityToken{
+						PolicyID: defaultAnonymousPolicyID,
+					}
+					sc.AuthPolicyURI = ua.SecurityPolicyURINone
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `SecurityFromEndpoint(anonymous)`,
 			opt:  SecurityFromEndpoint(endpoints[0], ua.UserTokenTypeAnonymous),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = "a"
-				c.SecurityMode = 5
-				c.RemoteCertificate = certDER
-				c.Thumbprint = uapolicy.Thumbprint(certDER)
-				return c
-			}(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
-				sc.AuthPolicyURI = "b"
-				return sc
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "a"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.AnonymousIdentityToken{}
+					sc.AuthPolicyURI = "b"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `SecurityFromEndpoint(username)`,
 			opt:  SecurityFromEndpoint(endpoints[1], ua.UserTokenTypeUserName),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = "a"
-				c.SecurityMode = 5
-				c.RemoteCertificate = certDER
-				c.Thumbprint = uapolicy.Thumbprint(certDER)
-				return c
-			}(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.UserNameIdentityToken{}
-				sc.AuthPolicyURI = "b"
-				return sc
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "a"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.UserNameIdentityToken{}
+					sc.AuthPolicyURI = "b"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `SecurityFromEndpoint(certificate)`,
 			opt:  SecurityFromEndpoint(endpoints[2], ua.UserTokenTypeCertificate),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = "a"
-				c.SecurityMode = 5
-				c.RemoteCertificate = certDER
-				c.Thumbprint = uapolicy.Thumbprint(certDER)
-				return c
-			}(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.X509IdentityToken{}
-				sc.AuthPolicyURI = "b"
-				return sc
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "a"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.X509IdentityToken{}
+					sc.AuthPolicyURI = "b"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `SecurityFromEndpoint(token)`,
 			opt:  SecurityFromEndpoint(endpoints[3], ua.UserTokenTypeIssuedToken),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = "a"
-				c.SecurityMode = 5
-				c.RemoteCertificate = certDER
-				c.Thumbprint = uapolicy.Thumbprint(certDER)
-				return c
-			}(),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.UserIdentityToken = &ua.IssuedIdentityToken{}
-				sc.AuthPolicyURI = "b"
-				return sc
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "a"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.IssuedIdentityToken{}
+					sc.AuthPolicyURI = "b"
+					return sc
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("None")`,
 			opt:  SecurityPolicy("None"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURINone
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURINone
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityMode(Sign)`,
 			opt:  SecurityMode(ua.MessageSecurityModeSign),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityMode = ua.MessageSecurityModeSign
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityMode = ua.MessageSecurityModeSign
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityModeString("bad")`,
 			opt:  SecurityModeString("bad"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityMode = ua.MessageSecurityModeInvalid
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityMode = ua.MessageSecurityModeInvalid
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityModeString("None")`,
 			opt:  SecurityModeString("None"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityMode = ua.MessageSecurityModeNone
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityMode = ua.MessageSecurityModeNone
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityModeString("Sign")`,
 			opt:  SecurityModeString("Sign"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityMode = ua.MessageSecurityModeSign
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityMode = ua.MessageSecurityModeSign
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityModeString("SignAndEncrypt")`,
 			opt:  SecurityModeString("SignAndEncrypt"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("Basic128Rsa15")`,
 			opt:  SecurityPolicy("Basic128Rsa15"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURIBasic128Rsa15
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURIBasic128Rsa15
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("Basic256")`,
 			opt:  SecurityPolicy("Basic256"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURIBasic256
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURIBasic256
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("Basic256Sha256")`,
 			opt:  SecurityPolicy("Basic256Sha256"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURIBasic256Sha256
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURIBasic256Sha256
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("Aes128_Sha256_RsaOaep")`,
 			opt:  SecurityPolicy("Aes128_Sha256_RsaOaep"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURIAes128Sha256RsaOaep
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURIAes128Sha256RsaOaep
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SecurityPolicy("Aes256_Sha256_RsaPss")`,
 			opt:  SecurityPolicy("Aes256_Sha256_RsaPss"),
-			c: func() *uasc.Config {
-				c := DefaultClientConfig()
-				c.SecurityPolicyURI = ua.SecurityPolicyURIAes256Sha256RsaPss
-				return c
-			}(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = ua.SecurityPolicyURIAes256Sha256RsaPss
+					return c
+				}(),
+			},
 		},
 		{
 			name: `SessionTimeout(5s)`,
 			opt:  SessionTimeout(5 * time.Second),
-			sc: func() *uasc.SessionConfig {
-				sc := DefaultSessionConfig()
-				sc.SessionTimeout = 5 * time.Second
-				return sc
-			}(),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.SessionTimeout = 5 * time.Second
+					return sc
+				}(),
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ttc := tt.c
-			if ttc == nil {
-				ttc = DefaultClientConfig()
+			if tt.cfg.sechan == nil {
+				tt.cfg.sechan = DefaultClientConfig()
 			}
-			ttsc := tt.sc
-			if ttsc == nil {
-				ttsc = DefaultSessionConfig()
+			if tt.cfg.session == nil {
+				tt.cfg.session = DefaultSessionConfig()
 			}
 
-			c, sc := ApplyConfig(tt.opt)
-			verify.Values(t, "", c, ttc)
-			verify.Values(t, "", sc, ttsc)
+			cfg := ApplyConfig(tt.opt)
+			verify.Values(t, "", cfg, tt.cfg)
 		})
 	}
 }

--- a/subscription.go
+++ b/subscription.go
@@ -180,8 +180,8 @@ func (s *Subscription) publishTimeout() time.Duration {
 	if timeout > uasc.MaxTimeout {
 		return uasc.MaxTimeout
 	}
-	if timeout < s.c.cfg.RequestTimeout {
-		return s.c.cfg.RequestTimeout
+	if timeout < s.c.cfg.sechan.RequestTimeout {
+		return s.c.cfg.sechan.RequestTimeout
 	}
 	return timeout
 }


### PR DESCRIPTION
This patch makes the `uacp.Dialer` configurable and allows to configure the dial timeout for establishing the uucp connection.

Fixes #464