### PR TITLE
ua: log unknown extension object type id

### DIFF
--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -5,6 +5,7 @@
 package ua
 
 import (
+	"github.com/gopcua/opcua/debug"
 	"github.com/gopcua/opcua/id"
 )
 
@@ -75,6 +76,7 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 	typeID := e.TypeID.NodeID
 	e.Value = eotypes.New(typeID)
 	if e.Value == nil {
+		debug.Printf("ua: unknown extension object %s", typeID)
 		return buf.Pos(), buf.Error()
 	}
 


### PR DESCRIPTION
Print the type id of an unknown extension object to the debug log.