### PR TITLE
client: expose statistics

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -4,6 +4,7 @@ rm -f */*_gen.go
 go run cmd/id/main.go
 go run cmd/status/main.go
 go run cmd/service/*.go
+go run cmd/stats/*.go
 
 # install stringer if not installed already
 command -v stringer || go get -u golang.org/x/tools/cmd/stringer
@@ -17,6 +18,9 @@ echo "Wrote ua/enums_strings_gen.go"
 
 stringer -type ConnState -output connstate_strings_gen.go
 echo "Wrote connstate_strings_gen.go"
+
+(cd stats && stringer -type Metric -output metrics_strings_gen.go)
+echo "Wrote stats/metrics_strings_gen.go"
 
 # remove golang.org/x/tools/cmd/stringer from list of dependencies
 go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,91 @@
+// Package stats provides instrumentation for the gopcua library via expvar.
+//
+// The API is experimental and might change.
+package stats
+
+import (
+	"expvar"
+	"io"
+	"reflect"
+
+	"github.com/gopcua/opcua/ua"
+)
+
+// stats is the global statistics counter.
+var stats = NewStats()
+
+func init() {
+	expvar.Publish("gopcua", expvar.Func(func() interface{} { return stats }))
+}
+
+// Stats collects gopcua statistics via expvar.
+type Stats struct {
+	Client       *expvar.Map
+	Error        *expvar.Map
+	Subscription *expvar.Map
+}
+
+func NewStats() *Stats {
+	return &Stats{
+		Client:       &expvar.Map{},
+		Error:        &expvar.Map{},
+		Subscription: &expvar.Map{},
+	}
+}
+
+// Reset resets all counters to zero.
+func (s *Stats) Reset() {
+	s.Client.Init()
+	s.Error.Init()
+	s.Subscription.Init()
+}
+
+// RecordError updates the metric for an error by one.
+func (s *Stats) RecordError(err error) {
+	if err == nil {
+		return
+	}
+	switch err {
+	case io.EOF:
+		s.Error.Add("io.EOF", 1)
+	case ua.StatusOK:
+		s.Error.Add("ua.StatusOK", 1)
+	case ua.StatusBad:
+		s.Error.Add("ua.StatusBad", 1)
+	case ua.StatusUncertain:
+		s.Error.Add("ua.StatusUncertain", 1)
+	default:
+		switch x := err.(type) {
+		case ua.StatusCode:
+			s.Error.Add("ua."+ua.StatusCodes[x].Name, 1)
+		default:
+			s.Error.Add(reflect.TypeOf(err).String(), 1)
+		}
+	}
+}
+
+// convenience functions for the global statistics
+
+// Reset resets all counters to zero.
+func Reset() {
+	stats.Reset()
+}
+
+// Client is the global client statistics map.
+func Client() *expvar.Map {
+	return stats.Client
+}
+
+// Error is the global error statistics map.
+func Error() *expvar.Map {
+	return stats.Error
+}
+
+// Subscription is the global subscription statistics map.
+func Subscription() *expvar.Map {
+	return stats.Subscription
+}
+
+func RecordError(err error) {
+	stats.RecordError(err)
+}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,0 +1,53 @@
+package stats
+
+import (
+	"errors"
+	"expvar"
+	"io"
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func newExpVarInt(i int64) *expvar.Int {
+	v := &expvar.Int{}
+	v.Set(i)
+	return v
+}
+
+func TestConvienienceFuncs(t *testing.T) {
+	Reset()
+
+	Client().Add("a", 1)
+	verify.Values(t, "", Client().Get("a"), newExpVarInt(1))
+
+	Error().Add("b", 2)
+	verify.Values(t, "", Error().Get("b"), newExpVarInt(2))
+
+	Subscription().Add("c", 3)
+	verify.Values(t, "", Subscription().Get("c"), newExpVarInt(3))
+}
+
+func TestRecordError(t *testing.T) {
+	tests := []struct {
+		err error
+		key string
+	}{
+		{io.EOF, "io.EOF"},
+		{ua.StatusOK, "ua.StatusOK"},
+		{ua.StatusBad, "ua.StatusBad"},
+		{ua.StatusUncertain, "ua.StatusUncertain"},
+		{ua.StatusBadAlreadyExists, "ua.StatusBadAlreadyExists"},
+		{errors.New("hello"), "*errors.errorString"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			s := NewStats()
+			s.RecordError(tt.err)
+			got, want := s.Error.Get(tt.key), newExpVarInt(1)
+			verify.Values(t, "", got, want)
+		})
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/errors"
 	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/stats"
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uasc"
 )
@@ -81,6 +82,7 @@ type PublishNotificationData struct {
 // Cancel stops the subscription and removes it
 // from the client and the server.
 func (s *Subscription) Cancel(ctx context.Context) error {
+	stats.Subscription().Add("Cancel", 1)
 	s.c.forgetSubscription(ctx, s.SubscriptionID)
 	return s.delete()
 }
@@ -110,6 +112,9 @@ func (s *Subscription) delete() error {
 }
 
 func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredItemCreateRequest) (*ua.CreateMonitoredItemsResponse, error) {
+	stats.Subscription().Add("Monitor", 1)
+	stats.Subscription().Add("MonitoredItems", int64(len(items)))
+
 	// Part 4, 5.12.2.2 CreateMonitoredItems Service Parameters
 	req := &ua.CreateMonitoredItemsRequest{
 		SubscriptionID:     s.SubscriptionID,
@@ -142,6 +147,9 @@ func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredI
 }
 
 func (s *Subscription) Unmonitor(monitoredItemIDs ...uint32) (*ua.DeleteMonitoredItemsResponse, error) {
+	stats.Subscription().Add("Unmonitor", 1)
+	stats.Subscription().Add("UnmonitoredItems", int64(len(monitoredItemIDs)))
+
 	req := &ua.DeleteMonitoredItemsRequest{
 		MonitoredItemIDs: monitoredItemIDs,
 		SubscriptionID:   s.SubscriptionID,
@@ -165,6 +173,9 @@ func (s *Subscription) Unmonitor(monitoredItemIDs ...uint32) (*ua.DeleteMonitore
 }
 
 func (s *Subscription) ModifyMonitoredItems(ts ua.TimestampsToReturn, items ...*ua.MonitoredItemModifyRequest) (*ua.ModifyMonitoredItemsResponse, error) {
+	stats.Subscription().Add("ModifyMonitoredItems", 1)
+	stats.Subscription().Add("ModifiedMonitoredItems", int64(len(items)))
+
 	s.itemsMu.Lock()
 	for _, item := range items {
 		id := item.MonitoredItemID
@@ -212,6 +223,8 @@ func (s *Subscription) ModifyMonitoredItems(ts ua.TimestampsToReturn, items ...*
 // To add links from a triggering item to an item to report provide the server assigned ID(s) in the `add` argument.
 // To remove links from a triggering item to an item to report provide the server assigned ID(s) in the `remove` argument.
 func (s *Subscription) SetTriggering(triggeringItemID uint32, add, remove []uint32) (*ua.SetTriggeringResponse, error) {
+	stats.Subscription().Add("SetTriggering", 1)
+
 	// Part 4, 5.12.5.2 SetTriggering Service Parameters
 	req := &ua.SetTriggeringRequest{
 		SubscriptionID:   s.SubscriptionID,

--- a/uatest/stats_test.go
+++ b/uatest/stats_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"expvar"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/stats"
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func newExpVarInt(i int64) *expvar.Int {
+	v := &expvar.Int{}
+	v.Set(i)
+	return v
+}
+
+func TestStats(t *testing.T) {
+	stats.Reset()
+
+	srv := NewServer("rw_server.py")
+	defer srv.Close()
+
+	c := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	c.Close()
+
+	expected := map[string]*expvar.Int{
+		"Dial":             newExpVarInt(1),
+		"ActivateSession":  newExpVarInt(1),
+		"NamespaceArray":   newExpVarInt(1),
+		"UpdateNamespaces": newExpVarInt(1),
+		"NodesToRead":      newExpVarInt(1),
+		"Read":             newExpVarInt(1),
+		"Send":             newExpVarInt(2),
+		"Close":            newExpVarInt(1),
+		"CloseSession":     newExpVarInt(2),
+	}
+
+	for k, ev := range expected {
+		v := stats.Client().Get(k)
+		verify.Values(t, k, v, ev)
+	}
+}


### PR DESCRIPTION
This patch collects statistics for all client operations and some of the
errors and exposes them via the Stats() method.

This API is experimental and should not be considered stable at this
point.

Fixes #532