### PR TITLE
Server: Ignore trailing slashes when checking matching endpoints.

### DIFF
--- a/server/session_service.go
+++ b/server/session_service.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rand"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/gopcua/opcua/ua"
@@ -59,9 +60,11 @@ func (s *SessionService) CreateSession(sc *uasc.SecureChannel, r ua.Request, req
 	}
 
 	matching_endpoints := make([]*ua.EndpointDescription, 0)
+	reqTrimmedURL, _ := strings.CutSuffix(req.EndpointURL, "/")
 	for i := range s.srv.endpoints {
 		ep := s.srv.endpoints[i]
-		if ep.EndpointURL == req.EndpointURL {
+		epTrimmedURL, _ := strings.CutSuffix(ep.EndpointURL, "/")
+		if epTrimmedURL == reqTrimmedURL {
 			matching_endpoints = append(matching_endpoints, ep)
 		}
 	}


### PR DESCRIPTION
This pull request includes changes to the server endpoint results so that trailing slashes are ignored.

Fixes #783 