### PR TITLE
Set conn write deadline for sendAsyncWithTimeout

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -1043,9 +1043,11 @@ func (s *SecureChannel) sendAsyncWithTimeout(
 
 		// send the message
 		var n int
+		s.c.SetWriteDeadline(time.Now().Add(timeout))
 		if n, err = s.c.Write(chunk); err != nil {
 			return nil, err
 		}
+		s.c.SetWriteDeadline(time.Time{})
 
 		atomic.AddUint64(&instance.bytesSent, uint64(n))
 		atomic.AddUint32(&instance.messagesSent, 1)


### PR DESCRIPTION
When losing connection to endpoint during calls to sendAsyncWithTimeout the Write call in connection doesn't respect the timeout parameter and waits for the lifetime in connection to expire before throwing an error.

I propose to SetWriteDeadline to timeout to prevent Write call taking longer than expected.