### PR TITLE
subscription: do not fail Monitor() on bad node (#491)

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -122,12 +122,6 @@ func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredI
 		return nil, err
 	}
 
-	for _, result := range res.Results {
-		if status := result.StatusCode; status != ua.StatusOK {
-			return nil, status
-		}
-	}
-
 	// store monitored items
 	// todo(fs): should we guard this with a lock?
 	for i, item := range items {


### PR DESCRIPTION
This patch restores the behavior of the Monitor() call to the v0.1
behavior of only returning an error if the Monitor call itself failed.

Fixes #491