### PR TITLE
feat: add support for AuthPrivateKey

### DIFF
--- a/config.go
+++ b/config.go
@@ -467,6 +467,16 @@ func AuthCertificate(cert []byte) Option {
 	}
 }
 
+// AuthPrivateKey sets the client's authentication RSA private key
+// Note: PolicyID still needs to be set outside of this method, typically through
+// the SecurityFromEndpoint() Option
+func AuthPrivateKey(key *rsa.PrivateKey) Option {
+	return func(cfg *Config) error {
+		cfg.sechan.UserKey = key
+		return nil
+	}
+}
+
 // AuthIssuedToken sets the client's authentication data based on an externally-issued token
 // Note: PolicyID still needs to be set outside of this method, typically through
 // the SecurityFromEndpoint() Option

--- a/config_test.go
+++ b/config_test.go
@@ -219,6 +219,17 @@ func TestOptions(t *testing.T) {
 			},
 		},
 		{
+			name: `AuthPrivateKey()`,
+			opt:  AuthPrivateKey(cert.PrivateKey.(*rsa.PrivateKey)),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.UserKey = cert.PrivateKey.(*rsa.PrivateKey)
+					return c
+				}(),
+			},
+		},
+		{
 			name: `AuthIssuedToken()`,
 			opt:  AuthIssuedToken([]byte("a")),
 			cfg: &Config{

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	// messages.  It is the key associated with Certificate
 	LocalKey *rsa.PrivateKey
 
+	// UserKey is a RSA Private Key which will be used to sign the UserTokenSignature.
+	// It is the key associated with AuthCertificate
+	UserKey *rsa.PrivateKey
+
 	// Thumbprint is the thumbprint of the X.509 v3 Certificate assigned to the receiving
 	// application Instance.
 	// The thumbprint is the CertificateDigest of the DER encoded form of the

--- a/uasc/secure_channel_crypto.go
+++ b/uasc/secure_channel_crypto.go
@@ -111,7 +111,7 @@ func (s *SecureChannel) NewUserTokenSignature(policyURI string, cert, nonce []by
 	}
 	remoteKey := remoteX509Cert.PublicKey.(*rsa.PublicKey)
 
-	enc, err := uapolicy.Asymmetric(policyURI, s.cfg.LocalKey, remoteKey)
+	enc, err := uapolicy.Asymmetric(policyURI, s.cfg.UserKey, remoteKey)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
NewUserTokenSignature should use the RSA key associated with AuthCertificate to sign the user token signature. Tested with Prosys OPC UA Simulation Server.

Closes #671