### PR TITLE
client: use nil-checked secure channel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        go: ["1.22.x", "1.23.x"]
+        go: ["1.23.x", "1.24.x"]
 
     steps:
       - name: Check out code into the Go module directory

--- a/client_sub.go
+++ b/client_sub.go
@@ -181,7 +181,7 @@ func (c *Client) sendRepublishRequests(ctx context.Context, sub *Subscription, a
 
 		debug.Printf("RepublishRequest: req=%s", debug.ToJSON(req))
 		var res *ua.RepublishResponse
-		err := c.SecureChannel().SendRequest(ctx, req, c.Session().resp.AuthenticationToken, func(v ua.Response) error {
+		err := sc.SendRequest(ctx, req, c.Session().resp.AuthenticationToken, func(v ua.Response) error {
 			return safeAssign(v, &res)
 		})
 		debug.Printf("RepublishResponse: res=%s err=%v", debug.ToJSON(res), err)


### PR DESCRIPTION
this is a regression introduced in commit https://github.com/gopcua/opcua/commit/4d56b5d38e0759d0a9782df6e1984e6c9b41a956. The race condition was fixed in https://github.com/gopcua/opcua/commit/5a155594a69dc78ee664d28607a89f4e3b97ceed.

Fixes #774