### PR TITLE
server: expose resolved URL

### DIFF
--- a/examples/browse/browse_test.go
+++ b/examples/browse/browse_test.go
@@ -16,7 +16,7 @@ func TestBrowse(t *testing.T) {
 
 	// start the server
 	s := server.New(
-		server.EndPoint("localhost", 4840),
+		server.EndPoint("localhost", 0),
 	)
 	populateServer(s)
 	if err := s.Start(ctx); err != nil {
@@ -25,7 +25,7 @@ func TestBrowse(t *testing.T) {
 	defer s.Close()
 
 	// prepare the client
-	c, err := opcua.NewClient("opc.tcp://localhost:4840")
+	c, err := opcua.NewClient(s.URL())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -96,7 +96,8 @@ type security struct {
 }
 
 // New returns an initialized OPC-UA server.
-// Call Start() afterwards to begin listening and serving connections
+// At least one [EndPoint] must be provided.
+// Call [Server.Start] afterwards to begin listening and serving connections
 func New(opts ...Option) *Server {
 	cfg := &serverConfig{
 		cap:              capabilities,
@@ -236,14 +237,11 @@ func (s *Server) URLs() []string {
 }
 
 // URL returns the resolved opc endpoint that the server is listening on.
-// Useful when a :0 port was provided.
 func (s *Server) URL() string {
 	return s.l.Endpoint()
 }
 
-// Start initializes and starts a Server listening on addr
-// If s was not initialized with NewServer(), addr defaults
-// to localhost:0 to let the OS select a random port
+// Start initializes and starts a Server.
 func (s *Server) Start(ctx context.Context) error {
 	var err error
 

--- a/server/server.go
+++ b/server/server.go
@@ -209,7 +209,6 @@ func (s *Server) AddNamespace(ns NameSpace) int {
 
 	if ns.ID() == 0 {
 		return 0
-
 	}
 
 	return len(s.namespaces) - 1
@@ -236,6 +235,12 @@ func (s *Server) URLs() []string {
 	return s.cfg.endpoints
 }
 
+// URL returns the resolved opc endpoint that the server is listening on.
+// Useful when a :0 port was provided.
+func (s *Server) URL() string {
+	return s.l.Endpoint()
+}
+
 // Start initializes and starts a Server listening on addr
 // If s was not initialized with NewServer(), addr defaults
 // to localhost:0 to let the OS select a random port
@@ -256,7 +261,7 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("Started listening on %v", s.URLs())
+	log.Printf("Started listening on %v", s.URL())
 
 	s.initEndpoints()
 	s.setServerState(ua.ServerStateRunning)

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -27,7 +27,7 @@ func PrivateKey(key *rsa.PrivateKey) Option {
 	}
 }
 
-// EndPointHostName adds an additional endpoint to the server based on the host name.
+// EndPoint adds an additional endpoint to the server based on the host name.
 // A 0 port will let the OS select a random port (call [Server.URL] to retrieve the port).
 func EndPoint(host string, port int) Option {
 	return func(s *serverConfig) {

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -27,7 +27,8 @@ func PrivateKey(key *rsa.PrivateKey) Option {
 	}
 }
 
-// EndPointHostName adds an additional endpoint to the server based on the host name
+// EndPointHostName adds an additional endpoint to the server based on the host name.
+// A 0 port will let the OS select a random port (call [Server.URL] to retrieve the port).
 func EndPoint(host string, port int) Option {
 	return func(s *serverConfig) {
 		if s.endpoints == nil {
@@ -99,7 +100,6 @@ func EnableSecurity(secPolicy string, secMode ua.MessageSecurityMode) Option {
 // must also be called with at least one non-"None" SecurityPolicy
 func EnableAuthMode(tokenType ua.UserTokenType) Option {
 	return func(s *serverConfig) {
-
 		for _, a := range s.enabledAuth {
 			if a.tokenType == tokenType {
 				if s.logger != nil {

--- a/uacp/conn_test.go
+++ b/uacp/conn_test.go
@@ -7,6 +7,8 @@ package uacp
 import (
 	"context"
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +61,25 @@ func TestConn(t *testing.T) {
 		if errors.As(err, &operr) && !operr.Timeout() {
 			t.Error(err)
 		}
+	})
+
+	t.Run("random endpoint ", func(t *testing.T) {
+		ep := "opc.tcp://localhost:0/foo/bar"
+		ln, err := Listen(context.Background(), ep, nil)
+		require.NoError(t, err)
+		defer ln.Close()
+
+		resolved := ln.Endpoint()
+
+		require.NotEqual(t, ep, resolved)
+
+		after, ok := strings.CutPrefix(resolved, "opc.tcp://localhost:")
+		require.True(t, ok)
+		port, ok := strings.CutSuffix(after, "/foo/bar")
+		require.True(t, ok)
+		p, err := strconv.Atoi(port)
+		require.NoError(t, err)
+		require.Greater(t, p, 0)
 	})
 }
 


### PR DESCRIPTION
useful when letting the OS choose a port with :0 (especially in tests)

The `srvhandshake` TODO could be fixed by this change? (however I don't know how it should behave when multiple endpoints are provided, since the listener actually listens only on one address)

https://github.com/gopcua/opcua/blob/359b38a5ff733969df3de09f23ab8e4bdd27d1de/uacp/conn.go#L305-L310