### PR TITLE
guard against double close

### DIFF
--- a/client.go
+++ b/client.go
@@ -299,6 +299,14 @@ func (c *Client) monitor(ctx context.Context) {
 						// a reconnection to the server
 
 						// close previous secure channel
+						//
+						// todo(fs): the two calls to Close() trigger a double-close on both the
+						// todo(fs): secure channel and the UACP connection. I have guarded for this
+						// todo(fs): with a sync.Once but that feels like a band-aid. We need to investigate
+						// todo(fs): why we are trying to create a new secure channel when we shut the client
+						// todo(fs): down.
+						//
+						// https://github.com/gopcua/opcua/pull/470
 						_ = c.conn.Close()
 						c.sechan.Close()
 						c.sechan = nil

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -811,6 +811,8 @@ func (s *SecureChannel) nextRequestID() uint32 {
 
 // Close closes an existing secure channel
 func (s *SecureChannel) Close() (err error) {
+	// https://github.com/gopcua/opcua/pull/470
+	// guard against double close until we found the root cause
 	err = io.EOF
 	s.closeOnce.Do(func() { err = s.close() })
 	return


### PR DESCRIPTION
This patch guards the Close() method of the secure channel to be called
more than once. This seems like a workaround I would like to remove once
we understand the root cause of the problem.

Fixes #430