### PR TITLE
Prevent panic when browsing a gopcua server

### DIFF
--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -45,9 +45,11 @@ func join(a, b string) string {
 	return a + "." + b
 }
 
+const maxDepth = 10
+
 func browse(ctx context.Context, n *opcua.Node, path string, level int) ([]NodeDef, error) {
 	// fmt.Printf("node:%s path:%q level:%d\n", n, path, level)
-	if level > 10 {
+	if level > maxDepth {
 		return nil, nil
 	}
 

--- a/examples/browse/browse.go
+++ b/examples/browse/browse.go
@@ -167,7 +167,7 @@ func browse(ctx context.Context, n *opcua.Node, path string, level int) ([]NodeD
 
 func main() {
 	endpoint := flag.String("endpoint", "opc.tcp://localhost:4840", "OPC UA Endpoint URL")
-	nodeID := flag.String("node", "", "node id for the root node")
+	nodeID := flag.String("node", "i=84", "node id for the root node") // i=84 is the standard root node
 	flag.BoolVar(&debug.Enable, "debug", false, "enable debug logging")
 	flag.Parse()
 	log.SetFlags(0)

--- a/examples/browse/browse_test.go
+++ b/examples/browse/browse_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/ua"
+)
+
+func TestBrowse(t *testing.T) {
+	ctx := context.Background()
+
+	// start the server
+	s := server.New(
+		server.EndPoint("localhost", 4840),
+	)
+	populateServer(s)
+	if err := s.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// prepare the client
+	c, err := opcua.NewClient("opc.tcp://localhost:4840")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Connect(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close(ctx)
+
+	// browse the nodes
+	nodeList, err := browse(
+		ctx,
+		c.Node(ua.MustParseNodeID("i=84")),
+		"",
+		maxDepth-3, // faster test with reduced depth
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure that the TestVar1 node was found
+	found := false
+	for _, n := range nodeList {
+		if n.BrowseName == "TestVar1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("TestVar1 not found in nodeList: %v", nodeList)
+	}
+}
+
+func populateServer(s *server.Server) {
+	// When the server is created, it will automatically create namespace 0 and populate it with
+	// the core opc ua nodes.
+
+	// add the namespaces to the server, and add a reference to them (otherwise browsing will not find it).
+	// here we are choosing to add the namespaces to the root/object folder
+	// to do this we first need to get the root namespace object folder so we
+	// get the object node
+	root_ns, _ := s.Namespace(0)
+	root_obj_node := root_ns.Objects()
+
+	// Now we'll add a node namespace.
+	nodeNS := server.NewNodeNameSpace(s, "NodeNamespace")
+	log.Printf("Node Namespace added at index %d", nodeNS.ID())
+
+	// add the reference for this namespace's root object folder to the server's root object folder
+	// but you can add a reference to whatever node(s) you need
+	nns_obj := nodeNS.Objects()
+	root_obj_node.AddRef(nns_obj, id.HasComponent, true)
+
+	// Create some nodes for it.  Here we are usin gthe AddNewVariableNode utility function to create a new variable node
+	// with an integer node ID that is automatically assigned. (ns=<namespace id>,s=<auto assigned>)
+	// be sure to add the reference to the node somewhere if desired, or clients won't be able to browse it.
+	var1 := nodeNS.AddNewVariableNode("TestVar1", float32(123.45))
+	nns_obj.AddRef(var1, id.HasComponent, true)
+}

--- a/ua/variant.go
+++ b/ua/variant.go
@@ -717,6 +717,8 @@ func (m *Variant) NodeID() *NodeID {
 	switch m.Type() {
 	case TypeIDNodeID:
 		return m.value.(*NodeID)
+	case TypeIDExpandedNodeID:
+		return m.value.(*ExpandedNodeID).NodeID
 	default:
 		return nil
 	}

--- a/ua/variant_test.go
+++ b/ua/variant_test.go
@@ -1031,6 +1031,13 @@ func TestVariantValueHelpers(t *testing.T) {
 			fn:   func(v *Variant) interface{} { return v.NodeID() },
 		},
 
+		// ExpandedNodeID
+		{
+			v:    NewExpandedNodeID(NewFourByteNodeID(1, 2), "uri", 1),
+			want: NewFourByteNodeID(1, 2),
+			fn:   func(v *Variant) interface{} { return v.NodeID() },
+		},
+
 		// QualifiedName
 		{
 			v:    false,
@@ -1227,7 +1234,7 @@ func TestVariantValueHelpers(t *testing.T) {
 	for i, tt := range tests {
 		name := fmt.Sprintf("test-%d %T -> %T", i, tt.v, tt.want)
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.fn(MustVariant(tt.v)))
+			require.EqualExportedValues(t, tt.want, tt.fn(MustVariant(tt.v)))
 		})
 	}
 }


### PR DESCRIPTION
I tried the browse example against a gopcua server and got a panic, because `ua.Variant.NodeID` returned nil on `TypeIDExpandedNodeID` (seems related to https://github.com/gopcua/opcua/discussions/524).

I guess it should return the underlying node instead.

I added a test to prevent any future regression (and adjusted the default `node` value of browse to prevent questions, like https://github.com/gopcua/opcua/discussions/545) 