### PR TITLE
Introduce test for Panic

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,9 +1,10 @@
 package opcua
 
 import (
+	"testing"
+
 	"github.com/gopcua/opcua/ua"
 	"github.com/pascaldekloe/goe/verify"
-	"testing"
 )
 
 func TestClient_Send_DoesNotPanicWhenDisconnected(t *testing.T) {
@@ -12,4 +13,9 @@ func TestClient_Send_DoesNotPanicWhenDisconnected(t *testing.T) {
 		return nil
 	})
 	verify.Values(t, "", err, ua.StatusBadServerNotConnected)
+}
+
+func TestClient_NewClientCanBeClosed(t *testing.T) {
+	c := NewClient("opc.tcp://example.com:4840")
+	c.Close()
 }


### PR DESCRIPTION
If we create a client and we close it immediately after, without actually connect it, the program panics.