### PR TITLE
skip StatusBadNoSubscription in monitor loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,6 +255,12 @@ func (c *Client) monitor(ctx context.Context) {
 				return
 			}
 
+			// the subscriptions don't exist for session.
+			// skip this error and continue monitor loop
+			if errors.Is(err, ua.StatusBadNoSubscription) {
+				continue
+			}
+
 			// tell the handler the connection is disconnected
 			c.setState(Disconnected)
 			dlog.Print("disconnected")


### PR DESCRIPTION
This small fix should fix the issue https://github.com/gopcua/opcua/issues/597

Fixes #597