### PR TITLE
Fixed panic if h.MessageSize < hdrlen bytes.

### DIFF
--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -367,7 +367,10 @@ func (c *Conn) Receive() ([]byte, error) {
 	}
 
 	if h.MessageSize > c.ack.ReceiveBufSize {
-		return nil, errors.Errorf("uacp: message too large: %d > %d bytes", h.MessageSize, c.ack.ReceiveBufSize)
+		return nil, errors.Errorf("uacp: message too large: %d > %d bytes. MsgType=%s, ChunkType=%c", h.MessageSize, c.ack.ReceiveBufSize, h.MessageType, h.ChunkType)
+	}
+	if h.MessageSize < hdrlen {
+		return nil, errors.Errorf("uacp: message too small: %d bytes. MsgType=%s, ChunkType=%c.", h.MessageSize, h.MessageType, h.ChunkType)
 	}
 
 	if _, err := io.ReadFull(c, b[hdrlen:h.MessageSize]); err != nil {


### PR DESCRIPTION
This fix resolves a Panic seen in Receive() where if a MessageSize in Packet was less than expected 8 bytes, then a panic would result from an out of bounds slice. Fix is to check MessageSize against hdrlen(8) bytes and if smaller, return in error. https://github.com/SailorStu/Pcaps/blob/main/gopcua/opcua-crash.pcap