### PR TITLE
client: add connState channel

### DIFF
--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	dialer  *uacp.Dialer
 	sechan  *uasc.Config
 	session *uasc.SessionConfig
+	stateCh chan<- ConnState
 }
 
 // NewDialer creates a uacp.Dialer from the config options
@@ -556,6 +557,17 @@ func SendBufferSize(n uint32) Option {
 	return func(cfg *Config) error {
 		initDialer(cfg)
 		cfg.dialer.ClientACK.SendBufSize = n
+		return nil
+	}
+}
+
+// StateChangedCh sets the channel for receiving client connection state changes.
+//
+// The caller must either consume the channel immediately or provide a buffer
+// to prevent blocking state changes in the client.
+func StateChangedCh(ch chan<- ConnState) Option {
+	return func(cfg *Config) error {
+		cfg.stateCh = ch
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -160,6 +160,8 @@ func TestOptions(t *testing.T) {
 	require.NoError(t, err, "WriteFile(keyPEMFile) failed")
 	defer os.Remove(keyPEMFile)
 
+	connStateCh := make(chan ConnState)
+
 	tests := []struct {
 		name string
 		opt  Option
@@ -305,6 +307,13 @@ func TestOptions(t *testing.T) {
 			opt:  CertificateFile("x"),
 			cfg:  &Config{},
 			err:  notFoundError("certificate", "x"),
+		},
+		{
+			name: `ConnStateCh`,
+			opt:  StateChangedCh(connStateCh),
+			cfg: &Config{
+				stateCh: connStateCh,
+			},
 		},
 		{
 			name: `Lifetime(10ms)`,


### PR DESCRIPTION
Add support for an optional channel to receive client state changes.

Fixes #741