### PR TITLE
fix: return nil on subscription.Delete

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -88,18 +88,20 @@ func (s *Subscription) delete() error {
 	req := &ua.DeleteSubscriptionsRequest{
 		SubscriptionIDs: []uint32{s.SubscriptionID},
 	}
+
 	var res *ua.DeleteSubscriptionsResponse
 	err := s.c.Send(req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
+
 	switch {
-	case err == ua.StatusOK:
-		s.items = make(map[uint32]*monitoredItem)
-		return nil
 	case err != nil:
 		return err
+	case res.Results[0] == ua.StatusOK:
+		s.items = make(map[uint32]*monitoredItem)
+		return nil
 	default:
-		return res.ResponseHeader.ServiceResult
+		return res.Results[0]
 	}
 }
 


### PR DESCRIPTION
First of all thank you for creating/maintaining this library.
I currently work for a company with a lot of clients in the industry field and we're planning to use OPCUA for various projets using Go. Therefore we'll try to contribute as much as we can according to our use cases.

# ISSUE:

When calling `Unsubscribe` on a subscription we expect an error.
However at the moment if the subscription client returns no error (err == nil) the `Unsubscribe` method will return `OK 0x0` instead of nil. 

## STEPS TO REPRODUCE:

- Create a node monitor
- Create a subscription from the monitor
- Call `subscription.Unsubscribe()` and check for the error
- If `Unsubscribe` is successful then we should receive an error of `OK 0x0` instead of nil

## SOLUTION:

- Return nil from the `subscription.delete` method if `s.c.Send == nil ` || `s.c.Send == ua.StatusOK`