### PR TITLE
Removed hardcoded SecurityMode in SecureChannel readChunk method.

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -481,6 +481,11 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
 			debug.Printf("uasc %d: setting securityPolicy to %s", s.c.ID(), m.SecurityPolicyURI)
 
+			if s.cfg.SecurityMode != ua.MessageSecurityModeSignAndEncrypt &&
+				s.cfg.SecurityMode != ua.MessageSecurityModeInvalid {
+				s.cfg.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
+			}
+
 			remoteCert, err := x509.ParseCertificate(s.cfg.RemoteCertificate)
 			if err != nil {
 				return nil, err

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -481,11 +481,6 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
 			debug.Printf("uasc %d: setting securityPolicy to %s", s.c.ID(), m.SecurityPolicyURI)
 
-			// TODO: where does this need to actually be set?  It should be independent of the securitypolicy
-			// but here I'm just assuming it is sign and encrypt when we have anything other than None
-			// The problem is we need to know whether the message has to be decrypted before we can look at the
-			// security mode field in the open request to see if it is encrypted!
-			s.cfg.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
 			remoteCert, err := x509.ParseCertificate(s.cfg.RemoteCertificate)
 			if err != nil {
 				return nil, err

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -319,7 +319,12 @@ func TestNewSecureChannel(t *testing.T) {
 	t.Run("uri not none, mode none", func(t *testing.T) {
 		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeNone}
 		_, err := NewSecureChannel("", &uacp.Conn{}, cfg, make(chan error))
-		require.ErrorContains(t, err, "Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' cannot be used with 'MessageSecurityModeNone'")
+		require.ErrorContains(t, err, "invalid channel config: Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' can only be used with 'MessageSecurityModeSign' or 'MessageSecurityModeSignAndEncrypt'")
+	})
+	t.Run("uri not none, security policy not none, mode invalid", func(t *testing.T) {
+		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeInvalid}
+		_, err := NewSecureChannel("", &uacp.Conn{}, cfg, make(chan error))
+		require.ErrorContains(t, err, "invalid channel config: Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' can only be used with 'MessageSecurityModeSign' or 'MessageSecurityModeSignAndEncrypt'")
 	})
 	t.Run("uri not none, local key missing", func(t *testing.T) {
 		cfg := &Config{SecurityPolicyURI: ua.SecurityPolicyURIBasic256, SecurityMode: ua.MessageSecurityModeSign}


### PR DESCRIPTION
This change removes the hardcoding of SecurityMode in readChunk method. 

This hardcoding which caused any `Sign` Security Mode connection to fail due to the mismatch between given endpoint selection (for example auth-mode: Username, sec-mode: Sign, sec-method: Basic256Sha256). 
Since this line overrides the selected security mode, the server returned an EOF and immediately closed connection, regardless of authentication method and certificate validity.

To fix the concern in the previous TODO comment, I've added a check to see if there's no valid provided security method, and set a default in that case, otherwise don't override.

I'd like to add this critical bugfix to the latest version of gopcua as this library is used in production by us at [Octotronic ](https://octotronic.com/)
