### PR TITLE
Issue #776: Obey access levels in the server

### DIFF
--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -212,8 +212,8 @@ func main() {
 	var4 := server.NewNode(
 		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
-			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
-			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
 			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},
@@ -226,8 +226,8 @@ func main() {
 	var5 := server.NewNode(
 		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
-			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
-			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
 			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},

--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -210,11 +210,11 @@ func main() {
 	nns_obj.AddRef(var3, id.HasComponent, true)
 
 	var4 := server.NewNode(
-		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		ua.NewNumericNodeID(nodeNS.ID(), 100), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
 			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
 			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
-			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadWriteVariable")),
 			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
 		},
 		nil,
@@ -224,7 +224,7 @@ func main() {
 	nns_obj.AddRef(var4, id.HasComponent, true)
 
 	var5 := server.NewNode(
-		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		ua.NewNumericNodeID(nodeNS.ID(), 101), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
 		map[ua.AttributeID]*ua.DataValue{
 			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
 			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
@@ -236,6 +236,20 @@ func main() {
 	)
 	nodeNS.AddNode(var5)
 	nns_obj.AddRef(var5, id.HasComponent, true)
+
+	var6 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 102), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("NoAccessVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var6)
+	nns_obj.AddRef(var6, id.HasComponent, true)
 
 	// simulate a background process updating the data in the namespace.
 	go func() {

--- a/examples/server/node_server/server.go
+++ b/examples/server/node_server/server.go
@@ -191,7 +191,7 @@ func main() {
 	// your variable node's value can also return a ua.Variant from a function if you want to update the value dynamically
 	// here we are just incrementing a counter every time the value is read.
 	var2Value := int32(0)
-	var2 := nodeNS.AddNewVariableStringNode("TestVar2", func() *ua.Variant { var2Value++; return ua.MustVariant(var2Value) })
+	var2 := nodeNS.AddNewVariableStringNode("TestVar2", func() *ua.DataValue { var2Value++; return server.DataValueFromValue(var2Value) })
 	nns_obj.AddRef(var2, id.HasComponent, true)
 
 	// Now we'll add a node from scratch.  This is a more manual way to add nodes to the server and gives you full
@@ -208,6 +208,34 @@ func main() {
 	)
 	nodeNS.AddNode(var3)
 	nns_obj.AddRef(var3, id.HasComponent, true)
+
+	var4 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 3321), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead | ua.AccessLevelExTypeCurrentWrite)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("testBrowseName")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(12.34) },
+	)
+	nodeNS.AddNode(var4)
+	nns_obj.AddRef(var4, id.HasComponent, true)
+
+	var5 := server.NewNode(
+		ua.NewNumericNodeID(nodeNS.ID(), 222), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelExTypeCurrentRead)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var5)
+	nns_obj.AddRef(var5, id.HasComponent, true)
 
 	// simulate a background process updating the data in the namespace.
 	go func() {

--- a/server/monitored_item_service.go
+++ b/server/monitored_item_service.go
@@ -58,7 +58,7 @@ func (s *MonitoredItemService) DeleteMonitoredItem(id uint32) {
 			continue
 		}
 		if n.ID == id {
-			slices.Delete(s.Nodes[nodeid], i, i+1)
+			s.Nodes[nodeid] = slices.Delete(s.Nodes[nodeid], i, i+1)
 		}
 	}
 	//slices.DeleteFunc(s.Nodes[nodeid], func(i *MonitoredItem) bool { return i.ID == item.ID })
@@ -72,7 +72,7 @@ func (s *MonitoredItemService) DeleteMonitoredItem(id uint32) {
 			continue
 		}
 		if n.ID == id {
-			slices.Delete(s.Subs[item.Sub.ID], i, i+1)
+			s.Subs[item.Sub.ID] = slices.Delete(s.Subs[item.Sub.ID], i, i+1)
 		}
 	}
 	//slices.DeleteFunc(s.Subs[item.Sub.ID], func(i *MonitoredItem) bool { return i.ID == item.ID })

--- a/server/namespace_node.go
+++ b/server/namespace_node.go
@@ -252,10 +252,66 @@ func (as *NodeNameSpace) SetAttribute(id *ua.NodeID, attr ua.AttributeID, val *u
 	}
 
 	access, err := n.Attribute(ua.AttributeIDUserAccessLevel)
-	if err == nil {
-		x := access.Value.Value.Value()
-		_ = x
-		return ua.StatusBadUserAccessDenied
+	if err == nil { // if we have an access level, we need to check it.
+		x := 0
+		switch val := access.Value.Value.Value().(type) {
+		case int8:
+			x = int(val)
+		case int:
+			x = int(val)
+		case int32:
+			x = int(val)
+		case int64:
+			x = int(val)
+		case uint32:
+			x = int(val)
+		case uint64:
+			x = int(val)
+		case uint:
+			x = int(val)
+		case uint16:
+			x = int(val)
+		case uint8:
+			x = int(val)
+		default:
+			return ua.StatusBadUserAccessDenied // if we can't convert it, we can't use it.
+		}
+
+		requirement := int(ua.AccessLevelExTypeCurrentWrite)
+		if x&requirement == 0 {
+			return ua.StatusBadUserAccessDenied
+		}
+	}
+	access, err = n.Attribute(ua.AttributeIDAccessLevel)
+	if err == nil { // if we have an access level, we need to check it.
+		x := 0
+		switch val := access.Value.Value.Value().(type) {
+		case int8:
+			x = int(val)
+		case int:
+			x = int(val)
+		case int32:
+			x = int(val)
+		case int64:
+			x = int(val)
+		case uint32:
+			x = int(val)
+		case uint64:
+			x = int(val)
+		case uint:
+			x = int(val)
+		case uint16:
+			x = int(val)
+		case uint8:
+			x = int(val)
+		default:
+			return ua.StatusBadUserAccessDenied // if we can't convert it, we can't use it.
+		}
+
+		requirement := int(ua.AccessLevelExTypeCurrentWrite)
+		if x&requirement == 0 {
+			return ua.StatusBadUserAccessDenied
+		}
 	}
 
 	err = n.SetAttribute(attr, val)

--- a/server/node.go
+++ b/server/node.go
@@ -28,6 +28,26 @@ func NewAttrValue(v *ua.DataValue) *AttrValue {
 }
 
 func DataValueFromValue(val any) *ua.DataValue {
+	// if we already have a data value, just return it.
+	switch v := val.(type) {
+	case *ua.DataValue:
+		return v
+	case ua.DataValue:
+		return &v
+	case ua.Variant:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           &v,
+			SourceTimestamp: time.Now(),
+		}
+	case *ua.Variant:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           v,
+			SourceTimestamp: time.Now(),
+		}
+
+	}
 
 	v := ua.MustVariant(val)
 	return &ua.DataValue{

--- a/server/node.go
+++ b/server/node.go
@@ -46,6 +46,12 @@ func DataValueFromValue(val any) *ua.DataValue {
 			Value:           v,
 			SourceTimestamp: time.Now(),
 		}
+	case int:
+		return &ua.DataValue{
+			EncodingMask:    ua.DataValueValue,
+			Value:           ua.MustVariant(int32(v)),
+			SourceTimestamp: time.Now(),
+		}
 
 	}
 

--- a/server/node.go
+++ b/server/node.go
@@ -99,6 +99,10 @@ func NewVariableNode(nodeID *ua.NodeID, name string, value any) *Node {
 				return DataValueFromValue(value)
 			},
 		)
+		dvFunc, ok := value.(ValueFunc)
+		if ok {
+			n.val = dvFunc
+		}
 		return n
 	}
 	typedef := ua.NewNumericExpandedNodeID(0, id.VariableNode)
@@ -154,7 +158,11 @@ func (n *Node) Attribute(id ua.AttributeID) (*AttrValue, error) {
 	switch {
 	case id == ua.AttributeIDValue:
 		if n.val != nil {
-			return NewAttrValue(n.val()), nil
+			val := n.val()
+			if val == nil {
+				return nil, ua.StatusBadAttributeIDInvalid
+			}
+			return NewAttrValue(val), nil
 		}
 		return nil, ua.StatusBadAttributeIDInvalid
 	case n.attr == nil:

--- a/server/node.go
+++ b/server/node.go
@@ -25,6 +25,7 @@ type AttrValue struct {
 
 func NewAttrValue(v *ua.DataValue) *AttrValue {
 	return &AttrValue{Value: v}
+
 }
 
 func DataValueFromValue(val any) *ua.DataValue {

--- a/server/node.go
+++ b/server/node.go
@@ -325,3 +325,39 @@ func (n *Node) AddRef(o *Node, rt RefType, forward bool) {
 	}
 	n.refs = append(n.refs, &ref)
 }
+
+// Access returns true if the node has the access level requested.
+// It checks both the UserAccessLevel and AccessLevel attributes.
+// If neither are present, it assumes global access and returns true.
+//
+// I'm not sure what the best way to implement "user" specific access levels
+// is presently.  Will need functioning user authentication first, and then a way to
+// pass it into the nodes user access attribute so it can be checked properly.
+func (n Node) Access(flag ua.AccessLevelType) bool {
+
+	access, err := n.Attribute(ua.AttributeIDUserAccessLevel)
+	if err == nil { // if we have a user access level, we need to check it.
+		val0 := access.Value.Value.Value()
+		val, ok := val0.(uint8)
+		if !ok {
+			return false
+		}
+		if val&uint8(flag) == 0 {
+			return false
+		}
+	}
+	access, err = n.Attribute(ua.AttributeIDAccessLevel)
+	if err == nil { // if we have an access level, we need to check it.
+		val0 := access.Value.Value.Value()
+		val, ok := val0.(uint8)
+		if !ok {
+			return false
+		}
+
+		if val&uint8(flag) == 0 {
+			return false
+		}
+	}
+	return true
+
+}

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -17,7 +17,7 @@ func (srv *Server) ImportNodeSet(nodes *schema.UANodeSet) error {
 	if err != nil {
 		return fmt.Errorf("problem creating nodes: %w", err)
 	}
-	srv.refsImportNodeSet(nodes)
+	err = srv.refsImportNodeSet(nodes)
 	if err != nil {
 		return fmt.Errorf("problem creating references: %w", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -144,6 +144,8 @@ func New(opts ...Option) *Server {
 	//s.namespaces[0].AddNode(n)
 	//}
 
+	// this nodeset is pre-compiled into the binary and contains a known set of nodes
+	// so it should *always* work ok.
 	var nodes schema.UANodeSet
 	xml.Unmarshal(schema.OpcUaNodeSet2, &nodes)
 

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -110,7 +110,7 @@ func suitableRefType(srv *Server, ref1, ref2 *ua.NodeID, subtypes bool) bool {
 	oktypes := getSubRefs(srv, ref1)
 	if !subtypes && slices.ContainsFunc(oktypes, hasSubtypeFn) {
 		for n := slices.IndexFunc(oktypes, hasSubtypeFn); n > 0; {
-			slices.Delete(oktypes, n, n+1)
+			oktypes = slices.Delete(oktypes, n, n+1)
 		}
 	}
 	return slices.ContainsFunc(oktypes, hasRef2Fn)

--- a/tests/go/server.go
+++ b/tests/go/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/server/attrs"
 	"github.com/gopcua/opcua/ua"
 )
 
@@ -67,6 +68,60 @@ func startServer() *server.Server {
 	nns_obj.AddRef(n, id.HasComponent, true)
 	n = nodeNS.AddNewVariableStringNode("rw_int32", int32(5))
 	nns_obj.AddRef(n, id.HasComponent, true)
+
+	var3 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "NoPermVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDBrowseName: server.DataValueFromValue(attrs.BrowseName("NoPermVariable")),
+			ua.AttributeIDNodeClass:  server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(int32(742)) },
+	)
+	nodeNS.AddNode(var3)
+	nns_obj.AddRef(var3, id.HasComponent, true)
+
+	var4 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "ReadWriteVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadWriteVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(12.34) },
+	)
+	nodeNS.AddNode(var4)
+	nns_obj.AddRef(var4, id.HasComponent, true)
+
+	var5 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "ReadOnlyVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(9.87) },
+	)
+	nodeNS.AddNode(var5)
+	nns_obj.AddRef(var5, id.HasComponent, true)
+
+	var6 := server.NewNode(
+		ua.NewStringNodeID(nodeNS.ID(), "NoAccessVariable"), // you can use whatever node id you want here, whether it's numeric, string, guid, etc...
+		map[ua.AttributeID]*ua.DataValue{
+			ua.AttributeIDAccessLevel:     server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDUserAccessLevel: server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
+			ua.AttributeIDBrowseName:      server.DataValueFromValue(attrs.BrowseName("NoAccessVariable")),
+			ua.AttributeIDNodeClass:       server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+		},
+		nil,
+		func() *ua.DataValue { return server.DataValueFromValue(55.43) },
+	)
+	nodeNS.AddNode(var6)
+	nns_obj.AddRef(var6, id.HasComponent, true)
 
 	// Create a new node namespace.  You can add namespaces before or after starting the server.
 	gopcuaNS := server.NewNodeNameSpace(s, "http://gopcua.com/")


### PR DESCRIPTION
This adds the necessary checks to the NodeNamespace to verify access levels before setting or returning attribute values.

A couple integration test cases were added to verify this functionality.  There are already some RO/RW integration tests but they weren't picking this up.

Further changes will eventually be needed to properly support both access types - user based and overall.  Right now it treats them both the same.  If server authentication is ever implemented, this will have to be revisited and the user data will somehow have to be provided to the attribute get/set functions or similar.

The issue also questions what the best way to get notifications from a node change event in the server is.  This was not addressed - you can achieve this today with a custom Namespace implementation or though custom value functions on your nodes.  I could add a generic notification mechanism to the server that would allow you to register a callback or channel to receive notifications on, but I'm not sure yet what would be a better solution so this is left for a future change.

There was also a problem with the new `DataValueFromValue` function introduced in the last change to the server which switched everything from variants to datavalues that would choke in certain cases.  These have been addressed.  In some future breaking change, I think this function should probably be renamed to `MustDataValue` or similar to match equivalent functions in other parts of the code.

-- Here's what copilot has to say about it --

This pull request introduces several improvements and new features to the server codebase, focusing on dynamic data value handling, access control, and enhanced testing. Below are the most important changes:

### Dynamic Data Value Handling:
* [`examples/server/node_server/server.go`](diffhunk://#diff-4ace899f2736433d0a8a0f2cdcd72ca6c183d535dd30de288f84b0077fe48675L194-R194): Updated `var2` to use `server.DataValueFromValue` instead of `ua.MustVariant` for better dynamic value handling. Added new nodes (`var4`, `var5`, `var6`) with different access levels and data values. [[1]](diffhunk://#diff-4ace899f2736433d0a8a0f2cdcd72ca6c183d535dd30de288f84b0077fe48675L194-R194) [[2]](diffhunk://#diff-4ace899f2736433d0a8a0f2cdcd72ca6c183d535dd30de288f84b0077fe48675R212-R253)

### Access Control Enhancements:
* [`server/namespace_node.go`](diffhunk://#diff-df87c70f74c3802b625509894450b907d83d7a1baa72fc73f35474fa39d59783L124-R134): Added access checks in `Attribute` and `SetAttribute` methods to enforce read and write permissions based on access levels. [[1]](diffhunk://#diff-df87c70f74c3802b625509894450b907d83d7a1baa72fc73f35474fa39d59783L124-R134) [[2]](diffhunk://#diff-df87c70f74c3802b625509894450b907d83d7a1baa72fc73f35474fa39d59783L254-R267)
* [`server/node.go`](diffhunk://#diff-f8f2de58ff42d0c5b5783c1ef31fd33f6c79d56466754490a4d8f6f5ca251426R354-R389): Introduced `Access` method to `Node` struct to check user and global access levels.

### Code Refactoring:
* [`server/monitored_item_service.go`](diffhunk://#diff-e3f30690c426d1dde692c4a8eb93dfdec1079e0f8671803db4a6ec4cfa8d14e0L61-R61): Modified `DeleteMonitoredItem` method to properly update the `Nodes` and `Subs` maps after deletion. [[1]](diffhunk://#diff-e3f30690c426d1dde692c4a8eb93dfdec1079e0f8671803db4a6ec4cfa8d14e0L61-R61) [[2]](diffhunk://#diff-e3f30690c426d1dde692c4a8eb93dfdec1079e0f8671803db4a6ec4cfa8d14e0L75-R75)
* [`server/node.go`](diffhunk://#diff-f8f2de58ff42d0c5b5783c1ef31fd33f6c79d56466754490a4d8f6f5ca251426R31-R56): Enhanced `DataValueFromValue` function to handle multiple types and added `ValueFunc` handling in `NewVariableNode`. [[1]](diffhunk://#diff-f8f2de58ff42d0c5b5783c1ef31fd33f6c79d56466754490a4d8f6f5ca251426R31-R56) [[2]](diffhunk://#diff-f8f2de58ff42d0c5b5783c1ef31fd33f6c79d56466754490a4d8f6f5ca251426R128-R131)

### Testing Improvements:
* [`tests/go/read_test.go`](diffhunk://#diff-40c0c2efb5532cbf22316dbf7b08cdde065a9a8a0cb36be60530e07f96aeadf6R59-R75): Added `TestReadPerms` to verify read permissions for various nodes and their expected status codes. [[1]](diffhunk://#diff-40c0c2efb5532cbf22316dbf7b08cdde065a9a8a0cb36be60530e07f96aeadf6R59-R75) [[2]](diffhunk://#diff-40c0c2efb5532cbf22316dbf7b08cdde065a9a8a0cb36be60530e07f96aeadf6R109-R147)
* [`tests/go/server.go`](diffhunk://#diff-fe62599d3b40368955030334ff33b230c414c28a4e6e411bee0eebb6c2c3e916R72-R125): Added new nodes with specific access levels for testing purposes.

### Miscellaneous:
* [`server/nodeset2_import.go`](diffhunk://#diff-73e23ef5a45ce6d620c6f4238b305bb57d3356874a24729d6537a40161f09e91L20-R20): Fixed error handling in `ImportNodeSet` method.
* [`server/server.go`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R147-R148): Added comments to explain the pre-compiled nodeset in the `New` function.
* [`server/view_service.go`](diffhunk://#diff-e7798eb2e4891195f338ea9a1932e8e4bf9fb57a0bb566b33c21f276e43635c6L113-R113): Corrected `slices.Delete` usage in `suitableRefType` function.

These changes collectively enhance the server's functionality, security, and maintainability, while also improving test coverage.