### PR TITLE
Account for signature padding as well as padding length byte (Fixes #781)

### DIFF
--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -137,11 +137,13 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	sequenceHeaderSize := 8
 	headerSize := 12
 	symmetricAlgorithmHeader := 4
+	signaturePadding := c.algo.PlaintextBlockSize() + 1
 
 	// this is the formula proposed by OPCUA - source node-opcua
+	// Modified to reserve worst-case padding + padding length byte
 	maxBodySize :=
 		c.algo.PlaintextBlockSize()*
-			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-1)/c.algo.BlockSize()) -
+			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-signaturePadding)/c.algo.BlockSize()) -
 			sequenceHeaderSize
 	c.maxBodySize = uint32(maxBodySize)
 

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -137,19 +137,34 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	sequenceHeaderSize := 8
 	headerSize := 12
 	symmetricAlgorithmHeader := 4
-	signaturePadding := c.algo.PlaintextBlockSize() + 1
 
-	// this is the formula proposed by OPCUA - source node-opcua
-	// Modified to reserve worst-case padding + padding length byte
+	// signAndEncrypt appends one PaddingSize byte (two if ExtraPaddingSize is
+	// present, i.e. for signatures longer than 256 bytes) before padding the
+	// plaintext to a block boundary.
+	paddingSizeBytes := 1
+	if c.algo.RemoteSignatureLength() > 256 {
+		paddingSizeBytes = 2
+	}
+
+	// OPC UA Part 6, 6.7.2.5 defines
+	//
+	//   MaxBodySize = PlainTextBlockSize *
+	//       Floor((MessageChunkSize - HeaderSize - 1) / CipherTextBlockSize) -
+	//       SequenceHeaderSize - SignatureSize
+	//
+	// where the -1 reserves room for the PaddingSize byte. Subtracting it
+	// inside the Floor only takes effect when chunkSize-headerSize is an exact
+	// multiple of the cipher block size. For any other chunk size (e.g. the
+	// default 65535) a maximum-size body pads out to one cipher block more
+	// than fits in the chunk. Reserving the PaddingSize byte(s) outside the
+	// Floor instead is exact: a body of maxBodySize fills the chunk to the
+	// last whole cipher block and one more byte no longer fits, for every
+	// chunk size (see TestMaxBodySizeFitsChunk).
 	maxBodySize :=
 		c.algo.PlaintextBlockSize()*
-			((chunkSize-headerSize-symmetricAlgorithmHeader-c.algo.SignatureLength()-signaturePadding)/c.algo.BlockSize()) -
-			sequenceHeaderSize
+			((chunkSize-headerSize-symmetricAlgorithmHeader)/c.algo.BlockSize()) -
+			sequenceHeaderSize - c.algo.SignatureLength() - paddingSizeBytes
 	c.maxBodySize = uint32(maxBodySize)
-
-	// this is the formula proposed by ERN - source node-opcua
-	// maxBlock := (chunkSize - headerSize) / c.algo.BlockSize()
-	// c.maxBodySize = c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
 }
 
 // signAndEncrypt encrypts the message bytes stored in b and returns the
@@ -179,8 +194,18 @@ func (c *channelInstance) signAndEncrypt(m *Message, b []byte) ([]byte, error) {
 		if extraPadding {
 			paddingBytes = 2
 		}
-		paddingLength := plaintextBlockSize - ((len(b[headerLength:]) + c.algo.SignatureLength() + paddingBytes) % plaintextBlockSize)
+		// The PaddingSize byte(s) and Padding must fill the plaintext up to a
+		// block boundary. If it is already block-aligned no padding is needed
+		// beyond the PaddingSize byte(s) themselves (cf. open62541
+		// ua_securechannel_crypto.c, padding calculation).
+		remainder := (len(b[headerLength:]) + c.algo.SignatureLength() + paddingBytes) % plaintextBlockSize
+		paddingLength := 0
+		if remainder != 0 {
+			paddingLength = plaintextBlockSize - remainder
+		}
 
+		// appends paddingLength Padding bytes plus one PaddingSize byte,
+		// each holding the paddingLength value (OPC UA Part 6, 6.7.2.5)
 		for i := 0; i <= paddingLength; i++ {
 			b = append(b, byte(paddingLength))
 		}

--- a/uasc/secure_channel_instance_test.go
+++ b/uasc/secure_channel_instance_test.go
@@ -1,0 +1,140 @@
+package uasc
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uapolicy"
+	"github.com/stretchr/testify/require"
+)
+
+func symmetricInstance(t *testing.T, uri string) *channelInstance {
+	t.Helper()
+
+	nonce := bytes.Repeat([]byte{0x5a}, 32)
+	algo, err := uapolicy.Symmetric(uri, nonce, nonce)
+	require.NoError(t, err, "error: create symmetric algorithm")
+
+	return &channelInstance{
+		sc:   &SecureChannel{cfg: &Config{SecurityMode: ua.MessageSecurityModeSignAndEncrypt}},
+		algo: algo,
+	}
+}
+
+// symmetricChunk returns the raw bytes of a MSG chunk (header, symmetric
+// security header, sequence header, body) and the matching Message needed
+// by signAndEncrypt.
+func symmetricChunk(body []byte) ([]byte, *Message) {
+	m := &Message{
+		MessageHeader: &MessageHeader{
+			Header:                  NewHeader(MessageTypeMessage, ChunkTypeFinal, 1),
+			SymmetricSecurityHeader: NewSymmetricSecurityHeader(1),
+			SequenceHeader:          NewSequenceHeader(1, 1),
+		},
+	}
+
+	b := make([]byte, 0, 24+len(body))
+	b = append(b, 'M', 'S', 'G', 'F')
+	b = append(b, 0, 0, 0, 0) // message size, set by signAndEncrypt
+	b = append(b, 1, 0, 0, 0) // secure channel id
+	b = append(b, 1, 0, 0, 0) // security token id
+	b = append(b, 1, 0, 0, 0) // sequence number
+	b = append(b, 1, 0, 0, 0) // request id
+	b = append(b, body...)
+	return b, m
+}
+
+var symmetricPolicyURIs = []string{
+	ua.SecurityPolicyURIBasic128Rsa15,
+	ua.SecurityPolicyURIBasic256,
+	ua.SecurityPolicyURIBasic256Sha256,
+	ua.SecurityPolicyURIAes128Sha256RsaOaep,
+	ua.SecurityPolicyURIAes256Sha256RsaPss,
+}
+
+// TestMaxBodySizeFitsChunk reproduces the bug from
+// https://github.com/gopcua/opcua/issues/781: a body of exactly maxBodySize
+// must produce an encrypted chunk that does not exceed the negotiated chunk
+// size, for every security policy and in particular for the default chunk
+// size of 65535 which is not a multiple of the AES block size.
+func TestMaxBodySizeFitsChunk(t *testing.T) {
+	chunkSizes := []int{4096, 8192, 65521, 65535, 65536}
+
+	for _, uri := range symmetricPolicyURIs {
+		for _, chunkSize := range chunkSizes {
+			t.Run(testName(uri, chunkSize), func(t *testing.T) {
+				c := symmetricInstance(t, uri)
+				c.SetMaximumBodySize(chunkSize)
+
+				body := bytes.Repeat([]byte{0xab}, int(c.maxBodySize))
+				b, m := symmetricChunk(body)
+				want := make([]byte, len(b)-16)
+				copy(want, b[16:])
+
+				cipher, err := c.signAndEncrypt(m, b)
+				require.NoError(t, err, "error: message encrypt")
+				require.LessOrEqual(t, len(cipher), chunkSize, "encrypted chunk exceeds negotiated chunk size")
+
+				// a body one byte larger must no longer fit, i.e. maxBodySize
+				// is not needlessly conservative
+				b2, m2 := symmetricChunk(append(body, 0xab))
+				cipher2, err := c.signAndEncrypt(m2, b2)
+				require.NoError(t, err, "error: message encrypt")
+				require.Greater(t, len(cipher2), chunkSize, "maxBodySize is more conservative than necessary")
+
+				// round trip
+				mc := new(MessageChunk)
+				_, err = mc.Decode(cipher)
+				require.NoError(t, err, "error: message decode")
+
+				plain, err := c.verifyAndDecrypt(mc, cipher)
+				require.NoError(t, err, "error: message decrypt")
+				require.Equal(t, want, plain, "plaintext not equal")
+			})
+		}
+	}
+}
+
+// TestPaddingBlockAligned reproduces the second bug discussed in
+// https://github.com/gopcua/opcua/pull/824: when the plaintext including the
+// PaddingSize byte is already block-aligned, no padding bytes must be added
+// beyond the PaddingSize byte itself. The old code added a full extra block.
+func TestPaddingBlockAligned(t *testing.T) {
+	for _, uri := range symmetricPolicyURIs {
+		t.Run(uri, func(t *testing.T) {
+			c := symmetricInstance(t, uri)
+
+			blockSize := c.algo.PlaintextBlockSize()
+			sigLen := c.algo.SignatureLength()
+
+			// sequence header (8) + body + signature + 1 PaddingSize byte
+			// is a multiple of the block size
+			bodyLen := 4*blockSize - 8 - sigLen - 1
+			for bodyLen < 0 {
+				bodyLen += blockSize
+			}
+			b, m := symmetricChunk(bytes.Repeat([]byte{0xab}, bodyLen))
+
+			cipher, err := c.signAndEncrypt(m, b)
+			require.NoError(t, err, "error: message encrypt")
+
+			// 16 byte header + already aligned plaintext + PaddingSize byte + signature
+			want := 16 + 8 + bodyLen + 1 + sigLen
+			require.Equal(t, want, len(cipher), "block-aligned plaintext got more than the PaddingSize byte of padding")
+
+			mc := new(MessageChunk)
+			_, err = mc.Decode(cipher)
+			require.NoError(t, err, "error: message decode")
+
+			plain, err := c.verifyAndDecrypt(mc, cipher)
+			require.NoError(t, err, "error: message decrypt")
+			require.Equal(t, b[16:], plain, "plaintext not equal")
+		})
+	}
+}
+
+func testName(uri string, chunkSize int) string {
+	return uri[len("http://opcfoundation.org/UA/SecurityPolicy#"):] + "/" + strconv.Itoa(chunkSize)
+}


### PR DESCRIPTION
This does fix the problem for me, although I am not 100% sure it's the correct fix. Here is my thinking:

I was able to reproduce the oversize message bug with an opcua server simulator. It happened on the very first message that needed to be split up into chunks. 

The `maxBodySize` calculation seems to be missing an allowance for the size of the signature padding. Signature padding is added in sign and encrypt, but not subtracted from the body size available. This means that any message that uses signAndEncrypt will fail if it's larger than the available message size and needs to be chunked. That's why the workaround of subscribing to less nodes works, as it lets the message fit inside one chunk.

By accounting for the worse case padding of 16 bytes + 1 byte for the padding size byte, the messages are small enough to fit, and I was able to subscribe to 10s of thousands of nodes with 1 client and 1 request.

It is possible that this is a red herring, and any "fix" that reduced the `maxBodySize` would have worked, but from my investigation, it does seem that the signature padding isn't accounted for so this feels at least plausible.


---
_Maintainer note (JeremyTheocharis): verified correct against OPC UA Part 6 v1.05 §6.7.2.5 and the current open62541 and OPC Foundation .NET reference implementations; see the review for details. Merging for v0.9.0._

Fixes #781
