### PR TITLE
Drop WithContext methods and add context to all methods

### DIFF
--- a/client_sub.go
+++ b/client_sub.go
@@ -17,15 +17,7 @@ import (
 // Subscribe creates a Subscription with given parameters.
 // Parameters that have not been set are set to their default values.
 // See opcua.DefaultSubscription* constants
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (c *Client) Subscribe(params *SubscriptionParameters, notifyCh chan<- *PublishNotificationData) (*Subscription, error) {
-	return c.SubscribeWithContext(context.Background(), params, notifyCh)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (c *Client) SubscribeWithContext(ctx context.Context, params *SubscriptionParameters, notifyCh chan<- *PublishNotificationData) (*Subscription, error) {
+func (c *Client) Subscribe(ctx context.Context, params *SubscriptionParameters, notifyCh chan<- *PublishNotificationData) (*Subscription, error) {
 	stats.Client().Add("Subscribe", 1)
 
 	if params == nil {
@@ -43,7 +35,7 @@ func (c *Client) SubscribeWithContext(ctx context.Context, params *SubscriptionP
 	}
 
 	var res *ua.CreateSubscriptionResponse
-	err := c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	if err != nil {
@@ -118,7 +110,7 @@ func (c *Client) transferSubscriptions(ctx context.Context, ids []uint32) (*ua.T
 	}
 
 	var res *ua.TransferSubscriptionsResponse
-	err := c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	return res, err
@@ -186,7 +178,7 @@ func (c *Client) sendRepublishRequests(ctx context.Context, sub *Subscription, a
 
 		debug.Printf("RepublishRequest: req=%s", debug.ToJSON(req))
 		var res *ua.RepublishResponse
-		err := sc.SendRequestWithContext(ctx, req, s.resp.AuthenticationToken, func(v interface{}) error {
+		err := c.SecureChannel().SendRequest(ctx, req, c.Session().resp.AuthenticationToken, func(v interface{}) error {
 			return safeAssign(v, &res)
 		})
 		debug.Printf("RepublishResponse: res=%s err=%v", debug.ToJSON(res), err)

--- a/client_test.go
+++ b/client_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pascaldekloe/goe/verify"
+
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
-	"github.com/pascaldekloe/goe/verify"
 )
 
 func TestClient_Send_DoesNotPanicWhenDisconnected(t *testing.T) {
 	c := NewClient("opc.tcp://example.com:4840")
-	err := c.SendWithContext(context.Background(), &ua.ReadRequest{}, func(i interface{}) error {
+	err := c.Send(context.Background(), &ua.ReadRequest{}, func(i interface{}) error {
 		return nil
 	})
 	verify.Values(t, "", err, ua.StatusBadServerNotConnected)

--- a/examples/accesslevel/accesslevel.go
+++ b/examples/accesslevel/accesslevel.go
@@ -29,7 +29,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
@@ -37,19 +37,19 @@ func main() {
 	}
 
 	n := c.Node(id)
-	accessLevel, err := n.AccessLevelWithContext(ctx)
+	accessLevel, err := n.AccessLevel(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Print("AccessLevel: ", accessLevel)
 
-	userAccessLevel, err := n.UserAccessLevelWithContext(ctx)
+	userAccessLevel, err := n.UserAccessLevel(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Print("UserAccessLevel: ", userAccessLevel)
 
-	v, err := n.ValueWithContext(ctx)
+	v, err := n.Value(ctx)
 	switch {
 	case err != nil:
 		log.Fatal(err)

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -51,7 +51,7 @@ func browse(ctx context.Context, n *opcua.Node, path string, level int) ([]NodeD
 		return nil, nil
 	}
 
-	attrs, err := n.AttributesWithContext(ctx, ua.AttributeIDNodeClass, ua.AttributeIDBrowseName, ua.AttributeIDDescription, ua.AttributeIDAccessLevel, ua.AttributeIDDataType)
+	attrs, err := n.Attributes(ctx, ua.AttributeIDNodeClass, ua.AttributeIDBrowseName, ua.AttributeIDDescription, ua.AttributeIDAccessLevel, ua.AttributeIDDataType)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func browse(ctx context.Context, n *opcua.Node, path string, level int) ([]NodeD
 	}
 
 	browseChildren := func(refType uint32) error {
-		refs, err := n.ReferencedNodesWithContext(ctx, refType, ua.BrowseDirectionForward, ua.NodeClassAll, true)
+		refs, err := n.ReferencedNodes(ctx, refType, ua.BrowseDirectionForward, ua.NodeClassAll, true)
 		if err != nil {
 			return errors.Errorf("References: %d: %s", refType, err)
 		}
@@ -178,7 +178,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {

--- a/examples/crypto/crypto.go
+++ b/examples/crypto/crypto.go
@@ -67,10 +67,10 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	// Use our connection (read the server's time)
-	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).ValueWithContext(ctx)
+	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	// Detach our session and try re-establish it on a different secure channel
-	s, err := c.DetachSessionWithContext(ctx)
+	s, err := c.DetachSession(ctx)
 	if err != nil {
 		log.Fatalf("Error detaching session: %s", err)
 	}
@@ -90,16 +90,16 @@ func main() {
 
 	// Create a channel only and do not activate it automatically
 	d.Dial(ctx)
-	defer d.CloseWithContext(ctx)
+	defer d.Close(ctx)
 
 	// Activate the previous session on the new channel
-	err = d.ActivateSessionWithContext(ctx, s)
+	err = d.ActivateSession(ctx, s)
 	if err != nil {
 		log.Fatalf("Error reactivating session: %s", err)
 	}
 
 	// Read the time again to prove our session is still OK
-	v, err = d.Node(ua.NewNumericNodeID(0, 2258)).ValueWithContext(ctx)
+	v, err = d.Node(ua.NewNumericNodeID(0, 2258)).Value(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -51,9 +51,9 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
-	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).ValueWithContext(ctx)
+	v, err := c.Node(ua.NewNumericNodeID(0, 2258)).Value(ctx)
 	switch {
 	case err != nil:
 		log.Fatal(err)

--- a/examples/history-read/history-read.go
+++ b/examples/history-read/history-read.go
@@ -28,7 +28,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
@@ -54,7 +54,7 @@ func main() {
 		// Reset old nodes
 		nodesToRequest = make([]*ua.HistoryReadValueID, 0)
 
-		data, err := c.HistoryReadRawModifiedWithContext(ctx, nodes, &ua.ReadRawModifiedDetails{
+		data, err := c.HistoryReadRawModified(ctx, nodes, &ua.ReadRawModifiedDetails{
 			IsReadModified: false,
 			StartTime:      time.Now().UTC().AddDate(0, -1, 0),
 			EndTime:        time.Now().UTC().AddDate(0, 1, 0),

--- a/examples/method/method.go
+++ b/examples/method/method.go
@@ -28,7 +28,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	in := int64(12)
 	req := &ua.CallMethodRequest{
@@ -37,7 +37,7 @@ func main() {
 		InputArguments: []*ua.Variant{ua.MustVariant(in)},
 	}
 
-	resp, err := c.CallWithContext(ctx, req)
+	resp, err := c.Call(ctx, req)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/monitor/monitor.go
+++ b/examples/monitor/monitor.go
@@ -68,7 +68,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	m, err := monitor.NewNodeMonitor(c)
 	if err != nil {

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -32,7 +32,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
@@ -49,7 +49,7 @@ func main() {
 
 	var resp *ua.ReadResponse
 	for {
-		resp, err = c.ReadWithContext(ctx, req)
+		resp, err = c.Read(ctx, req)
 		if err == nil {
 			break
 		}

--- a/examples/regread/regread.go
+++ b/examples/regread/regread.go
@@ -29,14 +29,14 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
 		log.Fatalf("invalid node id: %v", err)
 	}
 
-	regResp, err := c.RegisterNodesWithContext(ctx, &ua.RegisterNodesRequest{
+	regResp, err := c.RegisterNodes(ctx, &ua.RegisterNodesRequest{
 		NodesToRegister: []*ua.NodeID{id},
 	})
 	if err != nil {
@@ -51,7 +51,7 @@ func main() {
 		TimestampsToReturn: ua.TimestampsToReturnBoth,
 	}
 
-	resp, err := c.ReadWithContext(ctx, req)
+	resp, err := c.Read(ctx, req)
 	if err != nil {
 		log.Fatalf("Read failed: %s", err)
 	}
@@ -60,7 +60,7 @@ func main() {
 	}
 	log.Print(resp.Results[0].Value.Value())
 
-	_, err = c.UnregisterNodesWithContext(ctx, &ua.UnregisterNodesRequest{
+	_, err = c.UnregisterNodes(ctx, &ua.UnregisterNodesRequest{
 		NodesToUnregister: []*ua.NodeID{id},
 	})
 	if err != nil {

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -64,11 +64,11 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	notifyCh := make(chan *opcua.PublishNotificationData)
 
-	sub, err := c.SubscribeWithContext(ctx, &opcua.SubscriptionParameters{
+	sub, err := c.Subscribe(ctx, &opcua.SubscriptionParameters{
 		Interval: *interval,
 	}, notifyCh)
 	if err != nil {
@@ -89,7 +89,7 @@ func main() {
 	} else {
 		miCreateRequest = valueRequest(id)
 	}
-	res, err := sub.Monitor(ua.TimestampsToReturnBoth, miCreateRequest)
+	res, err := sub.Monitor(ctx, ua.TimestampsToReturnBoth, miCreateRequest)
 	if err != nil || res.Results[0].StatusCode != ua.StatusOK {
 		log.Fatal(err)
 	}

--- a/examples/translate/translate.go
+++ b/examples/translate/translate.go
@@ -31,10 +31,10 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	root := c.Node(ua.NewTwoByteNodeID(id.ObjectsFolder))
-	nodeID, err := root.TranslateBrowsePathInNamespaceToNodeIDWithContext(ctx, uint16(*ns), *nodePath)
+	nodeID, err := root.TranslateBrowsePathInNamespaceToNodeID(ctx, uint16(*ns), *nodePath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/trigger/trigger.go
+++ b/examples/trigger/trigger.go
@@ -63,11 +63,11 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	notifyCh := make(chan *opcua.PublishNotificationData)
 
-	sub, err := c.Subscribe(&opcua.SubscriptionParameters{
+	sub, err := c.Subscribe(ctx, &opcua.SubscriptionParameters{
 		Interval: *interval,
 	}, notifyCh)
 	if err != nil {
@@ -105,13 +105,13 @@ func main() {
 		},
 	}
 
-	subRes, err := sub.Monitor(ua.TimestampsToReturnBoth, miCreateRequests...)
+	subRes, err := sub.Monitor(ctx, ua.TimestampsToReturnBoth, miCreateRequests...)
 	if err != nil || subRes.Results[0].StatusCode != ua.StatusOK {
 		log.Fatal(err)
 	}
 
 	triggeringServerID, triggeredServerID := subRes.Results[0].MonitoredItemID, subRes.Results[1].MonitoredItemID
-	tRes, err := sub.SetTriggering(triggeringServerID, []uint32{triggeredServerID}, nil)
+	tRes, err := sub.SetTriggering(ctx, triggeringServerID, []uint32{triggeredServerID}, nil)
 
 	if err != nil {
 		log.Fatal(err)

--- a/examples/udt/udt.go
+++ b/examples/udt/udt.go
@@ -59,9 +59,9 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
-	v, err := c.Node(id).ValueWithContext(ctx)
+	v, err := c.Node(id).Value(ctx)
 	switch {
 	case err != nil:
 		log.Fatal(err)

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -30,7 +30,7 @@ func main() {
 	if err := c.Connect(ctx); err != nil {
 		log.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	id, err := ua.ParseNodeID(*nodeID)
 	if err != nil {
@@ -55,7 +55,7 @@ func main() {
 		},
 	}
 
-	resp, err := c.WriteWithContext(ctx, req)
+	resp, err := c.Write(ctx, req)
 	if err != nil {
 		log.Fatalf("Write failed: %s", err)
 	}

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -102,11 +102,11 @@ func newSubscription(ctx context.Context, m *NodeMonitor, params *opcua.Subscrip
 	}
 
 	var err error
-	if s.sub, err = m.client.SubscribeWithContext(ctx, params, s.internalNotifyCh); err != nil {
+	if s.sub, err = m.client.Subscribe(ctx, params, s.internalNotifyCh); err != nil {
 		return nil, err
 	}
 
-	if err = s.AddNodesWithContext(ctx, nodes...); err != nil {
+	if err = s.AddNodes(ctx, nodes...); err != nil {
 		return nil, err
 	}
 
@@ -254,32 +254,16 @@ func (s *Subscription) Dropped() uint64 {
 }
 
 // AddNodes adds nodes defined by their string representation
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) AddNodes(nodes ...string) error {
-	return s.AddNodesWithContext(context.Background(), nodes...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) AddNodesWithContext(ctx context.Context, nodes ...string) error {
+func (s *Subscription) AddNodes(ctx context.Context, nodes ...string) error {
 	nodeIDs, err := parseNodeSlice(nodes...)
 	if err != nil {
 		return err
 	}
-	return s.AddNodeIDsWithContext(ctx, nodeIDs...)
+	return s.AddNodeIDs(ctx, nodeIDs...)
 }
 
 // AddNodeIDs adds nodes
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) AddNodeIDs(nodes ...*ua.NodeID) error {
-	return s.AddNodeIDsWithContext(context.Background(), nodes...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) AddNodeIDsWithContext(ctx context.Context, nodes ...*ua.NodeID) error {
+func (s *Subscription) AddNodeIDs(ctx context.Context, nodes ...*ua.NodeID) error {
 	requests := make([]Request, len(nodes))
 
 	for i, node := range nodes {
@@ -288,20 +272,12 @@ func (s *Subscription) AddNodeIDsWithContext(ctx context.Context, nodes ...*ua.N
 			MonitoringMode: ua.MonitoringModeReporting,
 		}
 	}
-	_, err := s.AddMonitorItemsWithContext(ctx, requests...)
+	_, err := s.AddMonitorItems(ctx, requests...)
 	return err
 }
 
 // AddMonitorItems adds nodes with monitoring parameters to the subscription
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) AddMonitorItems(nodes ...Request) ([]Item, error) {
-	return s.AddMonitorItemsWithContext(context.Background(), nodes...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) AddMonitorItemsWithContext(ctx context.Context, nodes ...Request) ([]Item, error) {
+func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([]Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -328,7 +304,7 @@ func (s *Subscription) AddMonitorItemsWithContext(ctx context.Context, nodes ...
 		}
 		toAdd = append(toAdd, request)
 	}
-	resp, err := s.sub.MonitorWithContext(ctx, ua.TimestampsToReturnBoth, toAdd...)
+	resp, err := s.sub.Monitor(ctx, ua.TimestampsToReturnBoth, toAdd...)
 	if err != nil {
 		return nil, err
 	}
@@ -358,32 +334,16 @@ func (s *Subscription) AddMonitorItemsWithContext(ctx context.Context, nodes ...
 }
 
 // RemoveNodes removes nodes defined by their string representation
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) RemoveNodes(nodes ...string) error {
-	return s.RemoveNodesWithContext(context.Background(), nodes...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) RemoveNodesWithContext(ctx context.Context, nodes ...string) error {
+func (s *Subscription) RemoveNodes(ctx context.Context, nodes ...string) error {
 	nodeIDs, err := parseNodeSlice(nodes...)
 	if err != nil {
 		return err
 	}
-	return s.RemoveNodeIDsWithContext(ctx, nodeIDs...)
+	return s.RemoveNodeIDs(ctx, nodeIDs...)
 }
 
 // RemoveNodeIDs removes nodes
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) RemoveNodeIDs(nodes ...*ua.NodeID) error {
-	return s.RemoveNodeIDsWithContext(context.Background(), nodes...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) RemoveNodeIDsWithContext(ctx context.Context, nodes ...*ua.NodeID) error {
+func (s *Subscription) RemoveNodeIDs(ctx context.Context, nodes ...*ua.NodeID) error {
 	if len(nodes) == 0 {
 		return nil
 	}
@@ -398,19 +358,11 @@ func (s *Subscription) RemoveNodeIDsWithContext(ctx context.Context, nodes ...*u
 		}
 	}
 
-	return s.RemoveMonitorItemsWithContext(ctx, toRemove...)
+	return s.RemoveMonitorItems(ctx, toRemove...)
 }
 
 // RemoveMonitorItems removes nodes
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) RemoveMonitorItems(items ...Item) error {
-	return s.RemoveMonitorItemsWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) RemoveMonitorItemsWithContext(ctx context.Context, items ...Item) error {
+func (s *Subscription) RemoveMonitorItems(ctx context.Context, items ...Item) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -429,7 +381,7 @@ func (s *Subscription) RemoveMonitorItemsWithContext(ctx context.Context, items 
 		toRemove = append(toRemove, item.id)
 	}
 
-	resp, err := s.sub.UnmonitorWithContext(ctx, toRemove...)
+	resp, err := s.sub.Unmonitor(ctx, toRemove...)
 	if err != nil {
 		return err
 	}
@@ -452,16 +404,8 @@ func (s *Subscription) RemoveMonitorItemsWithContext(ctx context.Context, items 
 }
 
 // Stats returns statistics for the subscription
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) Stats() (*ua.SubscriptionDiagnosticsDataType, error) {
-	return s.StatsWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) StatsWithContext(ctx context.Context) (*ua.SubscriptionDiagnosticsDataType, error) {
-	return s.sub.StatsWithContext(ctx)
+func (s *Subscription) Stats(ctx context.Context) (*ua.SubscriptionDiagnosticsDataType, error) {
+	return s.sub.Stats(ctx)
 }
 
 func parseNodeSlice(nodes ...string) ([]*ua.NodeID, error) {

--- a/node.go
+++ b/node.go
@@ -27,16 +27,8 @@ func (n *Node) String() string {
 }
 
 // NodeClass returns the node class attribute.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
 func (n *Node) NodeClass(ctx context.Context) (ua.NodeClass, error) {
-	return n.NodeClassWithContext(ctx)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) NodeClassWithContext(ctx context.Context) (ua.NodeClass, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDNodeClass)
+	v, err := n.Attribute(ctx, ua.AttributeIDNodeClass)
 	if err != nil {
 		return 0, err
 	}
@@ -44,16 +36,8 @@ func (n *Node) NodeClassWithContext(ctx context.Context) (ua.NodeClass, error) {
 }
 
 // BrowseName returns the browse name of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) BrowseName() (*ua.QualifiedName, error) {
-	return n.BrowseNameWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) BrowseNameWithContext(ctx context.Context) (*ua.QualifiedName, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDBrowseName)
+func (n *Node) BrowseName(ctx context.Context) (*ua.QualifiedName, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDBrowseName)
 	if err != nil {
 		return nil, err
 	}
@@ -61,16 +45,8 @@ func (n *Node) BrowseNameWithContext(ctx context.Context) (*ua.QualifiedName, er
 }
 
 // Description returns the description of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) Description() (*ua.LocalizedText, error) {
-	return n.DescriptionWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) DescriptionWithContext(ctx context.Context) (*ua.LocalizedText, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDDescription)
+func (n *Node) Description(ctx context.Context) (*ua.LocalizedText, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDDescription)
 	if err != nil {
 		return nil, err
 	}
@@ -78,16 +54,8 @@ func (n *Node) DescriptionWithContext(ctx context.Context) (*ua.LocalizedText, e
 }
 
 // DisplayName returns the display name of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) DisplayName() (*ua.LocalizedText, error) {
-	return n.DisplayNameWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) DisplayNameWithContext(ctx context.Context) (*ua.LocalizedText, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDDisplayName)
+func (n *Node) DisplayName(ctx context.Context) (*ua.LocalizedText, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDDisplayName)
 	if err != nil {
 		return nil, err
 	}
@@ -97,16 +65,8 @@ func (n *Node) DisplayNameWithContext(ctx context.Context) (*ua.LocalizedText, e
 // AccessLevel returns the access level of the node.
 // The returned value is a mask where multiple values can be
 // set, e.g. read and write.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) AccessLevel() (ua.AccessLevelType, error) {
-	return n.AccessLevelWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) AccessLevelWithContext(ctx context.Context) (ua.AccessLevelType, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDAccessLevel)
+func (n *Node) AccessLevel(ctx context.Context) (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDAccessLevel)
 	if err != nil {
 		return 0, err
 	}
@@ -115,16 +75,8 @@ func (n *Node) AccessLevelWithContext(ctx context.Context) (ua.AccessLevelType, 
 
 // HasAccessLevel returns true if all bits from mask are
 // set in the access level mask of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) HasAccessLevel(mask ua.AccessLevelType) (bool, error) {
-	return n.HasAccessLevelWithContext(context.Background(), mask)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) HasAccessLevelWithContext(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
-	v, err := n.AccessLevelWithContext(ctx)
+func (n *Node) HasAccessLevel(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
+	v, err := n.AccessLevel(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -132,16 +84,8 @@ func (n *Node) HasAccessLevelWithContext(ctx context.Context, mask ua.AccessLeve
 }
 
 // UserAccessLevel returns the access level of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) UserAccessLevel() (ua.AccessLevelType, error) {
-	return n.UserAccessLevelWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) UserAccessLevelWithContext(ctx context.Context) (ua.AccessLevelType, error) {
-	v, err := n.AttributeWithContext(ctx, ua.AttributeIDUserAccessLevel)
+func (n *Node) UserAccessLevel(ctx context.Context) (ua.AccessLevelType, error) {
+	v, err := n.Attribute(ctx, ua.AttributeIDUserAccessLevel)
 	if err != nil {
 		return 0, err
 	}
@@ -150,16 +94,8 @@ func (n *Node) UserAccessLevelWithContext(ctx context.Context) (ua.AccessLevelTy
 
 // HasUserAccessLevel returns true if all bits from mask are
 // set in the user access level mask of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) HasUserAccessLevel(mask ua.AccessLevelType) (bool, error) {
-	return n.HasUserAccessLevelWithContext(context.Background(), mask)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) HasUserAccessLevelWithContext(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
-	v, err := n.UserAccessLevelWithContext(ctx)
+func (n *Node) HasUserAccessLevel(ctx context.Context, mask ua.AccessLevelType) (bool, error) {
+	v, err := n.UserAccessLevel(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -167,31 +103,15 @@ func (n *Node) HasUserAccessLevelWithContext(ctx context.Context, mask ua.Access
 }
 
 // Value returns the value of the node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) Value() (*ua.Variant, error) {
-	return n.ValueWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) ValueWithContext(ctx context.Context) (*ua.Variant, error) {
-	return n.AttributeWithContext(ctx, ua.AttributeIDValue)
+func (n *Node) Value(ctx context.Context) (*ua.Variant, error) {
+	return n.Attribute(ctx, ua.AttributeIDValue)
 }
 
 // Attribute returns the attribute of the node. with the given id.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) Attribute(attrID ua.AttributeID) (*ua.Variant, error) {
-	return n.AttributeWithContext(context.Background(), attrID)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) AttributeWithContext(ctx context.Context, attrID ua.AttributeID) (*ua.Variant, error) {
+func (n *Node) Attribute(ctx context.Context, attrID ua.AttributeID) (*ua.Variant, error) {
 	rv := &ua.ReadValueID{NodeID: n.ID, AttributeID: attrID}
 	req := &ua.ReadRequest{NodesToRead: []*ua.ReadValueID{rv}}
-	res, err := n.c.ReadWithContext(ctx, req)
+	res, err := n.c.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -208,21 +128,13 @@ func (n *Node) AttributeWithContext(ctx context.Context, attrID ua.AttributeID) 
 }
 
 // Attributes returns the given node attributes.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) Attributes(attrID ...ua.AttributeID) ([]*ua.DataValue, error) {
-	return n.AttributesWithContext(context.Background(), attrID...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) AttributesWithContext(ctx context.Context, attrID ...ua.AttributeID) ([]*ua.DataValue, error) {
+func (n *Node) Attributes(ctx context.Context, attrID ...ua.AttributeID) ([]*ua.DataValue, error) {
 	req := &ua.ReadRequest{}
 	for _, id := range attrID {
 		rv := &ua.ReadValueID{NodeID: n.ID, AttributeID: id}
 		req.NodesToRead = append(req.NodesToRead, rv)
 	}
-	res, err := n.c.ReadWithContext(ctx, req)
+	res, err := n.c.Read(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -230,36 +142,20 @@ func (n *Node) AttributesWithContext(ctx context.Context, attrID ...ua.Attribute
 }
 
 // Children returns the child nodes which match the node class mask.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) Children(refs uint32, mask ua.NodeClass) ([]*Node, error) {
-	return n.ChildrenWithContext(context.Background(), refs, mask)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) ChildrenWithContext(ctx context.Context, refs uint32, mask ua.NodeClass) ([]*Node, error) {
+func (n *Node) Children(ctx context.Context, refs uint32, mask ua.NodeClass) ([]*Node, error) {
 	if refs == 0 {
 		refs = id.HierarchicalReferences
 	}
-	return n.ReferencedNodesWithContext(ctx, refs, ua.BrowseDirectionForward, mask, true)
+	return n.ReferencedNodes(ctx, refs, ua.BrowseDirectionForward, mask, true)
 }
 
 // ReferencedNodes returns the nodes referenced by this node.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) ReferencedNodes(refs uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*Node, error) {
-	return n.ReferencedNodesWithContext(context.Background(), refs, dir, mask, includeSubtypes)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) ReferencedNodesWithContext(ctx context.Context, refs uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*Node, error) {
+func (n *Node) ReferencedNodes(ctx context.Context, refs uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*Node, error) {
 	if refs == 0 {
 		refs = id.References
 	}
 	var nodes []*Node
-	res, err := n.ReferencesWithContext(ctx, refs, dir, mask, includeSubtypes)
+	res, err := n.References(ctx, refs, dir, mask, includeSubtypes)
 	if err != nil {
 		return nil, err
 	}
@@ -271,17 +167,9 @@ func (n *Node) ReferencedNodesWithContext(ctx context.Context, refs uint32, dir 
 
 // References returns all references for the node.
 //
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-//
 // todo(fs): this is not complete since it only returns the
 // todo(fs): top-level reference at this point.
-func (n *Node) References(refType uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*ua.ReferenceDescription, error) {
-	return n.ReferencesWithContext(context.Background(), refType, dir, mask, includeSubtypes)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) ReferencesWithContext(ctx context.Context, refType uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*ua.ReferenceDescription, error) {
+func (n *Node) References(ctx context.Context, refType uint32, dir ua.BrowseDirection, mask ua.NodeClass, includeSubtypes bool) ([]*ua.ReferenceDescription, error) {
 	if refType == 0 {
 		refType = id.References
 	}
@@ -306,7 +194,7 @@ func (n *Node) ReferencesWithContext(ctx context.Context, refType uint32, dir ua
 		NodesToBrowse:                 []*ua.BrowseDescription{desc},
 	}
 
-	resp, err := n.c.BrowseWithContext(ctx, req)
+	resp, err := n.c.Browse(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +208,7 @@ func (n *Node) browseNext(ctx context.Context, results []*ua.BrowseResult) ([]*u
 			ContinuationPoints:        [][]byte{results[0].ContinuationPoint},
 			ReleaseContinuationPoints: false,
 		}
-		resp, err := n.c.BrowseNextWithContext(ctx, req)
+		resp, err := n.c.BrowseNext(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -331,15 +219,7 @@ func (n *Node) browseNext(ctx context.Context, results []*ua.BrowseResult) ([]*u
 }
 
 // TranslateBrowsePathsToNodeIDs translates an array of browseName segments to NodeIDs.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) TranslateBrowsePathsToNodeIDs(pathNames []*ua.QualifiedName) (*ua.NodeID, error) {
-	return n.TranslateBrowsePathsToNodeIDsWithContext(context.Background(), pathNames)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) TranslateBrowsePathsToNodeIDsWithContext(ctx context.Context, pathNames []*ua.QualifiedName) (*ua.NodeID, error) {
+func (n *Node) TranslateBrowsePathsToNodeIDs(ctx context.Context, pathNames []*ua.QualifiedName) (*ua.NodeID, error) {
 	req := ua.TranslateBrowsePathsToNodeIDsRequest{
 		BrowsePaths: []*ua.BrowsePath{
 			{
@@ -361,7 +241,7 @@ func (n *Node) TranslateBrowsePathsToNodeIDsWithContext(ctx context.Context, pat
 	}
 
 	var nodeID *ua.NodeID
-	err := n.c.SendWithContext(ctx, &req, func(i interface{}) error {
+	err := n.c.Send(ctx, &req, func(i interface{}) error {
 		if resp, ok := i.(*ua.TranslateBrowsePathsToNodeIDsResponse); ok {
 			if len(resp.Results) == 0 {
 				return ua.StatusBadUnexpectedError
@@ -383,20 +263,12 @@ func (n *Node) TranslateBrowsePathsToNodeIDsWithContext(ctx context.Context, pat
 }
 
 // TranslateBrowsePathInNamespaceToNodeID translates a browseName to a NodeID within the same namespace.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (n *Node) TranslateBrowsePathInNamespaceToNodeID(ns uint16, browsePath string) (*ua.NodeID, error) {
-	return n.TranslateBrowsePathInNamespaceToNodeIDWithContext(context.Background(), ns, browsePath)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (n *Node) TranslateBrowsePathInNamespaceToNodeIDWithContext(ctx context.Context, ns uint16, browsePath string) (*ua.NodeID, error) {
+func (n *Node) TranslateBrowsePathInNamespaceToNodeID(ctx context.Context, ns uint16, browsePath string) (*ua.NodeID, error) {
 	segments := strings.Split(browsePath, ".")
 	var names []*ua.QualifiedName
 	for _, segment := range segments {
 		qn := &ua.QualifiedName{NamespaceIndex: ns, Name: segment}
 		names = append(names, qn)
 	}
-	return n.TranslateBrowsePathsToNodeIDsWithContext(ctx, names)
+	return n.TranslateBrowsePathsToNodeIDs(ctx, names)
 }

--- a/subscription.go
+++ b/subscription.go
@@ -94,7 +94,7 @@ func (s *Subscription) delete(ctx context.Context) error {
 	}
 
 	var res *ua.DeleteSubscriptionsResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 
@@ -111,14 +111,7 @@ func (s *Subscription) delete(ctx context.Context) error {
 	}
 }
 
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) Monitor(ts ua.TimestampsToReturn, items ...*ua.MonitoredItemCreateRequest) (*ua.CreateMonitoredItemsResponse, error) {
-	return s.MonitorWithContext(context.Background(), ts, items...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) MonitorWithContext(ctx context.Context, ts ua.TimestampsToReturn, items ...*ua.MonitoredItemCreateRequest) (*ua.CreateMonitoredItemsResponse, error) {
+func (s *Subscription) Monitor(ctx context.Context, ts ua.TimestampsToReturn, items ...*ua.MonitoredItemCreateRequest) (*ua.CreateMonitoredItemsResponse, error) {
 	stats.Subscription().Add("Monitor", 1)
 	stats.Subscription().Add("MonitoredItems", int64(len(items)))
 
@@ -130,7 +123,7 @@ func (s *Subscription) MonitorWithContext(ctx context.Context, ts ua.TimestampsT
 	}
 
 	var res *ua.CreateMonitoredItemsResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 
@@ -153,14 +146,7 @@ func (s *Subscription) MonitorWithContext(ctx context.Context, ts ua.TimestampsT
 	return res, err
 }
 
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) Unmonitor(monitoredItemIDs ...uint32) (*ua.DeleteMonitoredItemsResponse, error) {
-	return s.UnmonitorWithContext(context.Background(), monitoredItemIDs...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) UnmonitorWithContext(ctx context.Context, monitoredItemIDs ...uint32) (*ua.DeleteMonitoredItemsResponse, error) {
+func (s *Subscription) Unmonitor(ctx context.Context, monitoredItemIDs ...uint32) (*ua.DeleteMonitoredItemsResponse, error) {
 	stats.Subscription().Add("Unmonitor", 1)
 	stats.Subscription().Add("UnmonitoredItems", int64(len(monitoredItemIDs)))
 
@@ -170,7 +156,7 @@ func (s *Subscription) UnmonitorWithContext(ctx context.Context, monitoredItemID
 	}
 
 	var res *ua.DeleteMonitoredItemsResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	if err != nil {
@@ -187,14 +173,7 @@ func (s *Subscription) UnmonitorWithContext(ctx context.Context, monitoredItemID
 	return res, nil
 }
 
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) ModifyMonitoredItems(ts ua.TimestampsToReturn, items ...*ua.MonitoredItemModifyRequest) (*ua.ModifyMonitoredItemsResponse, error) {
-	return s.ModifyMonitoredItemsWithContext(context.Background(), ts, items...)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) ModifyMonitoredItemsWithContext(ctx context.Context, ts ua.TimestampsToReturn, items ...*ua.MonitoredItemModifyRequest) (*ua.ModifyMonitoredItemsResponse, error) {
+func (s *Subscription) ModifyMonitoredItems(ctx context.Context, ts ua.TimestampsToReturn, items ...*ua.MonitoredItemModifyRequest) (*ua.ModifyMonitoredItemsResponse, error) {
 	stats.Subscription().Add("ModifyMonitoredItems", 1)
 	stats.Subscription().Add("ModifiedMonitoredItems", int64(len(items)))
 
@@ -213,7 +192,7 @@ func (s *Subscription) ModifyMonitoredItemsWithContext(ctx context.Context, ts u
 		ItemsToModify:      items,
 	}
 	var res *ua.ModifyMonitoredItemsResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	if err != nil {
@@ -244,15 +223,7 @@ func (s *Subscription) ModifyMonitoredItemsWithContext(ctx context.Context, ts u
 // SetTriggering sends a request to the server to add and/or remove triggering links from a triggering item.
 // To add links from a triggering item to an item to report provide the server assigned ID(s) in the `add` argument.
 // To remove links from a triggering item to an item to report provide the server assigned ID(s) in the `remove` argument.
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) SetTriggering(triggeringItemID uint32, add, remove []uint32) (*ua.SetTriggeringResponse, error) {
-	return s.SetTriggeringWithContext(context.Background(), triggeringItemID, add, remove)
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) SetTriggeringWithContext(ctx context.Context, triggeringItemID uint32, add, remove []uint32) (*ua.SetTriggeringResponse, error) {
+func (s *Subscription) SetTriggering(ctx context.Context, triggeringItemID uint32, add, remove []uint32) (*ua.SetTriggeringResponse, error) {
 	stats.Subscription().Add("SetTriggering", 1)
 
 	// Part 4, 5.12.5.2 SetTriggering Service Parameters
@@ -264,7 +235,7 @@ func (s *Subscription) SetTriggeringWithContext(ctx context.Context, triggeringI
 	}
 
 	var res *ua.SetTriggeringResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	return res, err
@@ -290,21 +261,13 @@ func (s *Subscription) notify(ctx context.Context, data *PublishNotificationData
 }
 
 // Stats returns a diagnostic struct with metadata about the current subscription
-//
-// Note: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *Subscription) Stats() (*ua.SubscriptionDiagnosticsDataType, error) {
-	return s.StatsWithContext(context.Background())
-}
-
-// Note: Starting with v0.5 this method is superseded by the non 'WithContext' method.
-func (s *Subscription) StatsWithContext(ctx context.Context) (*ua.SubscriptionDiagnosticsDataType, error) {
+func (s *Subscription) Stats(ctx context.Context) (*ua.SubscriptionDiagnosticsDataType, error) {
 	// TODO(kung-foo): once browsing feature is merged, attempt to get direct access to the
 	// diagnostics node. for example, Prosys lists them like:
 	// i=2290/ns=1;g=918ee6f4-2d25-4506-980d-e659441c166d
 	// maybe cache the nodeid to speed up future stats queries
 	node := s.c.Node(ua.NewNumericNodeID(0, id.Server_ServerDiagnostics_SubscriptionDiagnosticsArray))
-	v, err := node.ValueWithContext(ctx)
+	v, err := node.Value(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +324,7 @@ func (s *Subscription) recreate_NeedsSubMuxLock(ctx context.Context) error {
 			SubscriptionIDs: []uint32{s.SubscriptionID},
 		}
 		var res *ua.DeleteSubscriptionsResponse
-		_ = s.c.SendWithContext(ctx, req, func(v interface{}) error {
+		_ = s.c.Send(ctx, req, func(v interface{}) error {
 			return safeAssign(v, &res)
 		})
 		dlog.Print("subscription deleted")
@@ -378,7 +341,7 @@ func (s *Subscription) recreate_NeedsSubMuxLock(ctx context.Context) error {
 		Priority:                    params.Priority,
 	}
 	var res *ua.CreateSubscriptionResponse
-	err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+	err := s.c.Send(ctx, req, func(v interface{}) error {
 		return safeAssign(v, &res)
 	})
 	if err != nil {
@@ -421,7 +384,7 @@ func (s *Subscription) recreate_NeedsSubMuxLock(ctx context.Context) error {
 		}
 
 		var res *ua.CreateMonitoredItemsResponse
-		err := s.c.SendWithContext(ctx, req, func(v interface{}) error {
+		err := s.c.Send(ctx, req, func(v interface{}) error {
 			return safeAssign(v, &res)
 		})
 		if err != nil {

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -722,27 +722,11 @@ func (s *SecureChannel) Renew(ctx context.Context) error {
 }
 
 // SendRequest sends the service request and calls h with the response.
-// Deprecated: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *SecureChannel) SendRequest(req ua.Request, authToken *ua.NodeID, h func(interface{}) error) error {
-	return s.SendRequestWithContext(context.Background(), req, authToken, h)
+func (s *SecureChannel) SendRequest(ctx context.Context, req ua.Request, authToken *ua.NodeID, h func(interface{}) error) error {
+	return s.SendRequestWithTimeout(ctx, req, authToken, s.cfg.RequestTimeout, h)
 }
 
-// Note: This method will be replaced by the non "WithContext()" version
-// of this method.
-func (s *SecureChannel) SendRequestWithContext(ctx context.Context, req ua.Request, authToken *ua.NodeID, h func(interface{}) error) error {
-	return s.SendRequestWithTimeoutWithContext(ctx, req, authToken, s.cfg.RequestTimeout, h)
-}
-
-// Deprecated: Starting with v0.5 this method will require a context
-// and the corresponding XXXWithContext(ctx) method will be removed.
-func (s *SecureChannel) SendRequestWithTimeout(req ua.Request, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
-	return s.SendRequestWithTimeoutWithContext(context.Background(), req, authToken, timeout, h)
-}
-
-// Note: This method will be replaced by the non "WithContext()" version
-// of this method.
-func (s *SecureChannel) SendRequestWithTimeoutWithContext(ctx context.Context, req ua.Request, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
+func (s *SecureChannel) SendRequestWithTimeout(ctx context.Context, req ua.Request, authToken *ua.NodeID, timeout time.Duration, h func(interface{}) error) error {
 	s.reqLocker.waitIfLock()
 	active, err := s.getActiveChannelInstance()
 	if err != nil {
@@ -860,7 +844,7 @@ func (s *SecureChannel) close() error {
 	default:
 	}
 
-	err := s.SendRequestWithContext(context.Background(), &ua.CloseSecureChannelRequest{}, nil, nil)
+	err := s.SendRequest(context.Background(), &ua.CloseSecureChannelRequest{}, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/uatest/method_test.go
+++ b/uatest/method_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pascaldekloe/goe/verify"
+
 	"github.com/gopcua/opcua"
 	"github.com/gopcua/opcua/ua"
-	"github.com/pascaldekloe/goe/verify"
 )
 
 type Complex struct {
@@ -64,11 +65,11 @@ func TestCallMethod(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	for _, tt := range tests {
 		t.Run(tt.req.ObjectID.String(), func(t *testing.T) {
-			resp, err := c.CallWithContext(ctx, tt.req)
+			resp, err := c.Call(ctx, tt.req)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/uatest/namespace_test.go
+++ b/uatest/namespace_test.go
@@ -22,10 +22,10 @@ func TestNamespace(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	t.Run("NamespaceArray", func(t *testing.T) {
-		got, err := c.NamespaceArrayWithContext(ctx)
+		got, err := c.NamespaceArray(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -37,7 +37,7 @@ func TestNamespace(t *testing.T) {
 		verify.Values(t, "", got, want)
 	})
 	t.Run("FindNamespace", func(t *testing.T) {
-		ns, err := c.FindNamespaceWithContext(ctx, "http://gopcua.com/")
+		ns, err := c.FindNamespace(ctx, "http://gopcua.com/")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,7 +46,7 @@ func TestNamespace(t *testing.T) {
 		}
 	})
 	t.Run("UpdateNamespaces", func(t *testing.T) {
-		err := c.UpdateNamespacesWithContext(ctx)
+		err := c.UpdateNamespaces(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/uatest/read_test.go
+++ b/uatest/read_test.go
@@ -37,7 +37,7 @@ func TestRead(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestRead(t *testing.T) {
 func testRead(t *testing.T, ctx context.Context, c *opcua.Client, v interface{}, id *ua.NodeID) {
 	t.Helper()
 
-	resp, err := c.ReadWithContext(ctx, &ua.ReadRequest{
+	resp, err := c.Read(ctx, &ua.ReadRequest{
 		NodesToRead: []*ua.ReadValueID{
 			&ua.ReadValueID{NodeID: id},
 		},
@@ -74,7 +74,7 @@ func testRead(t *testing.T, ctx context.Context, c *opcua.Client, v interface{},
 func testRegisteredRead(t *testing.T, ctx context.Context, c *opcua.Client, v interface{}, id *ua.NodeID) {
 	t.Helper()
 
-	resp, err := c.RegisterNodesWithContext(ctx, &ua.RegisterNodesRequest{
+	resp, err := c.RegisterNodes(ctx, &ua.RegisterNodesRequest{
 		NodesToRegister: []*ua.NodeID{id},
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func testRegisteredRead(t *testing.T, ctx context.Context, c *opcua.Client, v in
 	testRead(t, ctx, c, v, resp.RegisteredNodeIDs[0])
 	testRead(t, ctx, c, v, resp.RegisteredNodeIDs[0])
 
-	_, err = c.UnregisterNodesWithContext(ctx, &ua.UnregisterNodesRequest{
+	_, err = c.UnregisterNodes(ctx, &ua.UnregisterNodesRequest{
 		NodesToUnregister: []*ua.NodeID{id},
 	})
 	if err != nil {

--- a/uatest/read_unknow_node_id_test.go
+++ b/uatest/read_unknow_node_id_test.go
@@ -24,12 +24,12 @@ func TestReadUnknowNodeID(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	// read node with unknown extension object
 	// This should be OK
 	nodeWithUnknownType := ua.NewStringNodeID(2, "IntValZero")
-	resp, err := c.Read(&ua.ReadRequest{
+	resp, err := c.Read(ctx, &ua.ReadRequest{
 		NodesToRead: []*ua.ReadValueID{
 			{NodeID: nodeWithUnknownType},
 		},
@@ -43,7 +43,7 @@ func TestReadUnknowNodeID(t *testing.T) {
 	}
 
 	// check that the connection is still usable by reading another node.
-	_, err = c.ReadWithContext(ctx, &ua.ReadRequest{
+	_, err = c.Read(ctx, &ua.ReadRequest{
 		NodesToRead: []*ua.ReadValueID{
 			{
 				NodeID: ua.NewNumericNodeID(0, id.Server_ServerStatus_State),

--- a/uatest/reconnection_test.go
+++ b/uatest/reconnection_test.go
@@ -31,7 +31,7 @@ func TestAutoReconnection(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	m, err := monitor.NewNodeMonitor(c)
 	if err != nil {
@@ -103,7 +103,7 @@ func TestAutoReconnection(t *testing.T) {
 
 			downC := make(chan struct{}, 1)
 			dTimeout := time.NewTimer(disconnectTimeout)
-			go c.CallWithContext(ctx, tt.req)
+			go c.Call(ctx, tt.req)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {

--- a/uatest/stats_test.go
+++ b/uatest/stats_test.go
@@ -32,8 +32,7 @@ func TestStats(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-
-	c.CloseWithContext(ctx)
+	c.Close(ctx)
 
 	want := map[string]*expvar.Int{
 		"Dial":             newExpVarInt(1),

--- a/uatest/write_test.go
+++ b/uatest/write_test.go
@@ -36,7 +36,7 @@ func TestWrite(t *testing.T) {
 	if err := c.Connect(ctx); err != nil {
 		t.Fatal(err)
 	}
-	defer c.CloseWithContext(ctx)
+	defer c.Close(ctx)
 
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestWrite(t *testing.T) {
 func testWrite(t *testing.T, ctx context.Context, c *opcua.Client, status ua.StatusCode, req *ua.WriteRequest) {
 	t.Helper()
 
-	resp, err := c.WriteWithContext(ctx, req)
+	resp, err := c.Write(ctx, req)
 	if err != nil {
 		t.Fatalf("Write failed: %s", err)
 	}


### PR DESCRIPTION
This patch drops the WithContext() methods and requires that all existing
methods have a context.

**NOTE THAT THIS IS A BREAKING CHANGE!!!**

Fixes #553