### PR TITLE
[WIP] Fix hiding of errors in SecureChannel.readChunk

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -341,8 +341,7 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 	// read a full message from the underlying conn.
 	b, err := s.c.Receive()
 
-	sliceIsEmpty := b != nil && len(b) == 0
-	if err == io.EOF || sliceIsEmpty {
+	if err == io.EOF || err == nil && len(b) == 0 {
 		return nil, io.EOF
 	}
 	// do not wrap this error since it hides conn error

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -340,7 +340,9 @@ func (s *SecureChannel) receive(ctx context.Context) *response {
 func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 	// read a full message from the underlying conn.
 	b, err := s.c.Receive()
-	if err == io.EOF || len(b) == 0 {
+
+	sliceIsEmpty := b != nil && len(b) == 0
+	if err == io.EOF || sliceIsEmpty {
 		return nil, io.EOF
 	}
 	// do not wrap this error since it hides conn error


### PR DESCRIPTION
Related to #550 

`readChunk` of `secure_channel.go` was hiding the errors of `Conn.Receive`, because of a wrong comparison. `len(b) == 0` returns true whenever `b=nil`.