### PR TITLE
Add Fallback to set session.AuthPolicyURI

### DIFF
--- a/client.go
+++ b/client.go
@@ -791,6 +791,10 @@ func (c *Client) CreateSession(ctx context.Context, cfg *uasc.SessionConfig) (*S
 			opt(c.cfg)
 		}
 
+		if cfg.AuthPolicyURI == "" {
+			return errors.Errorf("No AuthPolicyURI set")
+		}
+
 		s = &Session{
 			cfg:               cfg,
 			resp:              res,

--- a/client.go
+++ b/client.go
@@ -792,7 +792,7 @@ func (c *Client) CreateSession(ctx context.Context, cfg *uasc.SessionConfig) (*S
 		}
 
 		if cfg.AuthPolicyURI == "" {
-			return errors.Errorf("No AuthPolicyURI set")
+			return errors.Errorf("No AuthPolicyURI set in session configuration")
 		}
 
 		s = &Session{

--- a/config.go
+++ b/config.go
@@ -363,7 +363,11 @@ func SecurityFromEndpoint(ep *ua.EndpointDescription, authType ua.UserTokenType)
 			}
 
 			setPolicyID(cfg.session.UserIdentityToken, t.PolicyID)
-			cfg.session.AuthPolicyURI = t.SecurityPolicyURI
+			if t.SecurityPolicyURI != "" {
+				cfg.session.AuthPolicyURI = t.SecurityPolicyURI
+			} else {
+				cfg.session.AuthPolicyURI = ep.SecurityPolicyURI
+			}
 			return nil
 		}
 

--- a/uatest/unset_useridentitytoken_server.py
+++ b/uatest/unset_useridentitytoken_server.py
@@ -1,0 +1,21 @@
+from opcua import Server, ua
+
+if __name__ == "__main__":
+  # Create a server instance
+  server = Server()
+
+  # Set the endpoint
+  server.set_endpoint("opc.tcp://localhost:4840")
+  ns = server.register_namespace("http://gopcua.com/")
+  simulations = server.nodes.objects.add_object(ua.NodeId("simulations", ns), "simulations")
+
+  # Create a UserTokenPolicy
+  policy = ua.UserTokenPolicy()
+  policy.TokenType = ua.UserTokenType.UserName
+  policy.PolicyId = "username"
+
+  # Add the policy to the server
+  server.set_security_policy([ua.SecurityPolicyType.NoSecurity])
+  
+  # Start the server
+  server.start()

--- a/uatest/unset_useridentitytoken_server.py
+++ b/uatest/unset_useridentitytoken_server.py
@@ -1,6 +1,14 @@
 from opcua import Server, ua
+from opcua.server.user_manager import UserManager
+
+users = {'user': 'pass'}
+
+def user_manager(isession, username, password):
+  isession.user = UserManager.User
+  return username in users and password == users[username]
 
 if __name__ == "__main__":
+  
   # Create a server instance
   server = Server()
 
@@ -11,7 +19,7 @@ if __name__ == "__main__":
 
   # Add the policy to the server
   server.set_security_policy([ua.SecurityPolicyType.NoSecurity])
-  # server.set_security_IDs(["Anonymous"])
   server.set_security_IDs(["Username"])
+  server.user_manager.user_manager = user_manager
   # Start the server
   server.start()

--- a/uatest/unset_useridentitytoken_server.py
+++ b/uatest/unset_useridentitytoken_server.py
@@ -9,13 +9,9 @@ if __name__ == "__main__":
   ns = server.register_namespace("http://gopcua.com/")
   simulations = server.nodes.objects.add_object(ua.NodeId("simulations", ns), "simulations")
 
-  # Create a UserTokenPolicy
-  policy = ua.UserTokenPolicy()
-  policy.TokenType = ua.UserTokenType.UserName
-  policy.PolicyId = "username"
-
   # Add the policy to the server
   server.set_security_policy([ua.SecurityPolicyType.NoSecurity])
-  
+  # server.set_security_IDs(["Anonymous"])
+  server.set_security_IDs(["Username"])
   # Start the server
   server.start()

--- a/uatest/unset_useridentitytoken_test.go
+++ b/uatest/unset_useridentitytoken_test.go
@@ -28,8 +28,6 @@ func TestUnsetUserIdentityTokenConnect(t *testing.T) {
 	opts := []opcua.Option{
 		opcua.SecurityPolicy("None"),
 		opcua.SecurityModeString("None"),
-		//opcua.CertificateFile(*certFile),
-		//opcua.PrivateKeyFile(*keyFile),
 		opcua.AuthUsername("user", "pass"),
 		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeUserName),
 	}

--- a/uatest/unset_useridentitytoken_test.go
+++ b/uatest/unset_useridentitytoken_test.go
@@ -1,0 +1,27 @@
+//go:build integration
+// +build integration
+
+package uatest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gopcua/opcua"
+)
+
+func TestUnsetUserIdentityTokenConnect(t *testing.T) {
+	ctx := context.Background()
+
+	srv := NewServer("unset_useridentitytoken_server.py")
+	defer srv.Close()
+
+	c, err := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Connect(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close(ctx)
+}

--- a/uatest/unset_useridentitytoken_test.go
+++ b/uatest/unset_useridentitytoken_test.go
@@ -5,9 +5,11 @@ package uatest
 
 import (
 	"context"
+	"log"
 	"testing"
 
 	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
 )
 
 func TestUnsetUserIdentityTokenConnect(t *testing.T) {
@@ -16,7 +18,23 @@ func TestUnsetUserIdentityTokenConnect(t *testing.T) {
 	srv := NewServer("unset_useridentitytoken_server.py")
 	defer srv.Close()
 
-	c, err := opcua.NewClient(srv.Endpoint, srv.Opts...)
+	endpoints, err := opcua.GetEndpoints(ctx, *&srv.Endpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ep := opcua.SelectEndpoint(endpoints, "None", ua.MessageSecurityModeFromString("None"))
+
+	opts := []opcua.Option{
+		opcua.SecurityPolicy("None"),
+		opcua.SecurityModeString("None"),
+		//opcua.CertificateFile(*certFile),
+		//opcua.PrivateKeyFile(*keyFile),
+		opcua.AuthUsername("user", "pass"),
+		opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeUserName),
+	}
+
+	c, err := opcua.NewClient(ep.EndpointURL, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I´m using the lib in Telegraf. In a Certificate based connection I had the problem that the library raised the error
`error creating session signature: opcua: unsupported security policy`

I was able to track the origin of that issue: The field AuthPolicyURI of the session config is not set.

When setting up the Connection the library retrieves the endpoints from the server. I set up some debug prints to show information on the received endpoint information. The Server is providing one endpoint:
```
Endpoint1: policy: http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256, epurl: XXXXX, secmode: 3, transportProfileURI: http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary, seclevel: 4

UserIdentityTokens of Endpoint
tokentype: , issuerendpointurl , policyid 0, security policy uri: , token type: 0
tokentype: , issuerendpointurl , policyid 1, security policy uri: , token type: 1
tokentype: , issuerendpointurl , policyid 2, security policy uri: , token type: 2
```

During connection setup the telegraf opcua client is calling the SecurityFromEndpoint method of the opcua library. In that method the relevant userIdeentityToken from the received Endpoint is used to set the session.AuthPolicyURI field. However the field for the security policy uri of the relevant UserIdentityToken (token type: 2 in my case) is empty. As a result the AuthPolicyURI will get no value and the connection does fail.

I was able to fix that issue for that specific server by adding some fallback logic: If the relevant UserIdentityToken does not provide the needed security policy, that one from the endpoint will be used.

However I can´t say if this change is safe in general or if it´s more like a hack to fix the connection to that specific misbehaving server.