### PR TITLE
fix: ignore response with too many operations error and fix extension object decoding

### DIFF
--- a/client.go
+++ b/client.go
@@ -306,6 +306,10 @@ func (c *Client) monitor(ctx context.Context) {
 				continue
 			}
 
+			if errors.Is(err, ua.StatusBadTooManyOperations) {
+				continue
+			}
+
 			// tell the handler the connection is disconnected
 			c.setState(Disconnected)
 			dlog.Print("disconnected")

--- a/ua/extension_object.go
+++ b/ua/extension_object.go
@@ -61,21 +61,20 @@ func (e *ExtensionObject) Decode(b []byte) (int, error) {
 	if length == 0 || length == 0xffffffff || buf.Error() != nil {
 		return buf.Pos(), buf.Error()
 	}
-
-	body := NewBuffer(buf.ReadN(int(length)))
+	raw := buf.ReadN(int(length))
+	body := NewBuffer(raw)
 	if buf.Error() != nil {
 		return buf.Pos(), buf.Error()
 	}
-
 	if e.EncodingMask == ExtensionObjectXML {
-		e.Value = new(XMLElement)
-		body.ReadStruct(e.Value)
+		e.Value = XMLElement(raw)
 		return buf.Pos(), body.Error()
 	}
 
 	typeID := e.TypeID.NodeID
 	e.Value = eotypes.New(typeID)
 	if e.Value == nil {
+		e.Value = raw
 		debug.Printf("ua: unknown extension object %s", typeID)
 		return buf.Pos(), buf.Error()
 	}

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -141,7 +141,7 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 		c.algo.PlaintextBlockSize()*
 			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
 			sequenceHeaderSize
-	c.maxBodySize = uint32(maxBodySize)
+	c.maxBodySize = uint32(maxBodySize - 12)
 
 	// this is the formula proposed by ERN - source node-opcua
 	// maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()


### PR DESCRIPTION
`StatusBadTooManyOperations` error does not need to close the connection

according to https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2
`Body` `This field contains the raw bytes for [ByteString] bodies.`
So there is no need to parse length again when parsing XMLElement.Theoretically speaking, the encode method is also wrong.
