### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.x"
+          python-version: "3.9.X"
           architecture: "x64"
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
lxml build on Windows with Python 3.10 is failing. Pin to 3.9.

Specifically, there's no pre-built wheel for 3.10. So pip falls back to building from source. And lxml is not exactly a lightweight library.