### PR TITLE
fix: check connection before closing

### DIFF
--- a/client.go
+++ b/client.go
@@ -585,7 +585,9 @@ func (c *Client) CloseWithContext(ctx context.Context) error {
 
 	// close the connection but ignore the error since there isn't
 	// anything we can do about it anyway
-	c.conn.Close()
+	if c.conn != nil {
+		c.conn.Close()
+	}
 
 	return nil
 }


### PR DESCRIPTION
A user of Telegraf reported a panic when the client was trying to close
the connection, but it was already closed. See influxdata/telegraf#10595
for more details.

Fixes #567 
Closes #568 