### PR TITLE
Prevent hanging on TCP connections that won't return [any/full] OPC UA data

### DIFF
--- a/config.go
+++ b/config.go
@@ -508,6 +508,12 @@ func ReadTimeout(d time.Duration) Option {
 		cfg.dialer.ReadTimeout = d
 	}
 }
+
+// WriteTimeout sets the timeout for every write operation.
+func WriteTimeout(d time.Duration) Option {
+	return func(cfg *Config) {
+		initDialer(cfg)
+		cfg.dialer.WriteTimeout = d
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -81,7 +81,7 @@ func NewDialer(cfg *Config) *uacp.Dialer {
 // ApplyConfig applies the config options to the default configuration.
 // todo(fs): Can we find a better name?
 //
-// Note: Starting with v0.5 this function will will return an error.
+// Note: Starting with v0.5 this function will return an error.
 func ApplyConfig(opts ...Option) *Config {
 	cfg := &Config{
 		sechan:  DefaultClientConfig(),
@@ -498,6 +498,16 @@ func DialTimeout(d time.Duration) Option {
 	return func(cfg *Config) {
 		initDialer(cfg)
 		cfg.dialer.Dialer.Timeout = d
+	}
+}
+
+// ReadTimeout sets the timeout for every read operation.
+func ReadTimeout(d time.Duration) Option {
+	return func(cfg *Config) {
+		initDialer(cfg)
+		cfg.dialer.ReadTimeout = d
+	}
+}
 	}
 }
 


### PR DESCRIPTION
Great lib! I was using it to look at some interesting OPC UA servers I found on the internet (scanning for them truth be told) and ran into situations where io.ReadFull hangs forever. I made some changes and allowed the Dialer to have a read timeout it can pass to connections.