### PR TITLE
notify when there are no notifications on a publication response

### DIFF
--- a/client_sub.go
+++ b/client_sub.go
@@ -265,6 +265,8 @@ func (c *Client) notifySubscriptionsOfError(ctx context.Context, subID uint32, e
 	}
 }
 
+var ErrNoNotifs = errors.New("no notifications in publish response")
+
 func (c *Client) notifySubscription(ctx context.Context, sub *Subscription, notif *ua.NotificationMessage) {
 	// todo(fs): response.Results contains the status codes of which messages were
 	// todo(fs): were successfully removed from the transmission queue on the server.
@@ -277,6 +279,14 @@ func (c *Client) notifySubscription(ctx context.Context, sub *Subscription, noti
 		sub.notify(ctx, &PublishNotificationData{
 			SubscriptionID: sub.SubscriptionID,
 			Error:          errors.Errorf("empty NotificationMessage"),
+		})
+		return
+	}
+
+	if len(notif.NotificationData) == 0 {
+		sub.notify(ctx, &PublishNotificationData{
+			SubscriptionID: sub.SubscriptionID,
+			Error:          ErrNoNotifs,
 		})
 		return
 	}


### PR DESCRIPTION
At the moment there is no feedback from a call to the server asking for the latest changes in a subscription where the request is successful but there where no messages.

The change in this PR allows a client to know that the connection is still good but that there are no changed values. This is allows it to differentiate from the situation where there are no notifications being sent due to a bad slow connection.
I am not 100% sure this should be an error but I felt like it was a similar case to the "empty NotificationMessage" notification that is sent a few lines above in the case that the notif message itself is nil.