### PR TITLE
Bugfix: Close session properly if activation failed

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,6 +222,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 
 	if err := c.ActivateSessionWithContext(ctx, s); err != nil {
+		c.setSession(s)
 		c.CloseWithContext(ctx)
 		stats.RecordError(err)
 

--- a/client.go
+++ b/client.go
@@ -889,7 +889,7 @@ func (c *Client) ActivateSessionWithContext(ctx context.Context, s *Session) err
 		// We decided not to check the error of CloseSession() since we
 		// can't do much about it anyway and it creates a race in the
 		// re-connection logic.
-		c.CloseSession()
+		c.CloseSessionWithContext(ctx)
 
 		c.setSession(s)
 		return nil

--- a/client.go
+++ b/client.go
@@ -222,7 +222,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 
 	if err := c.ActivateSessionWithContext(ctx, s); err != nil {
-		c.setSession(s)
+		c.closeSession(ctx, s) // ignore error since we cannot handle it anyway
 		c.CloseWithContext(ctx)
 		stats.RecordError(err)
 


### PR DESCRIPTION
At the moment if the session activation failed the session dosn't get closed. Depending on the server session timeout there can accumulate lots of danggling sessions.

To close the session after a activation failure the session must be set before calling the `Close` function.