### PR TITLE
add contexts to all functions that make a remote call

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package opcua
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gopcua/opcua/id"
@@ -10,7 +11,7 @@ import (
 
 func TestClient_Send_DoesNotPanicWhenDisconnected(t *testing.T) {
 	c := NewClient("opc.tcp://example.com:4840")
-	err := c.Send(&ua.ReadRequest{}, func(i interface{}) error {
+	err := c.Send(context.Background(), &ua.ReadRequest{}, func(i interface{}) error {
 		return nil
 	})
 	verify.Values(t, "", err, ua.StatusBadServerNotConnected)

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -88,7 +88,7 @@ func NewNodeMonitor(client *opcua.Client) (*NodeMonitor, error) {
 	return m, nil
 }
 
-func newSubscription(m *NodeMonitor, params *opcua.SubscriptionParameters, notifyChanLength int, nodes ...string) (*Subscription, error) {
+func newSubscription(ctx context.Context, m *NodeMonitor, params *opcua.SubscriptionParameters, notifyChanLength int, nodes ...string) (*Subscription, error) {
 	if params == nil {
 		params = &opcua.SubscriptionParameters{}
 	}
@@ -102,11 +102,11 @@ func newSubscription(m *NodeMonitor, params *opcua.SubscriptionParameters, notif
 	}
 
 	var err error
-	if s.sub, err = m.client.Subscribe(params, s.internalNotifyCh); err != nil {
+	if s.sub, err = m.client.Subscribe(ctx, params, s.internalNotifyCh); err != nil {
 		return nil, err
 	}
 
-	if err = s.AddNodes(nodes...); err != nil {
+	if err = s.AddNodes(ctx, nodes...); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func (m *NodeMonitor) SetErrorHandler(cb ErrHandler) {
 // The caller must call `Unsubscribe` to stop and clean up resources. Canceling the context
 // will also cause the subscription to stop, but `Unsubscribe` must still be called.
 func (m *NodeMonitor) Subscribe(ctx context.Context, params *opcua.SubscriptionParameters, cb MsgHandler, nodes ...string) (*Subscription, error) {
-	sub, err := newSubscription(m, params, DefaultCallbackBufferLen, nodes...)
+	sub, err := newSubscription(ctx, m, params, DefaultCallbackBufferLen, nodes...)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (m *NodeMonitor) Subscribe(ctx context.Context, params *opcua.SubscriptionP
 // The caller must call `Unsubscribe` to stop and clean up resources. Canceling the context
 // will also cause the subscription to stop, but `Unsubscribe` must still be called.
 func (m *NodeMonitor) ChanSubscribe(ctx context.Context, params *opcua.SubscriptionParameters, ch chan<- *DataChangeMessage, nodes ...string) (*Subscription, error) {
-	sub, err := newSubscription(m, params, 16, nodes...)
+	sub, err := newSubscription(ctx, m, params, 16, nodes...)
 	if err != nil {
 		return nil, err
 	}
@@ -254,17 +254,17 @@ func (s *Subscription) Dropped() uint64 {
 }
 
 // AddNodes adds nodes defined by their string representation
-func (s *Subscription) AddNodes(nodes ...string) error {
+func (s *Subscription) AddNodes(ctx context.Context, nodes ...string) error {
 
 	nodeIDs, err := parseNodeSlice(nodes...)
 	if err != nil {
 		return err
 	}
-	return s.AddNodeIDs(nodeIDs...)
+	return s.AddNodeIDs(ctx, nodeIDs...)
 }
 
 // AddNodeIDs adds nodes
-func (s *Subscription) AddNodeIDs(nodes ...*ua.NodeID) error {
+func (s *Subscription) AddNodeIDs(ctx context.Context, nodes ...*ua.NodeID) error {
 	requests := make([]Request, len(nodes))
 
 	for i, node := range nodes {
@@ -273,12 +273,12 @@ func (s *Subscription) AddNodeIDs(nodes ...*ua.NodeID) error {
 			MonitoringMode: ua.MonitoringModeReporting,
 		}
 	}
-	_, err := s.AddMonitorItems(requests...)
+	_, err := s.AddMonitorItems(ctx, requests...)
 	return err
 }
 
 // AddMonitorItems adds nodes with monitoring parameters to the subscription
-func (s *Subscription) AddMonitorItems(nodes ...Request) ([]Item, error) {
+func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([]Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -305,7 +305,7 @@ func (s *Subscription) AddMonitorItems(nodes ...Request) ([]Item, error) {
 		}
 		toAdd = append(toAdd, request)
 	}
-	resp, err := s.sub.Monitor(ua.TimestampsToReturnBoth, toAdd...)
+	resp, err := s.sub.Monitor(ctx, ua.TimestampsToReturnBoth, toAdd...)
 	if err != nil {
 		return nil, err
 	}
@@ -335,16 +335,16 @@ func (s *Subscription) AddMonitorItems(nodes ...Request) ([]Item, error) {
 }
 
 // RemoveNodes removes nodes defined by their string representation
-func (s *Subscription) RemoveNodes(nodes ...string) error {
+func (s *Subscription) RemoveNodes(ctx context.Context, nodes ...string) error {
 	nodeIDs, err := parseNodeSlice(nodes...)
 	if err != nil {
 		return err
 	}
-	return s.RemoveNodeIDs(nodeIDs...)
+	return s.RemoveNodeIDs(ctx, nodeIDs...)
 }
 
 // RemoveNodeIDs removes nodes
-func (s *Subscription) RemoveNodeIDs(nodes ...*ua.NodeID) error {
+func (s *Subscription) RemoveNodeIDs(ctx context.Context, nodes ...*ua.NodeID) error {
 	if len(nodes) == 0 {
 		return nil
 	}
@@ -360,11 +360,11 @@ func (s *Subscription) RemoveNodeIDs(nodes ...*ua.NodeID) error {
 		}
 	}
 
-	return s.RemoveMonitorItems(toRemove...)
+	return s.RemoveMonitorItems(ctx, toRemove...)
 }
 
 // RemoveMonitorItems removes nodes
-func (s *Subscription) RemoveMonitorItems(items ...Item) error {
+func (s *Subscription) RemoveMonitorItems(ctx context.Context, items ...Item) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -385,7 +385,7 @@ func (s *Subscription) RemoveMonitorItems(items ...Item) error {
 		toRemove = append(toRemove, item.id)
 	}
 
-	resp, err := s.sub.Unmonitor(toRemove...)
+	resp, err := s.sub.Unmonitor(ctx, toRemove...)
 	if err != nil {
 		return err
 	}
@@ -408,8 +408,8 @@ func (s *Subscription) RemoveMonitorItems(items ...Item) error {
 }
 
 // Stats returns statistics for the subscription
-func (s *Subscription) Stats() (*ua.SubscriptionDiagnosticsDataType, error) {
-	return s.sub.Stats()
+func (s *Subscription) Stats(ctx context.Context) (*ua.SubscriptionDiagnosticsDataType, error) {
+	return s.sub.Stats(ctx)
 }
 
 func parseNodeSlice(nodes ...string) ([]*ua.NodeID, error) {

--- a/node.go
+++ b/node.go
@@ -5,6 +5,7 @@
 package opcua
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gopcua/opcua/id"
@@ -26,8 +27,8 @@ func (n *Node) String() string {
 }
 
 // NodeClass returns the node class attribute.
-func (n *Node) NodeClass() (ua.NodeClass, error) {
-	v, err := n.Attribute(ua.AttributeIDNodeClass)
+func (n *Node) NodeClass(ctx context.Context) (ua.NodeClass, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDNodeClass)
 	if err != nil {
 		return 0, err
 	}
@@ -35,8 +36,8 @@ func (n *Node) NodeClass() (ua.NodeClass, error) {
 }
 
 // BrowseName returns the browse name of the node.
-func (n *Node) BrowseName() (*ua.QualifiedName, error) {
-	v, err := n.Attribute(ua.AttributeIDBrowseName)
+func (n *Node) BrowseName(ctx context.Context) (*ua.QualifiedName, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDBrowseName)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +45,8 @@ func (n *Node) BrowseName() (*ua.QualifiedName, error) {
 }
 
 // Description returns the description of the node.
-func (n *Node) Description() (*ua.LocalizedText, error) {
-	v, err := n.Attribute(ua.AttributeIDDescription)
+func (n *Node) Description(ctx context.Context) (*ua.LocalizedText, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDDescription)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +54,8 @@ func (n *Node) Description() (*ua.LocalizedText, error) {
 }
 
 // DisplayName returns the display name of the node.
-func (n *Node) DisplayName() (*ua.LocalizedText, error) {
-	v, err := n.Attribute(ua.AttributeIDDisplayName)
+func (n *Node) DisplayName(ctx context.Context) (*ua.LocalizedText, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDDisplayName)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +65,8 @@ func (n *Node) DisplayName() (*ua.LocalizedText, error) {
 // AccessLevel returns the access level of the node.
 // The returned value is a mask where multiple values can be
 // set, e.g. read and write.
-func (n *Node) AccessLevel() (ua.AccessLevelType, error) {
-	v, err := n.Attribute(ua.AttributeIDAccessLevel)
+func (n *Node) AccessLevel(ctx context.Context) (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDAccessLevel)
 	if err != nil {
 		return 0, err
 	}
@@ -74,8 +75,8 @@ func (n *Node) AccessLevel() (ua.AccessLevelType, error) {
 
 // HasAccessLevel returns true if all bits from mask are
 // set in the access level mask of the node.
-func (n *Node) HasAccessLevel(mask ua.AccessLevelType) (bool, error) {
-	v, err := n.AccessLevel()
+func (n *Node) HasAccessLevel(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
+	v, err := n.AccessLevel(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -83,8 +84,8 @@ func (n *Node) HasAccessLevel(mask ua.AccessLevelType) (bool, error) {
 }
 
 // UserAccessLevel returns the access level of the node.
-func (n *Node) UserAccessLevel() (ua.AccessLevelType, error) {
-	v, err := n.Attribute(ua.AttributeIDUserAccessLevel)
+func (n *Node) UserAccessLevel(ctx context.Context) (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDUserAccessLevel)
 	if err != nil {
 		return 0, err
 	}
@@ -93,8 +94,8 @@ func (n *Node) UserAccessLevel() (ua.AccessLevelType, error) {
 
 // HasUserAccessLevel returns true if all bits from mask are
 // set in the user access level mask of the node.
-func (n *Node) HasUserAccessLevel(mask ua.AccessLevelType) (bool, error) {
-	v, err := n.UserAccessLevel()
+func (n *Node) HasUserAccessLevel(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
+	v, err := n.UserAccessLevel(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -102,15 +103,15 @@ func (n *Node) HasUserAccessLevel(mask ua.AccessLevelType) (bool, error) {
 }
 
 // Value returns the value of the node.
-func (n *Node) Value() (*ua.Variant, error) {
-	return n.Attribute(ua.AttributeIDValue)
+func (n *Node) Value(ctx context.Context) (*ua.Variant, error) {
+	return n.Attribute(ctx, ua.AttributeIDValue)
 }
 
 // Attribute returns the attribute of the node. with the given id.
-func (n *Node) Attribute(attrID ua.AttributeID) (*ua.Variant, error) {
+func (n *Node) Attribute(ctx context.Context, attrID ua.AttributeID) (*ua.Variant, error) {
 	rv := &ua.ReadValueID{NodeID: n.ID, AttributeID: attrID}
 	req := &ua.ReadRequest{NodesToRead: []*ua.ReadValueID{rv}}
-	res, err := n.c.Read(req)
+	res, err := n.c.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -126,32 +127,32 @@ func (n *Node) Attribute(attrID ua.AttributeID) (*ua.Variant, error) {
 	return value, nil
 }
 
-func (n *Node) Attributes(attrID ...ua.AttributeID) ([]*ua.DataValue, error) {
+func (n *Node) Attributes(ctx context.Context, attrID ...ua.AttributeID) ([]*ua.DataValue, error) {
 	req := &ua.ReadRequest{}
 	for _, id := range attrID {
 		rv := &ua.ReadValueID{NodeID: n.ID, AttributeID: id}
 		req.NodesToRead = append(req.NodesToRead, rv)
 	}
-	res, err := n.c.Read(req)
+	res, err := n.c.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return res.Results, nil
 }
 
-func (n *Node) Children(refs uint32, mask ua.NodeClass) ([]*Node, error) {
+func (n *Node) Children(ctx context.Context, refs uint32, mask ua.NodeClass) ([]*Node, error) {
 	if refs == 0 {
 		refs = id.HierarchicalReferences
 	}
-	return n.ReferencedNodes(refs, ua.BrowseDirectionForward, mask, true)
+	return n.ReferencedNodes(ctx, refs, ua.BrowseDirectionForward, mask, true)
 }
 
-func (n *Node) ReferencedNodes(refs uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*Node, error) {
+func (n *Node) ReferencedNodes(ctx context.Context, refs uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*Node, error) {
 	if refs == 0 {
 		refs = id.References
 	}
 	var nodes []*Node
-	res, err := n.References(refs, dir, mask, includeSubtypes)
+	res, err := n.References(ctx, refs, dir, mask, includeSubtypes)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +165,7 @@ func (n *Node) ReferencedNodes(refs uint32, dir ua.BrowseDirection, mask ua.Node
 // References returns all references for the node.
 // todo(fs): this is not complete since it only returns the
 // todo(fs): top-level reference at this point.
-func (n *Node) References(refType uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*ua.ReferenceDescription, error) {
+func (n *Node) References(ctx context.Context, refType uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*ua.ReferenceDescription, error) {
 	if refType == 0 {
 		refType = id.References
 	}
@@ -189,21 +190,21 @@ func (n *Node) References(refType uint32, dir ua.BrowseDirection, mask ua.NodeCl
 		NodesToBrowse:                 []*ua.BrowseDescription{desc},
 	}
 
-	resp, err := n.c.Browse(req)
+	resp, err := n.c.Browse(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	return n.browseNext(resp.Results)
+	return n.browseNext(ctx, resp.Results)
 }
 
-func (n *Node) browseNext(results []*ua.BrowseResult) ([]*ua.ReferenceDescription, error) {
+func (n *Node) browseNext(ctx context.Context, results []*ua.BrowseResult) ([]*ua.ReferenceDescription, error) {
 	refs := results[0].References
 	for len(results[0].ContinuationPoint) > 0 {
 		req := &ua.BrowseNextRequest{
 			ContinuationPoints:        [][]byte{results[0].ContinuationPoint},
 			ReleaseContinuationPoints: false,
 		}
-		resp, err := n.c.BrowseNext(req)
+		resp, err := n.c.BrowseNext(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +215,7 @@ func (n *Node) browseNext(results []*ua.BrowseResult) ([]*ua.ReferenceDescriptio
 }
 
 // TranslateBrowsePathsToNodeIDs translates an array of browseName segments to NodeIDs.
-func (n *Node) TranslateBrowsePathsToNodeIDs(pathNames []*ua.QualifiedName) (*ua.NodeID, error) {
+func (n *Node) TranslateBrowsePathsToNodeIDs(ctx context.Context, pathNames []*ua.QualifiedName) (*ua.NodeID, error) {
 	req := ua.TranslateBrowsePathsToNodeIDsRequest{
 		BrowsePaths: []*ua.BrowsePath{
 			{
@@ -236,7 +237,7 @@ func (n *Node) TranslateBrowsePathsToNodeIDs(pathNames []*ua.QualifiedName) (*ua
 	}
 
 	var nodeID *ua.NodeID
-	err := n.c.Send(&req, func(i interface{}) error {
+	err := n.c.Send(ctx, &req, func(i interface{}) error {
 		if resp, ok := i.(*ua.TranslateBrowsePathsToNodeIDsResponse); ok {
 			if len(resp.Results) == 0 {
 				return ua.StatusBadUnexpectedError
@@ -258,12 +259,12 @@ func (n *Node) TranslateBrowsePathsToNodeIDs(pathNames []*ua.QualifiedName) (*ua
 }
 
 // TranslateBrowsePathInNamespaceToNodeID translates a browseName to a NodeID within the same namespace.
-func (n *Node) TranslateBrowsePathInNamespaceToNodeID(ns uint16, browsePath string) (*ua.NodeID, error) {
+func (n *Node) TranslateBrowsePathInNamespaceToNodeID(ctx context.Context, ns uint16, browsePath string) (*ua.NodeID, error) {
 	segments := strings.Split(browsePath, ".")
 	var names []*ua.QualifiedName
 	for _, segment := range segments {
 		qn := &ua.QualifiedName{NamespaceIndex: ns, Name: segment}
 		names = append(names, qn)
 	}
-	return n.TranslateBrowsePathsToNodeIDs(names)
+	return n.TranslateBrowsePathsToNodeIDs(ctx, names)
 }

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -464,7 +464,6 @@ func (s *SecureChannel) Open(ctx context.Context) error {
 }
 
 func (s *SecureChannel) open(ctx context.Context, instance *channelInstance, requestType ua.SecurityTokenRequestType) error {
-	// TODO: do something with the context
 	defer s.rcvLocker.unlock()
 
 	s.openingMu.Lock()
@@ -544,7 +543,7 @@ func (s *SecureChannel) open(ctx context.Context, instance *channelInstance, req
 		RequestedLifetime:     s.cfg.Lifetime,
 	}
 
-	return s.sendRequestWithTimeout(req, reqID, s.openingInstance, nil, s.cfg.RequestTimeout, func(v interface{}) error {
+	return s.sendRequestWithTimeout(ctx, req, reqID, s.openingInstance, nil, s.cfg.RequestTimeout, func(v interface{}) error {
 		resp, ok := v.(*ua.OpenSecureChannelResponse)
 		if !ok {
 			return errors.Errorf("got %T, want OpenSecureChannelResponse", v)
@@ -661,6 +660,7 @@ func (s *SecureChannel) scheduleExpiration(instance *channelInstance) {
 }
 
 func (s *SecureChannel) sendRequestWithTimeout(
+	ctx context.Context,
 	req ua.Request,
 	reqID uint32,
 	instance *channelInstance,
@@ -671,7 +671,7 @@ func (s *SecureChannel) sendRequestWithTimeout(
 	s.pendingReq.Add(1)
 	respRequired := h != nil
 
-	ch, err := s.sendAsyncWithTimeout(req, reqID, instance, authToken, respRequired, timeout)
+	ch, err := s.sendAsyncWithTimeout(ctx, req, reqID, instance, authToken, respRequired, timeout)
 	s.pendingReq.Done()
 	if err != nil {
 		return err
@@ -686,6 +686,9 @@ func (s *SecureChannel) sendRequestWithTimeout(
 	defer timer.Stop()
 
 	select {
+	case <-ctx.Done():
+		s.popHandler(reqID)
+		return ctx.Err()
 	case <-s.disconnected:
 		s.popHandler(reqID)
 		return io.EOF
@@ -724,21 +727,23 @@ func (s *SecureChannel) Renew(ctx context.Context) error {
 }
 
 // SendRequest sends the service request and calls h with the response.
-func (s *SecureChannel) SendRequest(req ua.Request, authToken *ua.NodeID, h func(interface{}) error) error {
-	return s.SendRequestWithTimeout(req, authToken, s.cfg.RequestTimeout, h)
+func (s *SecureChannel) SendRequest(ctx context.Context, req ua.Request, authToken *ua.NodeID, h func(interface{}) error) error {
+
+	return s.SendRequestWithTimeout(ctx, req, authToken, s.cfg.RequestTimeout, h)
 }
 
-func (s *SecureChannel) SendRequestWithTimeout(req ua.Request, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
+func (s *SecureChannel) SendRequestWithTimeout(ctx context.Context, req ua.Request, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
 	s.reqLocker.waitIfLock()
 	active, err := s.getActiveChannelInstance()
 	if err != nil {
 		return err
 	}
 
-	return s.sendRequestWithTimeout(req, s.nextRequestID(), active, authToken, timeout, h)
+	return s.sendRequestWithTimeout(ctx, req, s.nextRequestID(), active, authToken, timeout, h)
 }
 
 func (s *SecureChannel) sendAsyncWithTimeout(
+	ctx context.Context,
 	req ua.Request,
 	reqID uint32,
 	instance *channelInstance,
@@ -778,6 +783,11 @@ func (s *SecureChannel) sendAsyncWithTimeout(
 	}
 
 	for i, chunk := range chunks {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		if i > 0 { // fix sequence number on subsequent chunks
 			number := instance.nextSequenceNumber()
 			binary.LittleEndian.PutUint32(chunk[16:], uint32(number))
@@ -840,7 +850,7 @@ func (s *SecureChannel) close() error {
 	default:
 	}
 
-	err := s.SendRequest(&ua.CloseSecureChannelRequest{}, nil, nil)
+	err := s.SendRequest(context.Background(), &ua.CloseSecureChannelRequest{}, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Proposal to addresses issue #502. This PR is exploration of how much the API would need to break for all methods that call an OPC UA server to accept a context. Some notes below

- [ ] TODO finish updating examples. (checking if this approach is acceptable first)
- Myself and a college are of the opinion that making breaking changes to the API rather than adding `client.FooWithContext` is the correct way forward. because there are so many functions that make calls to the server. i.e. ActivateSession, AttributeID that it would be extremely cumbersome to have them all duplicated.
- also we noted that the timeout value passed to `sendWithTimeout` was sent as a hint to the server. This has subtly different meaning to cancelling a context and so we have left functions to take both timeout and context.