### PR TITLE
keep-alive mechanism

### DIFF
--- a/client_sub.go
+++ b/client_sub.go
@@ -181,8 +181,13 @@ func (c *Client) sendRepublishRequests(ctx context.Context, sub *Subscription, a
 
 		debug.Printf("RepublishRequest: req=%s", debug.ToJSON(req))
 		var res *ua.RepublishResponse
-		err := sc.SendRequest(ctx, req, c.Session().resp.AuthenticationToken, func(v ua.Response) error {
-			return safeAssign(v, &res)
+		err := sc.SendRequest(ctx, req, s.resp.AuthenticationToken, func(v ua.Response) error {
+			err := safeAssign(v, &res)
+			// Update session activity on successful republish response
+			if err == nil {
+				s.setLastActivity(time.Now())
+			}
+			return err
 		})
 		debug.Printf("RepublishResponse: res=%s err=%v", debug.ToJSON(res), err)
 

--- a/uasc/config.go
+++ b/uasc/config.go
@@ -148,4 +148,14 @@ type SessionConfig struct {
 	// PolicyURI to use when encrypting secrets for the User Identity Token
 	// Could be different from the secure channel's policy
 	AuthPolicyURI string
+
+	// SessionKeepAlive enables proactive session keep alive before timeout
+	// If enabled, the client will monitor session timeout and proactively
+	// send keep alive requests before the session expires, instead of waiting for errors.
+	SessionKeepAlive bool
+
+	// SessionKeepAliveThreshold is the percentage of SessionTimeout at which
+	// to trigger proactive keep alive. Default is 0.75 (75% of timeout).
+	// Must be between 0.1 and 0.9.
+	SessionKeepAliveThreshold float64
 }


### PR DESCRIPTION
This change introduces a mechanism to explicitly send keep-alive requests to the Siemens Sinumerik OPC UA server in order to prevent premature session termination.

## Background

The Sinumerik OPC UA server enforces a very short session timeout (≈1 minute), even when the client requests a longer duration.
When a subscription exists but no monitored items are returned, the server does not refresh the session timeout automatically.
Without intervention, this behavior causes the client session to expire unexpectedly.

## Solution

Implemented a proof of concept (POC) that periodically sends keep-alive requests to the server.
This ensures that the client session remains active, even when the server has no monitored items to publish.

## Notes

The implementation is functional but not production-ready.
Additional polish, configuration options, and extensive testing are required before considering it stable.