### PR TITLE
uasc: stop expiration timer

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -626,6 +626,7 @@ func (s *SecureChannel) scheduleExpiration(instance *channelInstance) {
 	debug.Printf("uasc %d: security token expires at %s. channelID=%d tokenID=%d", s.c.ID(), when.UTC().Format(time.RFC3339), instance.secureChannelID, instance.securityTokenID)
 
 	t := time.NewTimer(time.Until(when))
+	defer t.Stop()
 
 	select {
 	case <-s.closing:


### PR DESCRIPTION
We have a memory leak with some code and it points to lots of timers. @kung-foo did we forget to stop a timer here or is there a good reason not to stop the timer?