### PR TITLE
remove markdown filter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,11 +3,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
+
 jobs:
   test:
     name: Test ${{ matrix.os }} go${{ matrix.go }}


### PR DESCRIPTION
GitHub still creates a test requirement even if all files are excluded. But the test never runs, so the action hangs forever.