### PR TITLE
Add support for arrays

### DIFF
--- a/ua/decode.go
+++ b/ua/decode.go
@@ -128,7 +128,7 @@ func decodeSlice(b []byte, val reflect.Value, name string) (int, error) {
 	}
 
 	if n > math.MaxInt32 {
-		return buf.Pos(), errors.Errorf("array too large: %d", n)
+		return buf.Pos(), errors.Errorf("array too large: %d > %d", n, math.MaxInt32)
 	}
 
 	// elemType is the type of the slice elements
@@ -178,11 +178,11 @@ func decodeArray(b []byte, val reflect.Value, name string) (int, error) {
 	}
 
 	if n > math.MaxInt32 {
-		return buf.Pos(), errors.Errorf("array too large: %d", n)
+		return buf.Pos(), errors.Errorf("array too large: %d > %d", n, math.MaxInt32)
 	}
 
 	if n > uint32(val.Len()) {
-		return buf.Pos(), errors.Errorf("array too large, it does not fit into the type: encoded array len = %d, array len = %d", n, val.Len())
+		return buf.Pos(), errors.Errorf("array too large: %d > %d", n, val.Len())
 	}
 
 	// elemType is the type of the slice elements

--- a/ua/decode.go
+++ b/ua/decode.go
@@ -190,6 +190,13 @@ func decodeArray(b []byte, val reflect.Value, name string) (int, error) {
 	elemType := val.Type().Elem()
 	// fmt.Println("elemType: ", elemType.String())
 
+	// fast path for []byte
+	if elemType.Kind() == reflect.Uint8 {
+		// fmt.Println("decode: []byte fast path")
+		reflect.Copy(val, reflect.ValueOf(buf.ReadN(int(n))))
+		return buf.Pos(), buf.Error()
+	}
+
 	pos := buf.Pos()
 	// a is a pointer to an array [n]*Foo, where n is know at compile time
 	a := reflect.New(val.Type()).Elem()

--- a/ua/decode_test.go
+++ b/ua/decode_test.go
@@ -22,6 +22,7 @@ type B struct {
 
 type C struct {
 	A [2]int32
+	B [2]byte
 }
 
 func TestCodec(t *testing.T) {
@@ -117,6 +118,30 @@ func TestCodec(t *testing.T) {
 			},
 		},
 		{
+			name: "[2]byte",
+			v:    &struct{ V [2]byte }{[2]byte{0x12, 0x34}},
+			b: []byte{
+				// length
+				0x02, 0x00, 0x00, 0x00,
+				// elem 1
+				0x12,
+				// elem 2
+				0x34,
+			},
+		},
+		{
+			name: "[2]byte{1}",
+			v:    &struct{ V [2]byte }{[2]byte{0x12}},
+			b: []byte{
+				// length
+				0x02, 0x00, 0x00, 0x00,
+				// elem 1
+				0x12,
+				// elem 2
+				0x00,
+			},
+		},
+		{
 			name: "[2]uint32",
 			v:    &struct{ V [2]uint32 }{[2]uint32{0x1234, 0x4567}},
 			b: []byte{
@@ -209,6 +234,17 @@ func TestCodec(t *testing.T) {
 			},
 		},
 		{
+			name: "[2]byte",
+			v:    &struct{ V [2]byte }{[2]byte{}},
+			b: []byte{
+				// length
+				0x02, 0x00, 0x00, 0x00,
+				// values
+				0x00,
+				0x00,
+			},
+		},
+		{
 			name: "[2]uint32",
 			v:    &struct{ V [2]uint32 }{[2]uint32{}},
 			b: []byte{
@@ -273,7 +309,7 @@ func TestCodec(t *testing.T) {
 		},
 		{
 			name: "&C",
-			v:    &C{A: [2]int32{1, 2}},
+			v:    &C{A: [2]int32{1, 2}, B: [2]byte{3, 4}},
 			b: []byte{
 				// len(C.A)
 				0x02, 0x00, 0x00, 0x00,
@@ -281,33 +317,54 @@ func TestCodec(t *testing.T) {
 				0x01, 0x00, 0x00, 0x00,
 				// C.A[1]
 				0x02, 0x00, 0x00, 0x00,
+				// len(C.B)
+				0x02, 0x00, 0x00, 0x00,
+				// C.B[0]
+				0x03,
+				// C.B[1]
+				0x04,
 			},
 		},
 		{
 			name: "[3]C",
 			v: &struct{ V [3]C }{[3]C{
 				{},
-				{A: [2]int32{7}},
-				{A: [2]int32{0, 9}},
+				{A: [2]int32{7}, B: [2]byte{1}},
+				{A: [2]int32{0, 9}, B: [2]byte{3, 4}},
 			}},
 			b: []byte{
 				// len(V)
 				0x03, 0x00, 0x00, 0x00,
-				// len(V[0])
+				// len(V[0].A)
 				0x02, 0x00, 0x00, 0x00,
-				// V[0]
+				// V[0].A
 				0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00,
-				// len(V[1])
+				// len(V[0].B)
 				0x02, 0x00, 0x00, 0x00,
-				// V[1]
+				// V[0].B
+				0x00,
+				0x00,
+				// len(V[1].A)
+				0x02, 0x00, 0x00, 0x00,
+				// V[1].A
 				0x07, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00,
-				// len(V[2])
+				// len(V[1].B)
 				0x02, 0x00, 0x00, 0x00,
-				// V[2]
+				// V[1].B
+				0x01,
+				0x00,
+				// len(V[2].A)
+				0x02, 0x00, 0x00, 0x00,
+				// V[2].A
 				0x00, 0x00, 0x00, 0x00,
 				0x09, 0x00, 0x00, 0x00,
+				// len(V[2].B)
+				0x02, 0x00, 0x00, 0x00,
+				// V[2].B
+				0x03,
+				0x04,
 			},
 		},
 	}

--- a/ua/encode.go
+++ b/ua/encode.go
@@ -148,6 +148,15 @@ func writeArray(val reflect.Value, name string) ([]byte, error) {
 
 	buf.WriteUint32(uint32(val.Len()))
 
+	// fast path for []byte
+	if val.Type().Elem().Kind() == reflect.Uint8 {
+		// fmt.Println("encode: []byte fast path")
+		b := make([]byte, val.Len())
+		reflect.Copy(reflect.ValueOf(b), val)
+		buf.Write(b)
+		return buf.Bytes(), buf.Error()
+	}
+
 	// loop over elements
 	// we write all the elements, also the zero values
 	for i := 0; i < val.Len(); i++ {

--- a/ua/encode.go
+++ b/ua/encode.go
@@ -143,7 +143,7 @@ func writeArray(val reflect.Value, name string) ([]byte, error) {
 	buf := NewBuffer(nil)
 
 	if val.Len() > math.MaxInt32 {
-		return nil, errors.Errorf("array too large")
+		return nil, errors.Errorf("array too large: %d > %d", val.Len(), math.MaxInt32)
 	}
 
 	buf.WriteUint32(uint32(val.Len()))

--- a/ua/encode.go
+++ b/ua/encode.go
@@ -149,6 +149,7 @@ func writeArray(val reflect.Value, name string) ([]byte, error) {
 	buf.WriteUint32(uint32(val.Len()))
 
 	// loop over elements
+	// we write all the elements, also the zero values
 	for i := 0; i < val.Len(); i++ {
 		ename := fmt.Sprintf("%s[%d]", name, i)
 		b, err := encode(val.Index(i), ename)


### PR DESCRIPTION
Any reason why this was not implemented?

We have a use case with static size array, and it was returning an error.