### PR TITLE
config: bubble up errors from configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,6 +133,15 @@ type Client struct {
 
 	// monitorOnce ensures only one connection monitor is running
 	monitorOnce sync.Once
+
+	// cfgerr contains an error that was captured in ApplyConfig.
+	// Since the API does not allow to bubble the error up in NewClient
+	// and we don't want to break existing code right away we carry the
+	// error here and bubble it up during Dial and Connect.
+	//
+	// Note: Starting with v0.5 NewClient will return the error and this
+	// variable needs to be removed.
+	cfgerr error
 }
 
 // NewClient creates a new Client.
@@ -146,6 +155,8 @@ type Client struct {
 // #Option for details.
 //
 // https://godoc.org/github.com/gopcua/opcua#Option
+//
+// Note: Starting with v0.5 this function will will return an error.
 func NewClient(endpoint string, opts ...Option) *Client {
 	cfg := ApplyConfig(opts...)
 	c := Client{
@@ -156,6 +167,7 @@ func NewClient(endpoint string, opts ...Option) *Client {
 		pendingAcks: make([]*ua.SubscriptionAcknowledgement, 0),
 		pausech:     make(chan struct{}, 2),
 		resumech:    make(chan struct{}, 2),
+		cfgerr:      cfg.Error(), // todo(fs): remove with v0.5.0 and return the error
 	}
 	c.pauseSubscriptions(context.Background())
 	c.setPublishTimeout(uasc.MaxTimeout)
@@ -182,6 +194,11 @@ const (
 
 // Connect establishes a secure channel and creates a new session.
 func (c *Client) Connect(ctx context.Context) (err error) {
+	// todo(fs): remove with v0.5.0
+	if c.cfgerr != nil {
+		return c.cfgerr
+	}
+
 	if c.SecureChannel() != nil {
 		return errors.Errorf("already connected")
 	}
@@ -513,6 +530,11 @@ func (c *Client) monitor(ctx context.Context) {
 
 // Dial establishes a secure channel.
 func (c *Client) Dial(ctx context.Context) error {
+	// todo(fs): remove with v0.5.0
+	if c.cfgerr != nil {
+		return c.cfgerr
+	}
+
 	stats.Client().Add("Dial", 1)
 
 	if c.SecureChannel() != nil {

--- a/config.go
+++ b/config.go
@@ -56,6 +56,18 @@ type Config struct {
 	dialer  *uacp.Dialer
 	sechan  *uasc.Config
 	session *uasc.SessionConfig
+	err     error
+}
+
+func (cfg *Config) setError(err error) {
+	if cfg.err != nil {
+		return
+	}
+	cfg.err = err
+}
+
+func (cfg *Config) Error() error {
+	return cfg.err
 }
 
 // NewDialer creates a uacp.Dialer from the config options
@@ -68,6 +80,8 @@ func NewDialer(cfg *Config) *uacp.Dialer {
 
 // ApplyConfig applies the config options to the default configuration.
 // todo(fs): Can we find a better name?
+//
+// Note: Starting with v0.5 this function will will return an error.
 func ApplyConfig(opts ...Option) *Config {
 	cfg := &Config{
 		sechan:  DefaultClientConfig(),
@@ -162,7 +176,8 @@ func RemoteCertificateFile(filename string) Option {
 	return func(cfg *Config) {
 		cert, err := loadCertificate(filename)
 		if err != nil {
-			log.Fatal(err)
+			cfg.setError(err)
+			return
 		}
 		cfg.sechan.RemoteCertificate = cert
 	}
@@ -220,7 +235,8 @@ func PrivateKeyFile(filename string) Option {
 		}
 		key, err := loadPrivateKey(filename)
 		if err != nil {
-			log.Fatal(err)
+			cfg.setError(err)
+			return
 		}
 		cfg.sechan.LocalKey = key
 	}
@@ -267,7 +283,8 @@ func CertificateFile(filename string) Option {
 
 		cert, err := loadCertificate(filename)
 		if err != nil {
-			log.Fatal(err)
+			cfg.setError(err)
+			return
 		}
 		setCertificate(cert, cfg)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -4,11 +4,12 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"encoding/pem"
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -141,6 +142,16 @@ func TestOptions(t *testing.T) {
 		keyDERFile  = filepath.Join(d, "key.der")
 		keyPEMFile  = filepath.Join(d, "key.pem")
 	)
+
+	// the error message for "file not found" is platform dependent.
+	notFoundError := func(msg, name string) error {
+		switch runtime.GOOS {
+		case "windows":
+			return fmt.Errorf("opcua: Failed to load %s: open %s: The system cannot find the file specified.", msg, name)
+		default:
+			return fmt.Errorf("opcua: Failed to load %s: open %s: no such file or directory", msg, name)
+		}
+	}
 
 	if err := ioutil.WriteFile(certDERFile, certDER, 0644); err != nil {
 		t.Fatal(err)
@@ -288,7 +299,7 @@ func TestOptions(t *testing.T) {
 			name: `CertificateFile() error`,
 			opt:  CertificateFile("x"),
 			cfg: &Config{
-				err: errors.New("opcua: Failed to load certificate: open x: no such file or directory"),
+				err: notFoundError("certificate", "x"),
 			},
 		},
 		{
@@ -350,7 +361,7 @@ func TestOptions(t *testing.T) {
 			name: `PrivateKeyFile() error`,
 			opt:  PrivateKeyFile("x"),
 			cfg: &Config{
-				err: errors.New("opcua: Failed to load private key: open x: no such file or directory"),
+				err: notFoundError("private key", "x"),
 			},
 		},
 		{
@@ -423,7 +434,7 @@ func TestOptions(t *testing.T) {
 			name: `RemoteCertificateFile() error`,
 			opt:  RemoteCertificateFile("x"),
 			cfg: &Config{
-				err: errors.New("opcua: Failed to load certificate: open x: no such file or directory"),
+				err: notFoundError("certificate", "x"),
 			},
 		},
 		{


### PR DESCRIPTION
The current config code has some options which can have errors. The current code calls `log.Fatal` which terminates the application instead of returning the error.

The correct solution would be to return the error in ApplyConfig and then return it in NewClient. However, this would break all existing clients.

We therefore postpone this breaking change to v0.5.0 when we update the API with breaking changes anyway and in the meantime bubble the error up in the Connect and Dial method.

Fixes #616