### PR TITLE
Fix nil subscription stats to return error

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -308,6 +308,10 @@ func (s *Subscription) StatsWithContext(ctx context.Context) (*ua.SubscriptionDi
 		return nil, err
 	}
 
+	if v == nil {
+		return nil, errors.Errorf("empty SubscriptionDiagnostics for sub=%d", s.SubscriptionID)
+	}
+
 	for _, eo := range v.Value().([]*ua.ExtensionObject) {
 		stat := eo.Value.(*ua.SubscriptionDiagnosticsDataType)
 


### PR DESCRIPTION
## Fix nil subscription stats to return error

### Bug Report
I'm connecting to KepwareEX V6 with v0.3.5 with a number of subscriptions and calling the experimental feature `StatsWithContext(ctx)`. Calling `StatsWithContext` on a BadNodeId subscription is responding with a StatusOK and a nil `*ua.Variant` object which then results in a panic as it tries to cast and iterate a slice `v.Value().([]*ua.ExtensionObject)` see [subscription.go line 311](https://github.com/gopcua/opcua/blob/main/subscription.go#L311). 

I expect if the value (`v` set on [subscription.go line 306](https://github.com/gopcua/opcua/blob/main/subscription.go#L306)) is empty, it either returns an error stating such, or returns a nil `*ua.SubscriptionDiagnosticsDataType` but does not panic.

### Fix
Add a nil pointer check before casting and iterating the array, returning an error message if the value is empty.

### Review Notes
Is there anywhere to document error messages or a style guide for error messages?