### PR TITLE
set openSecureChannelRequest AuthenticationToken to nil on server side

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -740,9 +740,7 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(reqID uint32, svc ua.Requ
 	}
 
 	// Part 6.7.4: The AuthenticationToken should be nil. ???
-	if req.RequestHeader.AuthenticationToken.IntID() != 0 {
-		return ua.StatusBadSecureChannelTokenUnknown
-	}
+	req.RequestHeader.AuthenticationToken = nil
 
 	s.cfg.Lifetime = req.RequestedLifetime
 	s.cfg.SecurityMode = req.SecurityMode

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -740,7 +740,9 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(reqID uint32, svc ua.Requ
 	}
 
 	// Part 6.7.4: The AuthenticationToken should be nil. ???
-	req.RequestHeader.AuthenticationToken = nil
+	if req.RequestHeader.AuthenticationToken == nil {
+		debug.Printf("Received non-nil AuthenticationToken on OpenSecureChannelRequest")
+	}
 
 	s.cfg.Lifetime = req.RequestedLifetime
 	s.cfg.SecurityMode = req.SecurityMode

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -740,7 +740,7 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(reqID uint32, svc ua.Requ
 	}
 
 	// Part 6.7.4: The AuthenticationToken should be nil. ???
-	if req.RequestHeader.AuthenticationToken == nil {
+	if req.RequestHeader.AuthenticationToken != nil {
 		debug.Printf("Received non-nil AuthenticationToken on OpenSecureChannelRequest")
 	}
 


### PR DESCRIPTION
Some opc client libraries don't send the openSecureChannelRequest with a nil AuthenticationToken (e.g. open62541, which is used by Qt OPC UA: https://github.com/open62541/open62541/blob/10b66c8176cbd8d181931c7fe703038b887b6218/src/client/ua_client_connect.c#L608) With the current implementation, the client-server connection will be interrupted after 75% of the requested channel lifetime, leading to crashes or loss of data. This change improves compatibility of the gopcua server with applications building on Qt or open62541.