### PR TITLE
Use ERN formula instead of OPCUA formula

### DIFF
--- a/uasc/message.go
+++ b/uasc/message.go
@@ -5,6 +5,8 @@
 package uasc
 
 import (
+	"math"
+
 	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/ua"
 )
@@ -111,25 +113,74 @@ func (m *Message) Decode(b []byte) (int, error) {
 }
 
 func (m *Message) Encode() ([]byte, error) {
-	body := ua.NewBuffer(nil)
+	chunks, err := m.EncodeChunks(math.MaxUint32)
+	if err != nil {
+		return nil, err
+	}
+	return chunks[0], nil
+}
+
+func (m *Message) EncodeChunks(maxBodySize uint32) ([][]byte, error) {
+	dataBody := ua.NewBuffer(nil)
+	dataBody.WriteStruct(m.TypeID)
+	dataBody.WriteStruct(m.Service)
+
+	if dataBody.Error() != nil {
+		return nil, dataBody.Error()
+	}
+
+	nrChunks := uint32(dataBody.Len())/(maxBodySize) + 1
+	chunks := make([][]byte, nrChunks)
+
 	switch m.Header.MessageType {
 	case "OPN":
-		body.WriteStruct(m.AsymmetricSecurityHeader)
+		partialHeader := ua.NewBuffer(nil)
+		partialHeader.WriteStruct(m.AsymmetricSecurityHeader)
+		partialHeader.WriteStruct(m.SequenceHeader)
+
+		if partialHeader.Error() != nil {
+			return nil, partialHeader.Error()
+		}
+
+		m.Header.MessageSize = uint32(12 + partialHeader.Len() + dataBody.Len())
+		buf := ua.NewBuffer(nil)
+		buf.WriteStruct(m.Header)
+		buf.Write(partialHeader.Bytes())
+		buf.Write(dataBody.Bytes())
+
+		return [][]byte{buf.Bytes()}, buf.Error()
+
 	case "CLO", "MSG":
-		body.WriteStruct(m.SymmetricSecurityHeader)
+
+		for i := uint32(0); i < nrChunks-1; i++ {
+			m.Header.MessageSize = maxBodySize + 24
+			m.Header.ChunkType = ChunkTypeIntermediate
+			chunk := ua.NewBuffer(nil)
+			chunk.WriteStruct(m.Header)
+			chunk.WriteStruct(m.SymmetricSecurityHeader)
+			chunk.WriteStruct(m.SequenceHeader)
+			chunk.Write(dataBody.ReadN(int(maxBodySize)))
+			if chunk.Error() != nil {
+				return nil, chunk.Error()
+			}
+
+			chunks[i] = chunk.Bytes()
+		}
+
+		m.Header.ChunkType = ChunkTypeFinal
+		m.Header.MessageSize = uint32(24 + dataBody.Len())
+		chunk := ua.NewBuffer(nil)
+		chunk.WriteStruct(m.Header)
+		chunk.WriteStruct(m.SymmetricSecurityHeader)
+		chunk.WriteStruct(m.SequenceHeader)
+		chunk.Write(dataBody.Bytes())
+		if chunk.Error() != nil {
+			return nil, chunk.Error()
+		}
+
+		chunks[nrChunks-1] = chunk.Bytes()
+		return chunks, nil
 	default:
 		return nil, errors.Errorf("invalid message type %q", m.Header.MessageType)
 	}
-	body.WriteStruct(m.SequenceHeader)
-	body.WriteStruct(m.TypeID)
-	body.WriteStruct(m.Service)
-	if body.Error() != nil {
-		return nil, body.Error()
-	}
-
-	m.Header.MessageSize = uint32(12 + body.Len())
-	buf := ua.NewBuffer(nil)
-	buf.WriteStruct(m.Header)
-	buf.Write(body.Bytes())
-	return buf.Bytes(), buf.Error()
 }

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -35,10 +35,10 @@ type channelInstance struct {
 	algo            *uapolicy.EncryptionAlgorithm
 	maxBodySize     uint32
 
-	messagesSent uint32
-	// messagesReceived uint32
-	bytesSent uint64
+	bytesSent uint64 // atomic.Load/Store - needs to be aligned for 32bit systems
 	// bytesReceived    uint64
+	messagesSent uint32 // atomic.Load/Store
+	// messagesReceived uint32
 }
 
 func newChannelInstance(sc *SecureChannel) *channelInstance {

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -137,15 +137,16 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	symmetricAlgorithmHeader := 4
 
 	// this is the formula proposed by OPCUA - source node-opcua
-	maxBodySize :=
-		c.algo.PlaintextBlockSize()*
-			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
-			sequenceHeaderSize
-	c.maxBodySize = uint32(maxBodySize)
+	// maxBodySize :=
+	// 	c.algo.PlaintextBlockSize()*
+	// 		((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
+	// 		sequenceHeaderSize
+	// c.maxBodySize = uint32(maxBodySize)
 
 	// this is the formula proposed by ERN - source node-opcua
-	// maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()
-	// c.maxBodySize = c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
+	maxBlock := (chunkSize - headerSize - symmetricAlgorithmHeader) / c.algo.BlockSize()
+	maxBodySize := c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
+	c.maxBodySize = uint32(maxBodySize)
 }
 
 // signAndEncrypt encrypts the message bytes stored in b and returns the

--- a/uatest/timeout_test.go
+++ b/uatest/timeout_test.go
@@ -1,0 +1,67 @@
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gopcua/opcua"
+)
+
+const (
+	// this _must_ be a "host" that will silently eat SYNs (no RSTs)
+	// 203.0.113.0/24 is IETF TEST-NET-3
+	tcpNoRstTestServer   = "opc.tcp://203.0.113.0:4840"
+	forceTimeoutDuration = time.Second * 5
+)
+
+func TestClientTimeoutViaOptions(t *testing.T) {
+	c := opcua.NewClient(tcpNoRstTestServer, opcua.DialTimeout(forceTimeoutDuration))
+
+	connectAndValidate(t, c, context.Background(), forceTimeoutDuration)
+}
+
+func TestClientTimeoutViaContext(t *testing.T) {
+	c := opcua.NewClient(tcpNoRstTestServer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), forceTimeoutDuration)
+	defer cancel()
+
+	connectAndValidate(t, c, ctx, forceTimeoutDuration)
+}
+
+func connectAndValidate(t *testing.T, c *opcua.Client, ctx context.Context, d time.Duration) {
+	start := time.Now()
+
+	err := c.Connect(ctx)
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+
+	elapsed := time.Since(start)
+
+	if oe, ok := err.(*net.OpError); ok {
+		if !oe.Timeout() {
+			t.Fatalf("got %#v, wanted net.timeoutError", oe.Unwrap())
+		}
+	} else {
+		t.Fatalf("got %T, wanted %T", err, net.OpError{})
+	}
+
+	pct := 0.05
+
+	if !within(elapsed, d, pct) {
+		t.Fatalf("took %s, expected %s +/- %v%%", elapsed, d, pct*100)
+	}
+}
+
+func within(x, y time.Duration, pct float64) bool {
+	if pct > 1 || pct < 0 {
+		panic("invalid pct")
+	}
+	p := float64(x) * pct
+	return float64(y) >= (float64(x)-p) && float64(y) <= (float64(x)+p)
+}


### PR DESCRIPTION
Hi, 

I've encountered an edge case where the encrypted chunk size is a tad to big when the maximum receive buffer isn't aligned to the algorithm block size.

I've replaced the calculation for the maximum body size of a chunk to a more conservative one (in line with the current implementation of node-opcua)