### PR TITLE
subscription: add SetMonitoringMode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Here is the current set of supported services. For low-level access use the clie
 | MonitoredItems Service Set  | CreateMonitoredItems          | Yes    |              |
 |                             | DeleteMonitoredItems          | Yes    |              |
 |                             | ModifyMonitoredItems          | Yes    |              |
-|                             | SetMonitoringMode             |        |              |
+|                             | SetMonitoringMode             | Yes    |              |
 |                             | SetTriggering                 |        |              |
 | Subscription Service Set    | CreateSubscription            | Yes    |              |
 |                             | ModifySubscription            |        |              |


### PR DESCRIPTION
closes #711

Add SetMonitoringMode functionality and fix the potential issue that leaves the mutex locked.

Simply add the following code to `examples/subscribe/subscribe.go` can test this new feature
```
resp, err := sub.SetMonitoringMode(ctx, ua.MonitoringModeSampling, res.Results[0].MonitoredItemID)
if err != nil || resp.Results[0] != ua.StatusOK {
	log.Fatal(err)
}
```