### PR TITLE
Create a subscription to prevent reconnection infinite loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 )
+
+require golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect

--- a/uatest/stats_test.go
+++ b/uatest/stats_test.go
@@ -42,12 +42,13 @@ func TestStats(t *testing.T) {
 		"UpdateNamespaces": newExpVarInt(1),
 		"NodesToRead":      newExpVarInt(1),
 		"Read":             newExpVarInt(1),
-		"Send":             newExpVarInt(2),
+		"Send":             newExpVarInt(4),
 		"Close":            newExpVarInt(1),
 		"CloseSession":     newExpVarInt(2),
 		"SecureChannel":    newExpVarInt(2),
 		"Session":          newExpVarInt(4),
 		"State":            newExpVarInt(0),
+		"Subscribe":        newExpVarInt(1),
 	}
 
 	got := map[string]expvar.Var{}

--- a/uatest/timeout_test.go
+++ b/uatest/timeout_test.go
@@ -17,17 +17,17 @@ const (
 	// this _must_ be a "host" that will silently eat SYNs (no RSTs)
 	// 203.0.113.0/24 is IETF TEST-NET-3
 	tcpNoRstTestServer   = "opc.tcp://203.0.113.0:4840"
-	forceTimeoutDuration = time.Second * 5
+	forceTimeoutDuration = time.Second * 1
 )
 
 func TestClientTimeoutViaOptions(t *testing.T) {
-	c := opcua.NewClient(tcpNoRstTestServer, opcua.DialTimeout(forceTimeoutDuration))
+	c := opcua.NewClient(tcpNoRstTestServer, opcua.DialTimeout(forceTimeoutDuration), opcua.AutoReconnect(false))
 
 	connectAndValidate(t, c, context.Background(), forceTimeoutDuration)
 }
 
 func TestClientTimeoutViaContext(t *testing.T) {
-	c := opcua.NewClient(tcpNoRstTestServer)
+	c := opcua.NewClient(tcpNoRstTestServer, opcua.AutoReconnect(false))
 
 	ctx, cancel := context.WithTimeout(context.Background(), forceTimeoutDuration)
 	defer cancel()


### PR DESCRIPTION
##Issue
The main problem is that if we have a long running connection, with little operations, when the next request comes, the session will have been expired. The autoreconnection logic assumes there are subscription to be restarted, but when this is attempted, the restart errors out since there is nothing to be restarted. This triggers the reconection loop again, ending in a forever running loop.

##Fix 
1. Add a default subscription to prevent this loop
2. Add a monitor to the time node for this subscription. The reason why we need it is that without it the session will timeout once every minute or so and this would trigger the reconnection logic, thus creating unneeded load on the server.