### PR TITLE
client: do not clear session during reconnect

### DIFF
--- a/client.go
+++ b/client.go
@@ -360,12 +360,14 @@ func (c *Client) monitor(ctx context.Context) {
 						// This only works if the session is still open on the server
 						// otherwise recreate it
 
-						dlog.Printf("trying to restore session")
-						s, err := c.DetachSession()
-						if err != nil {
-							action = createSecureChannel
+						s := c.Session()
+						if s == nil {
+							dlog.Printf("no session to restore")
+							action = recreateSession
 							continue
 						}
+
+						dlog.Printf("trying to restore session")
 						if err := c.ActivateSession(s); err != nil {
 							dlog.Printf("restore session failed")
 							action = recreateSession


### PR DESCRIPTION
This patch checks if the session to be restored exists before trying to
restore it. It also prevents the internal session variable from being
cleared during a reconnect since the client would then try to restore
the session only once.

Fixes #503