### PR TITLE
client: standardize use of atomic.Value

### DIFF
--- a/client_sub.go
+++ b/client_sub.go
@@ -165,7 +165,7 @@ func (c *Client) sendRepublishRequests(sub *Subscription, availableSeq []uint32)
 
 		debug.Printf("RepublishRequest: req=%s", debug.ToJSON(req))
 		var res *ua.RepublishResponse
-		err := c.sechan.SendRequest(req, c.Session().resp.AuthenticationToken, func(v interface{}) error {
+		err := c.SecureChannel().SendRequest(req, c.Session().resp.AuthenticationToken, func(v interface{}) error {
 			return safeAssign(v, &res)
 		})
 		debug.Printf("RepublishResponse: res=%s err=%v", debug.ToJSON(res), err)

--- a/client_sub.go
+++ b/client_sub.go
@@ -230,7 +230,7 @@ func (c *Client) updatePublishTimeout() {
 			maxTimeout = d
 		}
 	}
-	c.publishTimeout.Store(maxTimeout)
+	c.setPublishTimeout(maxTimeout)
 }
 
 func (c *Client) notifySubscriptionsOfError(ctx context.Context, subID uint32, err error) {
@@ -513,7 +513,7 @@ func (c *Client) sendPublishRequest() (*ua.PublishResponse, error) {
 
 	dlog.Printf("PublishRequest: %s", debug.ToJSON(req))
 	var res *ua.PublishResponse
-	err := c.sendWithTimeout(req, c.publishTimeout.Load().(time.Duration), func(v interface{}) error {
+	err := c.sendWithTimeout(req, c.publishTimeout(), func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	dlog.Printf("PublishResponse: %s", debug.ToJSON(res))


### PR DESCRIPTION
* use getters/setters for accessing the `atomic.Value` fields
* store the secure channel in an `atomic.Value`