### PR TITLE
set SecureChannel nil in Close() method

### DIFF
--- a/client.go
+++ b/client.go
@@ -563,6 +563,7 @@ func (c *Client) CloseWithContext(ctx context.Context) error {
 	}
 	if c.SecureChannel() != nil {
 		c.SecureChannel().Close()
+		c.setSecureChannel(nil)
 	}
 
 	// https://github.com/gopcua/opcua/pull/462

--- a/uatest/stats_test.go
+++ b/uatest/stats_test.go
@@ -45,7 +45,7 @@ func TestStats(t *testing.T) {
 		"Send":             newExpVarInt(2),
 		"Close":            newExpVarInt(1),
 		"CloseSession":     newExpVarInt(2),
-		"SecureChannel":    newExpVarInt(2),
+		"SecureChannel":    newExpVarInt(3),
 		"Session":          newExpVarInt(4),
 		"State":            newExpVarInt(0),
 	}


### PR DESCRIPTION
I was trying to implement this flow `Connect() -> Read data -> Disconnect network from host -> Close() -> Connect() in loop` but I was always receiving `opcua: already connected`.
Client has option `opcua.AutoReconnect(false)`.
So I noticed that SecureChannel exists even after Close() method call.