### PR TITLE
Update subscription.go. Added check status code for result in Subscription.Monitor

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -168,6 +168,11 @@ func (s *Subscription) Monitor(ctx context.Context, ts ua.TimestampsToReturn, it
 	s.itemsMu.Lock()
 	for i, item := range items {
 		result := res.Results[i]
+
+		if result.StatusCode != ua.StatusGood {
+			continue
+		}
+		
 		s.items[result.MonitoredItemID] = &monitoredItem{
 			req: item,
 			res: result,


### PR DESCRIPTION
As per OPC UA specification for CreateMonitoringItems request MonitoredItem Id in results array is uninitialized if status code != Good. Because of that they can not be used in subscription recreation routine (during reconnect). But invalid results  are going to be stored in items map in subscription.

(https://reference.opcfoundation.org/Core/Part4/v104/docs/5.12.2)
> Server-assigned id for the _MonitoredItem_ (see 7.14 for _IntegerId_ definition). ... This parameter **is present only** if the _statusCode_ indicates that the _MonitoredItem_ was successfully created.

During monitoring items creation in _Subscription.Monitor_ status code in results array is not checked. It is necessary to check it because otherwise it will add item with monitoring item id = 0, which then will be used on subscription recreation.

User of the library can check the status codes in response results array and handle them accordingly.