### PR TITLE
remove pkg dependency

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,21 +2,20 @@ package errors
 
 import (
 	"errors"
-
-	pkg_errors "github.com/pkg/errors"
+	"fmt"
 )
 
 // Prefix is the default error string prefix
 const Prefix = "opcua: "
 
-// Errorf wraps github.com/pig/errors#Errorf`
+// Errorf wraps fmt.Errorf
 func Errorf(format string, a ...interface{}) error {
-	return pkg_errors.Errorf(Prefix+format, a...)
+	return fmt.Errorf(Prefix+format, a...)
 }
 
-// New wraps github.com/pkg/errors#New
+// New wraps errors.New
 func New(text string) error {
-	return pkg_errors.New(Prefix + text)
+	return errors.New(Prefix + text)
 }
 
 // Is wraps errors.Is

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/pascaldekloe/goe v0.1.1
-	github.com/pkg/errors v0.9.1
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/term v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/pascaldekloe/goe v0.1.1 h1:Ah6WQ56rZONR3RW3qWa2NCZ6JAVvSpUcoLBaOmYFt9Q=
 github.com/pascaldekloe/goe v0.1.1/go.mod h1:KSyfaxQOh0HZPjDP1FL/kFtbqYqrALJTaMafFUIccqU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=


### PR DESCRIPTION
Simple PR which removes the pkg dependency and replaces it by the standard errors library, the PR is related to issue #723

The PR has been tested against the errors_test

![image](https://github.com/gopcua/opcua/assets/42218215/92219cb1-1aff-4ca0-9400-772c82b99b40)
