### PR TITLE
feat: add state change func

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,10 +58,11 @@ func DefaultSessionConfig() *uasc.SessionConfig {
 
 // Config contains all config options.
 type Config struct {
-	dialer  *uacp.Dialer
-	sechan  *uasc.Config
-	session *uasc.SessionConfig
-	stateCh chan<- ConnState
+	dialer    *uacp.Dialer
+	sechan    *uasc.Config
+	session   *uasc.SessionConfig
+	stateCh   chan<- ConnState
+	stateFunc func(ConnState)
 }
 
 func DefaultDialer() *uacp.Dialer {
@@ -577,6 +578,14 @@ func SendBufferSize(n uint32) Option {
 func StateChangedCh(ch chan<- ConnState) Option {
 	return func(cfg *Config) error {
 		cfg.stateCh = ch
+		return nil
+	}
+}
+
+// StateChangedFunc sets the function for receiving client connection state changes.
+func StateChangedFunc(f func(ConnState)) Option {
+	return func(cfg *Config) error {
+		cfg.stateFunc = f
 		return nil
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -173,6 +173,7 @@ func TestOptions(t *testing.T) {
 	defer os.Remove(keyPEMFile)
 
 	connStateCh := make(chan ConnState)
+	connStateFunc := func(ConnState) {}
 
 	tests := []struct {
 		name string
@@ -325,6 +326,13 @@ func TestOptions(t *testing.T) {
 			opt:  StateChangedCh(connStateCh),
 			cfg: &Config{
 				stateCh: connStateCh,
+			},
+		},
+		{
+			name: `ConnStateCh`,
+			opt:  StateChangedFunc(connStateFunc),
+			cfg: &Config{
+				stateFunc: connStateFunc,
 			},
 		},
 		{
@@ -842,6 +850,13 @@ func TestOptions(t *testing.T) {
 			if got, want := errstr(err), errstr(tt.err); got != "" || want != "" {
 				require.Equal(t, want, got, "got error %q want %q", got, want)
 				return
+			}
+			if tt.cfg.stateFunc != nil { // Functions are not comparable, so we check manually and unset
+				require.NotNil(t, cfg.stateFunc)
+				tt.cfg.stateFunc = nil
+				cfg.stateFunc = nil
+			} else {
+				require.Nil(t, cfg.stateFunc)
 			}
 			require.Equal(t, tt.cfg, cfg)
 		})


### PR DESCRIPTION
Addition to #767.

Rational: as #767 handles the calls more or less synchronous this provides a simpler way to hook into state changes.