### PR TITLE
Encode nil node id as zero

### DIFF
--- a/ua/node_id.go
+++ b/ua/node_id.go
@@ -405,6 +405,12 @@ func (n *NodeID) Decode(b []byte) (int, error) {
 }
 
 func (n *NodeID) Encode() ([]byte, error) {
+	// https://github.com/gopcua/opcua/issues/506
+	// encode 'nil' node ids as two byte zero values
+	if n == nil {
+		return []byte{0, 0}, nil
+	}
+
 	buf := NewBuffer(nil)
 	buf.WriteByte(byte(n.mask))
 

--- a/ua/node_id_test.go
+++ b/ua/node_id_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gopcua/opcua/errors"
+	"github.com/pascaldekloe/goe/verify"
 )
 
 func TestNodeID(t *testing.T) {
@@ -130,6 +131,15 @@ func BenchmarkReflectDecode(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestEncodeNilNodeID(t *testing.T) {
+	var n *NodeID
+	b, err := n.Encode()
+	if err != nil {
+		t.Fatalf("got error %v want %v", err, nil)
+	}
+	verify.Values(t, "", b, []byte{0, 0})
 }
 
 func TestParseNodeID(t *testing.T) {


### PR DESCRIPTION
This patch encodes a `nil` NodeID as a two byte zero node id.

See #506 