### PR TITLE
fix: regression in examples introduced by #753

### DIFF
--- a/examples/datetime/datetime.go
+++ b/examples/datetime/datetime.go
@@ -32,7 +32,7 @@ func main() {
 		log.Fatal(err)
 	}
 	ep, err := opcua.SelectEndpoint(endpoints, *policy, ua.MessageSecurityModeFromString(*mode))
-	if err == nil {
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/monitor/monitor.go
+++ b/examples/monitor/monitor.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	ep, err := opcua.SelectEndpoint(endpoints, *policy, ua.MessageSecurityModeFromString(*mode))
-	if err == nil {
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -44,7 +44,7 @@ func main() {
 		log.Fatal(err)
 	}
 	ep, err := opcua.SelectEndpoint(endpoints, *policy, ua.MessageSecurityModeFromString(*mode))
-	if err == nil {
+	if err != nil {
 		log.Fatal(err)
 	}
 	ep.EndpointURL = *endpoint

--- a/examples/trigger/trigger.go
+++ b/examples/trigger/trigger.go
@@ -44,7 +44,7 @@ func main() {
 		log.Fatal(err)
 	}
 	ep, err := opcua.SelectEndpoint(endpoints, *policy, ua.MessageSecurityModeFromString(*mode))
-	if err == nil {
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/udt/udt.go
+++ b/examples/udt/udt.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatal(err)
 	}
 	ep, err := opcua.SelectEndpoint(endpoints, *policy, ua.MessageSecurityModeFromString(*mode))
-	if err == nil {
+	if err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
It looks like there was a mistake when updating the examples. (`err == nil` should be `err != nil`)

The broken commit: https://github.com/gopcua/opcua/pull/753/commits/f3e85a2928361e16b0b577a1255a45e628986177