### PR TITLE
Handle reads with unknown extension objects

### DIFF
--- a/client.go
+++ b/client.go
@@ -799,7 +799,23 @@ func (c *Client) Read(req *ua.ReadRequest) (*ua.ReadResponse, error) {
 
 	var res *ua.ReadResponse
 	err := c.Send(req, func(v interface{}) error {
-		return safeAssign(v, &res)
+		err := safeAssign(v, &res)
+
+		// If the client cannot decode an extension object then its
+		// value will be nil. However, since the EO was known to the
+		// server the StatusCode for that data value will be OK. We
+		// therefore check for extension objects with nil values and set
+		// the status code to StatusBadDataTypeIDUnknown.
+		if err == nil {
+			for _, dv := range res.Results {
+				val := dv.Value.Value()
+				if eo, ok := val.(*ua.ExtensionObject); ok && eo.Value == nil {
+					dv.Status = ua.StatusBadDataTypeIDUnknown
+				}
+			}
+		}
+
+		return err
 	})
 	return res, err
 }

--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -5,7 +5,6 @@
 package ua
 
 import (
-	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
 )
 
@@ -76,7 +75,7 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 	typeID := e.TypeID.NodeID
 	e.Value = eotypes.New(typeID)
 	if e.Value == nil {
-		return buf.Pos(), errors.Errorf("invalid extension object with id %s", typeID)
+		return buf.Pos(), buf.Error()
 	}
 
 	body.ReadStruct(e.Value)

--- a/uatest/read_unknow_node_id_server.py
+++ b/uatest/read_unknow_node_id_server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+from opcua import ua, Server
+from opcua.ua import uatypes
+
+from opcua.ua.object_ids import ObjectIds
+
+
+class Complex(uatypes.FrozenClass):
+    ua_types = [
+        ('i', 'Int64'),
+        ('j', 'Int64'),
+    ]
+
+    def __init__(self):
+        self.i = 0
+        self.j = 0
+        self._freeze = True
+
+    def __str__(self):
+        return 'Complex(' + 'i:' + str(self.i) + ', ' + \
+               'j:' + str(self.j) + ')'
+
+    __repr__ = __str__
+
+
+if __name__ == "__main__":
+    server = Server()
+    server.set_endpoint("opc.tcp://0.0.0.0:4840/")
+
+    ns = server.register_namespace("http://gopcua.com/")
+
+    complexNode = ua.StringNodeId("ComplexType", ns)
+    uatypes.register_extension_object('Complex', complexNode, Complex)
+
+    # definitely not clear why this is needed, but without it does not work
+    setattr(ua.ObjectIds, 'Complex', 'ComplexType')
+
+    main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
+
+    complexZero = Complex()
+    complexZero = main.add_variable(
+        ua.NodeId("ComplexZero", ns), "ComplexZero", complexZero, ua.VariantType.ExtensionObject)
+
+    server.start()

--- a/uatest/read_unknow_node_id_server.py
+++ b/uatest/read_unknow_node_id_server.py
@@ -6,20 +6,17 @@ from opcua.ua import uatypes
 from opcua.ua.object_ids import ObjectIds
 
 
-class Complex(uatypes.FrozenClass):
+class IntVal(uatypes.FrozenClass):
     ua_types = [
         ('i', 'Int64'),
-        ('j', 'Int64'),
     ]
 
     def __init__(self):
         self.i = 0
-        self.j = 0
         self._freeze = True
 
     def __str__(self):
-        return 'Complex(' + 'i:' + str(self.i) + ', ' + \
-               'j:' + str(self.j) + ')'
+        return 'IntVal(' + 'i:' + str(self.i) + ')'
 
     __repr__ = __str__
 
@@ -30,16 +27,13 @@ if __name__ == "__main__":
 
     ns = server.register_namespace("http://gopcua.com/")
 
-    complexNode = ua.StringNodeId("ComplexType", ns)
-    uatypes.register_extension_object('Complex', complexNode, Complex)
+    uatypes.register_extension_object('IntVal', ua.StringNodeId("IntValType", ns), IntVal)
 
     # definitely not clear why this is needed, but without it does not work
-    setattr(ua.ObjectIds, 'Complex', 'ComplexType')
+    setattr(ua.ObjectIds, 'IntVal', 'IntValType')
 
     main = server.nodes.objects.add_object(ua.NodeId("main", ns), "main")
 
-    complexZero = Complex()
-    complexZero = main.add_variable(
-        ua.NodeId("ComplexZero", ns), "ComplexZero", complexZero, ua.VariantType.ExtensionObject)
+    main.add_variable(ua.NodeId("IntValZero", ns), "IntValZero", IntVal(), ua.VariantType.ExtensionObject)
 
     server.start()

--- a/uatest/read_unknow_node_id_test.go
+++ b/uatest/read_unknow_node_id_test.go
@@ -26,7 +26,7 @@ func TestReadUnknowNodeID(t *testing.T) {
 
 	// read node with unknown extension object
 	// This should be OK
-	nodeWithUnknownType := ua.NewStringNodeID(2, "ComplexZero")
+	nodeWithUnknownType := ua.NewStringNodeID(2, "IntValZero")
 	resp, err := c.Read(&ua.ReadRequest{
 		NodesToRead: []*ua.ReadValueID{
 			{NodeID: nodeWithUnknownType},

--- a/uatest/read_unknow_node_id_test.go
+++ b/uatest/read_unknow_node_id_test.go
@@ -1,0 +1,54 @@
+//go:build integration
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+)
+
+// TestRead performs an integration test to read values
+// from an OPC/UA server.
+func TestReadUnknowNodeID(t *testing.T) {
+	srv := NewServer("read_unknow_node_id_server.py")
+	defer srv.Close()
+
+	c := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// read node with unknown extension object
+	// This should be OK
+	nodeWithUnknownType := ua.NewStringNodeID(2, "ComplexZero")
+	resp, err := c.Read(&ua.ReadRequest{
+		NodesToRead: []*ua.ReadValueID{
+			{NodeID: nodeWithUnknownType},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := resp.Results[0].Status, ua.StatusBadDataTypeIDUnknown; got != want {
+		t.Errorf("got status %v want %v for a node with an unknown type", got, want)
+	}
+
+	// check that the connection is still usable by reading another node.
+	_, err = c.Read(&ua.ReadRequest{
+		NodesToRead: []*ua.ReadValueID{
+			{
+				NodeID: ua.NewNumericNodeID(0, id.Server_ServerStatus_State),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
This patch sets the status code for a `DataValue` in a `ReadResponse` to `StatusBadDataTypeIDUnknown` when the value is an extension object but could not be decoded because it is unknown to the client.

This patch also replaces the test in #477 since I could not overwrite it.

Fixes #480
Closes #477
