### PR TITLE
Trigger resumeSubscriptions only if there are subscriptions

### DIFF
--- a/client_sub.go
+++ b/client_sub.go
@@ -376,6 +376,9 @@ publish:
 
 		default:
 			// send publish request and handle response
+			//
+			// publish() blocks until a PublishResponse
+			// is received or the context is cancelled.
 			if err := c.publish(ctx); err != nil {
 				dlog.Print("error: ", err.Error())
 				c.pauseSubscriptions(ctx)


### PR DESCRIPTION
When no subscription is present, then when the reconnect logic kicks in and it tries to get the subscriptions to restart, we get an error saying there are no subscriptions to restart. This triggers the reconnection logic, ending up in an infinite loop.

###Solution
Only resume subscriptions if at least one was found to be present before the client got disconnected