### PR TITLE
uasc: use different algorithm to calculate max body size

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -641,7 +641,7 @@ func (s *SecureChannel) open(ctx context.Context, instance *channelInstance, req
 	reqID := s.nextRequestID()
 
 	s.openingInstance.algo = algo
-	s.openingInstance.SetMaximumBodySize(int(s.c.SendBufSize()))
+	s.openingInstance.setMaximumBodySize(int(s.c.SendBufSize()))
 
 	localNonce, err := algo.MakeNonce()
 	if err != nil {
@@ -683,7 +683,7 @@ func (s *SecureChannel) handleOpenSecureChannelResponse(resp *ua.OpenSecureChann
 		return err
 	}
 
-	instance.SetMaximumBodySize(int(s.c.SendBufSize()))
+	instance.setMaximumBodySize(int(s.c.SendBufSize()))
 
 	s.instancesMu.Lock()
 	defer s.instancesMu.Unlock()

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -146,8 +146,8 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	// c.maxBodySize = uint32(maxBodySize)
 
 	// this is the formula proposed by ERN - source node-opcua
-	maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()
-	maxBodySize := c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
+	maxBlock := (chunkSize - headerSize - 1) / c.algo.BlockSize()
+	maxBodySize := c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength()
 	c.maxBodySize = uint32(maxBodySize)
 }
 

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -136,18 +136,19 @@ func (c *channelInstance) newMessage(srv interface{}, typeID uint16, requestID u
 func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	sequenceHeaderSize := 8
 	headerSize := 12
-	symmetricAlgorithmHeader := 4
+	// symmetricAlgorithmHeader := 4
 
 	// this is the formula proposed by OPCUA - source node-opcua
-	maxBodySize :=
-		c.algo.PlaintextBlockSize()*
-			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
-			sequenceHeaderSize
-	c.maxBodySize = uint32(maxBodySize)
+	// maxBodySize :=
+	// 	c.algo.PlaintextBlockSize()*
+	// 		((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
+	// 		sequenceHeaderSize
+	// c.maxBodySize = uint32(maxBodySize)
 
 	// this is the formula proposed by ERN - source node-opcua
-	// maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()
-	// c.maxBodySize = c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
+	maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()
+	maxBodySize := c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
+	c.maxBodySize = uint32(maxBodySize)
 }
 
 // signAndEncrypt encrypts the message bytes stored in b and returns the

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -133,7 +133,7 @@ func (c *channelInstance) newMessage(srv interface{}, typeID uint16, requestID u
 	}
 }
 
-func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
+func (c *channelInstance) setMaximumBodySize(chunkSize int) {
 	sequenceHeaderSize := 8
 	headerSize := 12
 	// symmetricAlgorithmHeader := 4

--- a/uasc/secure_channel_instance_test.go
+++ b/uasc/secure_channel_instance_test.go
@@ -82,7 +82,7 @@ func TestSetMaximumBodySize_Padding(t *testing.T) {
 			require.NoError(t, err)
 
 			ch := &channelInstance{algo: algo}
-			ch.SetMaximumBodySize(tt.messageSize)
+			ch.setMaximumBodySize(tt.messageSize)
 			require.NoError(t, err)
 			require.Equal(t, int(tt.expectedBody), int(ch.maxBodySize))
 		})

--- a/uasc/secure_channel_instance_test.go
+++ b/uasc/secure_channel_instance_test.go
@@ -1,0 +1,110 @@
+package uasc
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uapolicy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetMaximumBodySize_Padding(t *testing.T) {
+	tests := []struct {
+		name           string
+		securityPolicy string
+		nonceLength    int
+		messageSize    int
+		expectedBody   uint32
+	}{
+		{
+			name:           "No Security",
+			securityPolicy: ua.SecurityPolicyURINone,
+			nonceLength:    0,
+			messageSize:    8192,
+			expectedBody: maxBodySizeAccordingToSpec(maxBodySizeArgs{
+				plaintextBlockSize:  1,
+				messageChunkSize:    8192,
+				headerSize:          12,
+				cipherTextBlockSize: 1,
+				sequenceHeaderSize:  8,
+				signatureSize:       0,
+			}),
+		},
+		{
+			name:           "Basic128Rsa15",
+			securityPolicy: ua.SecurityPolicyURIBasic128Rsa15,
+			nonceLength:    16,
+			messageSize:    8192,
+			expectedBody: maxBodySizeAccordingToSpec(maxBodySizeArgs{
+				plaintextBlockSize:  16,
+				messageChunkSize:    8192,
+				headerSize:          12,
+				cipherTextBlockSize: 16,
+				sequenceHeaderSize:  8,
+				signatureSize:       160 / 8,
+			}),
+		},
+		{
+			name:           "Basic256",
+			securityPolicy: ua.SecurityPolicyURIBasic256,
+			nonceLength:    32,
+			messageSize:    8192,
+			expectedBody: maxBodySizeAccordingToSpec(maxBodySizeArgs{
+				plaintextBlockSize:  16,
+				messageChunkSize:    8192,
+				headerSize:          12,
+				cipherTextBlockSize: 16,
+				sequenceHeaderSize:  8,
+				signatureSize:       160 / 8,
+			}),
+		},
+		{
+			name:           "Basic256Sha256",
+			securityPolicy: ua.SecurityPolicyURIBasic256Sha256,
+			nonceLength:    32,
+			messageSize:    8192,
+			expectedBody: maxBodySizeAccordingToSpec(maxBodySizeArgs{
+				plaintextBlockSize:  16,
+				messageChunkSize:    8192,
+				headerSize:          12,
+				cipherTextBlockSize: 16,
+				sequenceHeaderSize:  8,
+				signatureSize:       256 / 8,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeNonce := make([]byte, tt.nonceLength)
+			algo, err := uapolicy.Symmetric(tt.securityPolicy, fakeNonce, fakeNonce)
+			require.NoError(t, err)
+
+			ch := &channelInstance{algo: algo}
+			ch.SetMaximumBodySize(tt.messageSize)
+			require.NoError(t, err)
+			require.Equal(t, int(tt.expectedBody), int(ch.maxBodySize))
+		})
+	}
+}
+
+type maxBodySizeArgs struct {
+	plaintextBlockSize  int
+	messageChunkSize    int
+	headerSize          int
+	cipherTextBlockSize int
+	sequenceHeaderSize  int
+	signatureSize       int
+}
+
+// https://reference.opcfoundation.org/v104/Core/docs/Part6/6.7.2/
+// The formula to calculate the amount of padding depends on the amount of data that needs to be sent (called BytesToWrite). The sender shall first calculate the maximum amount of space available in the MessageChunk (called MaxBodySize) using the following formula:
+//
+// MaxBodySize = PlainTextBlockSize * Floor ((MessageChunkSize – HeaderSize - 1)/CipherTextBlockSize) –
+//
+//     SequenceHeaderSize – SignatureSize;
+
+func maxBodySizeAccordingToSpec(args maxBodySizeArgs) uint32 {
+	return uint32(args.plaintextBlockSize*int(math.Floor(float64(args.messageChunkSize-args.headerSize-1)/float64(args.cipherTextBlockSize))) - args.sequenceHeaderSize - args.signatureSize)
+}


### PR DESCRIPTION
This is an attempt to narrow the problem down since I'm a bit out of my depth here. Let's check if this looks in the right spot and if that's the case then I'll try to fully understand what is going on.

First attempt failed. 

Second attempt fixes the ERN formula since it did not align with the algorithm proposed by the OPC/UA spec: https://reference.opcfoundation.org/v104/Core/docs/Part6/6.7.2/

Fixes #781 (maybe)