### PR TITLE
Add handshake config options (#495)

### DIFF
--- a/config.go
+++ b/config.go
@@ -466,6 +466,7 @@ func RequestTimeout(t time.Duration) Option {
 // Dialer sets the uacp.Dialer to establish the connection to the server.
 func Dialer(d *uacp.Dialer) Option {
 	return func(cfg *Config) {
+		initDialer(cfg)
 		cfg.dialer = d
 	}
 }
@@ -474,12 +475,7 @@ func Dialer(d *uacp.Dialer) Option {
 // Defaults to DefaultDialTimeout. Set to zero for no timeout.
 func DialTimeout(d time.Duration) Option {
 	return func(cfg *Config) {
-		if cfg.dialer == nil {
-			cfg.dialer = &uacp.Dialer{}
-		}
-		if cfg.dialer.Dialer == nil {
-			cfg.dialer.Dialer = &net.Dialer{}
-		}
+		initDialer(cfg)
 		cfg.dialer.Dialer.Timeout = d
 	}
 }
@@ -487,12 +483,7 @@ func DialTimeout(d time.Duration) Option {
 // MaxMessageSize sets the maximum message size for the UACP handshake.
 func MaxMessageSize(n uint32) Option {
 	return func(cfg *Config) {
-		if cfg.dialer == nil {
-			cfg.dialer = &uacp.Dialer{}
-		}
-		if cfg.dialer.ClientACK == nil {
-			cfg.dialer.ClientACK = uacp.DefaultClientACK
-		}
+		initDialer(cfg)
 		cfg.dialer.ClientACK.MaxMessageSize = n
 	}
 }
@@ -500,12 +491,7 @@ func MaxMessageSize(n uint32) Option {
 // MaxChunkCount sets the maximum chunk count for the UACP handshake.
 func MaxChunkCount(n uint32) Option {
 	return func(cfg *Config) {
-		if cfg.dialer == nil {
-			cfg.dialer = &uacp.Dialer{}
-		}
-		if cfg.dialer.ClientACK == nil {
-			cfg.dialer.ClientACK = uacp.DefaultClientACK
-		}
+		initDialer(cfg)
 		cfg.dialer.ClientACK.MaxChunkCount = n
 	}
 }
@@ -513,12 +499,7 @@ func MaxChunkCount(n uint32) Option {
 // ReceiveBufferSize sets the receive buffer size for the UACP handshake.
 func ReceiveBufferSize(n uint32) Option {
 	return func(cfg *Config) {
-		if cfg.dialer == nil {
-			cfg.dialer = &uacp.Dialer{}
-		}
-		if cfg.dialer.ClientACK == nil {
-			cfg.dialer.ClientACK = uacp.DefaultClientACK
-		}
+		initDialer(cfg)
 		cfg.dialer.ClientACK.ReceiveBufSize = n
 	}
 }
@@ -526,12 +507,19 @@ func ReceiveBufferSize(n uint32) Option {
 // SendBufferSize sets the send buffer size for the UACP handshake.
 func SendBufferSize(n uint32) Option {
 	return func(cfg *Config) {
-		if cfg.dialer == nil {
-			cfg.dialer = &uacp.Dialer{}
-		}
-		if cfg.dialer.ClientACK == nil {
-			cfg.dialer.ClientACK = uacp.DefaultClientACK
-		}
+		initDialer(cfg)
 		cfg.dialer.ClientACK.SendBufSize = n
+	}
+}
+
+func initDialer(cfg *Config) {
+	if cfg.dialer == nil {
+		cfg.dialer = &uacp.Dialer{}
+	}
+	if cfg.dialer.Dialer == nil {
+		cfg.dialer.Dialer = &net.Dialer{}
+	}
+	if cfg.dialer.ClientACK == nil {
+		cfg.dialer.ClientACK = uacp.DefaultClientACK
 	}
 }

--- a/config.go
+++ b/config.go
@@ -53,25 +53,17 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 
 // Config contains all config options.
 type Config struct {
-	dialer      *uacp.Dialer
-	dialTimeout *time.Duration
-	sechan      *uasc.Config
-	session     *uasc.SessionConfig
+	dialer  *uacp.Dialer
+	sechan  *uasc.Config
+	session *uasc.SessionConfig
 }
 
 // NewDialer creates a uacp.Dialer from the config options
 func NewDialer(cfg *Config) *uacp.Dialer {
-	d := cfg.dialer
-	if d == nil {
-		d = &uacp.Dialer{}
+	if cfg.dialer == nil {
+		return &uacp.Dialer{}
 	}
-	if d.Dialer == nil {
-		d.Dialer = &net.Dialer{}
-	}
-	if cfg.dialTimeout != nil {
-		d.Dialer.Timeout = *cfg.dialTimeout
-	}
-	return d
+	return cfg.dialer
 }
 
 // ApplyConfig applies the config options to the default configuration.
@@ -471,6 +463,64 @@ func Dialer(d *uacp.Dialer) Option {
 // Defaults to DefaultDialTimeout. Set to zero for no timeout.
 func DialTimeout(d time.Duration) Option {
 	return func(cfg *Config) {
-		cfg.dialTimeout = &d
+		if cfg.dialer == nil {
+			cfg.dialer = &uacp.Dialer{}
+		}
+		if cfg.dialer.Dialer == nil {
+			cfg.dialer.Dialer = &net.Dialer{}
+		}
+		cfg.dialer.Dialer.Timeout = d
+	}
+}
+
+// MaxMessageSize sets the maximum message size for the UACP handshake.
+func MaxMessageSize(n uint32) Option {
+	return func(cfg *Config) {
+		if cfg.dialer == nil {
+			cfg.dialer = &uacp.Dialer{}
+		}
+		if cfg.dialer.ClientACK == nil {
+			cfg.dialer.ClientACK = uacp.DefaultClientACK
+		}
+		cfg.dialer.ClientACK.MaxMessageSize = n
+	}
+}
+
+// MaxChunkCount sets the maximum chunk count for the UACP handshake.
+func MaxChunkCount(n uint32) Option {
+	return func(cfg *Config) {
+		if cfg.dialer == nil {
+			cfg.dialer = &uacp.Dialer{}
+		}
+		if cfg.dialer.ClientACK == nil {
+			cfg.dialer.ClientACK = uacp.DefaultClientACK
+		}
+		cfg.dialer.ClientACK.MaxChunkCount = n
+	}
+}
+
+// ReceiveBufferSize sets the receive buffer size for the UACP handshake.
+func ReceiveBufferSize(n uint32) Option {
+	return func(cfg *Config) {
+		if cfg.dialer == nil {
+			cfg.dialer = &uacp.Dialer{}
+		}
+		if cfg.dialer.ClientACK == nil {
+			cfg.dialer.ClientACK = uacp.DefaultClientACK
+		}
+		cfg.dialer.ClientACK.ReceiveBufSize = n
+	}
+}
+
+// SendBufferSize sets the send buffer size for the UACP handshake.
+func SendBufferSize(n uint32) Option {
+	return func(cfg *Config) {
+		if cfg.dialer == nil {
+			cfg.dialer = &uacp.Dialer{}
+		}
+		if cfg.dialer.ClientACK == nil {
+			cfg.dialer.ClientACK = uacp.DefaultClientACK
+		}
+		cfg.dialer.ClientACK.SendBufSize = n
 	}
 }

--- a/config.go
+++ b/config.go
@@ -131,10 +131,21 @@ func ProductURI(s string) Option {
 	}
 }
 
+// stubbed out for testing
+var randomRequestID func() uint32 = nil
+
 // RandomRequestID assigns a random initial request id.
+//
+// The request id is generated using the 'rand' package and it
+// is the caller's responsibility to initialize the random number
+// generator properly.
 func RandomRequestID() Option {
 	return func(cfg *Config) {
-		cfg.sechan.RequestIDSeed = uint32(rand.Int31())
+		if randomRequestID != nil {
+			cfg.sechan.RequestIDSeed = randomRequestID()
+		} else {
+			cfg.sechan.RequestIDSeed = uint32(rand.Int31())
+		}
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uacp"
 	"github.com/gopcua/opcua/uapolicy"
 	"github.com/gopcua/opcua/uasc"
 
@@ -612,6 +614,68 @@ func TestOptions(t *testing.T) {
 					sc := DefaultSessionConfig()
 					sc.SessionTimeout = 5 * time.Second
 					return sc
+				}(),
+			},
+		},
+		{
+			name: `Dialer()`,
+			opt:  Dialer(&uacp.Dialer{}),
+			cfg: &Config{
+				dialer: &uacp.Dialer{},
+			},
+		},
+		{
+			name: `DialTimeout(5s)`,
+			opt:  DialTimeout(5 * time.Second),
+			cfg: &Config{
+				dialer: &uacp.Dialer{
+					Dialer: &net.Dialer{
+						Timeout: 5 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			name: `MaxMessageSize()`,
+			opt:  MaxMessageSize(5),
+			cfg: &Config{
+				dialer: func() *uacp.Dialer {
+					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d.ClientACK.MaxMessageSize = 5
+					return d
+				}(),
+			},
+		},
+		{
+			name: `MaxChunkCount()`,
+			opt:  MaxChunkCount(5),
+			cfg: &Config{
+				dialer: func() *uacp.Dialer {
+					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d.ClientACK.MaxChunkCount = 5
+					return d
+				}(),
+			},
+		},
+		{
+			name: `ReceiveBufferSize()`,
+			opt:  ReceiveBufferSize(5),
+			cfg: &Config{
+				dialer: func() *uacp.Dialer {
+					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d.ClientACK.ReceiveBufSize = 5
+					return d
+				}(),
+			},
+		},
+		{
+			name: `SendBufferSize()`,
+			opt:  SendBufferSize(5),
+			cfg: &Config{
+				dialer: func() *uacp.Dialer {
+					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d.ClientACK.SendBufSize = 5
+					return d
 				}(),
 			},
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -125,6 +125,9 @@ func x509Cert(c, k []byte) tls.Certificate {
 }
 
 func TestOptions(t *testing.T) {
+	randomRequestID = func() uint32 { return 125 }
+	defer func() { randomRequestID = nil }()
+
 	d, err := ioutil.TempDir("", "gopcua")
 	if err != nil {
 		t.Fatal(err)
@@ -231,6 +234,17 @@ func TestOptions(t *testing.T) {
 			},
 		},
 		{
+			name: `AutoReconnect()`,
+			opt:  AutoReconnect(true),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.AutoReconnect = true
+					return c
+				}(),
+			},
+		},
+		{
 			name: `Certificate`,
 			opt:  Certificate(certDER),
 			cfg: &Config{
@@ -332,6 +346,28 @@ func TestOptions(t *testing.T) {
 					sc := DefaultSessionConfig()
 					sc.ClientDescription.ProductURI = "a"
 					return sc
+				}(),
+			},
+		},
+		{
+			name: `RandomRequestID()`,
+			opt:  RandomRequestID(),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.RequestIDSeed = 125
+					return c
+				}(),
+			},
+		},
+		{
+			name: `ReconnectInterval()`,
+			opt:  ReconnectInterval(5 * time.Second),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.ReconnectInterval = 5 * time.Second
+					return c
 				}(),
 			},
 		},
@@ -603,6 +639,17 @@ func TestOptions(t *testing.T) {
 					c := DefaultClientConfig()
 					c.SecurityPolicyURI = ua.SecurityPolicyURIAes256Sha256RsaPss
 					return c
+				}(),
+			},
+		},
+		{
+			name: `SessionName()`,
+			opt:  SessionName("a"),
+			cfg: &Config{
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.SessionName = "a"
+					return sc
 				}(),
 			},
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -666,9 +666,25 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name: `Dialer()`,
-			opt:  Dialer(&uacp.Dialer{}),
+			opt: Dialer(&uacp.Dialer{
+				Dialer: &net.Dialer{Timeout: 3 * time.Second},
+				ClientACK: &uacp.Acknowledge{
+					MaxMessageSize: 1,
+					MaxChunkCount:  2,
+					SendBufSize:    3,
+					ReceiveBufSize: 4,
+				},
+			}),
 			cfg: &Config{
-				dialer: &uacp.Dialer{},
+				dialer: &uacp.Dialer{
+					Dialer: &net.Dialer{Timeout: 3 * time.Second},
+					ClientACK: &uacp.Acknowledge{
+						MaxMessageSize: 1,
+						MaxChunkCount:  2,
+						SendBufSize:    3,
+						ReceiveBufSize: 4,
+					},
+				},
 			},
 		},
 		{
@@ -676,9 +692,8 @@ func TestOptions(t *testing.T) {
 			opt:  DialTimeout(5 * time.Second),
 			cfg: &Config{
 				dialer: &uacp.Dialer{
-					Dialer: &net.Dialer{
-						Timeout: 5 * time.Second,
-					},
+					Dialer:    &net.Dialer{Timeout: 5 * time.Second},
+					ClientACK: uacp.DefaultClientACK,
 				},
 			},
 		},
@@ -687,7 +702,10 @@ func TestOptions(t *testing.T) {
 			opt:  MaxMessageSize(5),
 			cfg: &Config{
 				dialer: func() *uacp.Dialer {
-					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d := &uacp.Dialer{
+						Dialer:    &net.Dialer{},
+						ClientACK: uacp.DefaultClientACK,
+					}
 					d.ClientACK.MaxMessageSize = 5
 					return d
 				}(),
@@ -698,7 +716,10 @@ func TestOptions(t *testing.T) {
 			opt:  MaxChunkCount(5),
 			cfg: &Config{
 				dialer: func() *uacp.Dialer {
-					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d := &uacp.Dialer{
+						Dialer:    &net.Dialer{},
+						ClientACK: uacp.DefaultClientACK,
+					}
 					d.ClientACK.MaxChunkCount = 5
 					return d
 				}(),
@@ -709,7 +730,10 @@ func TestOptions(t *testing.T) {
 			opt:  ReceiveBufferSize(5),
 			cfg: &Config{
 				dialer: func() *uacp.Dialer {
-					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d := &uacp.Dialer{
+						Dialer:    &net.Dialer{},
+						ClientACK: uacp.DefaultClientACK,
+					}
 					d.ClientACK.ReceiveBufSize = 5
 					return d
 				}(),
@@ -720,7 +744,10 @@ func TestOptions(t *testing.T) {
 			opt:  SendBufferSize(5),
 			cfg: &Config{
 				dialer: func() *uacp.Dialer {
-					d := &uacp.Dialer{ClientACK: uacp.DefaultClientACK}
+					d := &uacp.Dialer{
+						Dialer:    &net.Dialer{},
+						ClientACK: uacp.DefaultClientACK,
+					}
 					d.ClientACK.SendBufSize = 5
 					return d
 				}(),


### PR DESCRIPTION
This patch adds config options for the client handshake options

* MaxMessageSize
* MaxChunkCount
* ReceiveBufferSize
* SendBufferSize

Fixes #435
Fixes #495