### PR TITLE
setSession to nil in recreateSession action to avoid unnecessary CloseSession 

### DIFF
--- a/client.go
+++ b/client.go
@@ -447,6 +447,10 @@ func (c *Client) monitor(ctx context.Context) {
 						c.setState(Reconnecting)
 						// create a new session to replace the previous one
 
+						// clear any previous session as we know the server has closed it
+						// this also prevents any unnecessary calls to CloseSession
+						c.setSession(nil)
+
 						dlog.Printf("trying to recreate session")
 						s, err := c.CreateSession(ctx, c.cfg.session)
 						if err != nil {


### PR DESCRIPTION
In the client.go monitor loop, the recreateSession action builds a new session on the assumption that the server is no longer holding the previous. It does not clear the value of the Client's atomicSession, which leads to CloseSession being called in ActivateSession even if there are no old sessions on the server to be removed.

This behavior is referenced in issue #673.