### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
       - name: Setup Go ${{ matrix.go }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.11.X"
           architecture: "x64"
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,9 @@ jobs:
         go: ["1.20.x", "1.21.x"]
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Setup Go ${{ matrix.go }}
         uses: actions/setup-go@v4
         with:
@@ -29,9 +32,6 @@ jobs:
         with:
           python-version: "3.11.X"
           architecture: "x64"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,13 @@
 name: gopuca
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 jobs:
   test:
     name: Test ${{ matrix.os }} go${{ matrix.go }}


### PR DESCRIPTION
* update the GitHub actions to disable the warnings
* build for push on `main` OR on PR but not on both
* take advantage of the Go module cache