### PR TITLE
fix/support method call in server

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Here is the current set of supported services. For low-level access use the clie
 |                             | Write                         | Yes    | Yes    |              |
 |                             | HistoryRead                   | Yes    |        |              |
 |                             | HistoryUpdate                 |        |        |              |
-| Method Service Set          | Call                          | Yes    |        |              |
+| Method Service Set          | Call                          | Yes    | Yes       |              |
 | MonitoredItems Service Set  | CreateMonitoredItems          | Yes    | Yes    |              |
 |                             | DeleteMonitoredItems          | Yes    | Yes    |              |
 |                             | ModifyMonitoredItems          | Yes    | Yes    |              |

--- a/schema/uaNodeSet.go
+++ b/schema/uaNodeSet.go
@@ -259,8 +259,19 @@ type ValueExtensionObjectArgument struct {
 	} `xml:"Description"`
 }
 
+type ValueExtensionObjectEnumValueType struct {
+	Value       int `xml:"Value"`
+	DisplayName struct {
+		Text string `xml:"Text"`
+	} `xml:"DisplayName"`
+	Description struct {
+		Text string `xml:"Text"`
+	} `xml:"Description"`
+}
+
 type ValueExtensionObjectBody struct {
-	Argument ValueExtensionObjectArgument `xml:"Argument"`
+	Argument      *ValueExtensionObjectArgument      `xml:"Argument,omitempty"`
+	EnumValueType *ValueExtensionObjectEnumValueType `xml:"EnumValueType,omitempty"`
 }
 
 type ValueExtensionObject struct {

--- a/schema/uaNodeSet.go
+++ b/schema/uaNodeSet.go
@@ -2,7 +2,10 @@
 
 package schema
 
-import _ "embed"
+import (
+	_ "embed"
+	"time"
+)
 
 //go:embed Opc.Ua.NodeSet2.xml
 var OpcUaNodeSet2 []byte
@@ -234,8 +237,91 @@ type UAObject struct {
 	*UAInstance
 }
 
+type ValueBool struct {
+	Data bool `xml:",chardata"`
+}
+
+type ValueDateTime struct {
+	Data time.Time `xml:",chardata"`
+}
+
+type ValueExtensionObjectArgument struct {
+	Name     string `xml:"Name"`
+	DataType struct {
+		Identifier string `xml:"Identifier"`
+	} `xml:"DataType"`
+	ValueRank       int `xml:"ValueRank"`
+	ArrayDimensions struct {
+		Data []ValueUInt32 `xml:"UInt32,omitempty"`
+	}
+	Description struct {
+		Text string `xml:"Text"`
+	} `xml:"Description"`
+}
+
+type ValueExtensionObjectBody struct {
+	Argument ValueExtensionObjectArgument `xml:"Argument"`
+}
+
+type ValueExtensionObject struct {
+	TypeID struct {
+		Identifier string `xml:"Identifier"`
+	} `xml:"TypeId"`
+	Body ValueExtensionObjectBody `xml:"Body"`
+}
+
+type ValueExtensionObjectList struct {
+	Data []ValueExtensionObject `xml:"ExtensionObject"`
+}
+
+type ValueInt32 struct {
+	Data int32 `xml:",chardata"`
+}
+
+type ValueInt32List struct {
+	Data []ValueInt32 `xml:"Int32"`
+}
+
+type ValueLocalizedText struct {
+	Locale string `xml:"Locale"`
+	Text   string `xml:"Text"`
+}
+
+type ValueLocalizedTextList struct {
+	Data []ValueLocalizedText `xml:"LocalizedText"`
+}
+
+type ValueQualifiedName struct {
+	NamespaceIndex int    `xml:"NamespaceIndex"`
+	Name           string `xml:"Name"`
+}
+
+type ValueUInt32 struct {
+	Data uint32 `xml:",chardata"`
+}
+
+type ValueString struct {
+	Data string `xml:",chardata"`
+}
+
+type ValueStringList struct {
+	Data []ValueString `xml:"String"`
+}
+
 // Value ...
 type Value struct {
+	BoolAttr          *ValueBool                `xml:"Boolean,omitempty"`
+	DateTimeAttr      *ValueDateTime            `xml:"DateTime,omitempty"`
+	ExtObjAttr        *ValueExtensionObject     `xml:"ExtensionObject,omitempty"`
+	ExtObjListAttr    *ValueExtensionObjectList `xml:"ListOfExtensionObject,omitempty"`
+	Int32Attr         *ValueInt32               `xml:"Int32,omitempty"`
+	Int32ListAttr     *ValueInt32List           `xml:"ListOfInt32,omitempty"`
+	QualifiedNameAttr *ValueQualifiedName       `xml:"QualifiedName,omitempty"`
+	StringAttr        *ValueString              `xml:"String,omitempty"`
+	StringListAttr    *ValueStringList          `xml:"ListOfString,omitempty"`
+	TextAttr          *ValueLocalizedText       `xml:"LocalizedText,omitempty"`
+	TextListAttr      *ValueLocalizedTextList   `xml:"ListOfLocalizedText,omitempty"`
+	UInt32Attr        *ValueUInt32              `xml:"UInt32,omitempty"`
 }
 
 // UAVariable ...

--- a/schema/uaNodeSet.go
+++ b/schema/uaNodeSet.go
@@ -241,6 +241,10 @@ type ValueBool struct {
 	Data bool `xml:",chardata"`
 }
 
+type ValueByteString struct {
+	Data string `xml:",chardata"`
+}
+
 type ValueDateTime struct {
 	Data time.Time `xml:",chardata"`
 }
@@ -322,6 +326,7 @@ type ValueStringList struct {
 // Value ...
 type Value struct {
 	BoolAttr          *ValueBool                `xml:"Boolean,omitempty"`
+	ByteStringAttr    *ValueByteString          `xml:"ByteString,omitempty"`
 	DateTimeAttr      *ValueDateTime            `xml:"DateTime,omitempty"`
 	ExtObjAttr        *ValueExtensionObject     `xml:"ExtensionObject,omitempty"`
 	ExtObjListAttr    *ValueExtensionObjectList `xml:"ListOfExtensionObject,omitempty"`

--- a/server/context/context.go
+++ b/server/context/context.go
@@ -1,0 +1,77 @@
+package context
+
+import (
+	"context"
+)
+
+type srvCtxKeyType struct{}
+
+var srvCtxKey = srvCtxKeyType{}
+
+type srvctx struct {
+	methodID         string
+	methodName       string
+	methodObjectID   string
+	methodObjectName string
+
+	serviceSet  string
+	serviceName string
+}
+
+func load(ctx context.Context) *srvctx {
+	sc, ok := ctx.Value(srvCtxKey).(*srvctx)
+
+	if !ok {
+		return &srvctx{}
+	}
+
+	return sc
+}
+
+func store(ctx context.Context, sc *srvctx) context.Context {
+	return context.WithValue(ctx, srvCtxKey, sc)
+}
+
+func WithMethodCall(ctx context.Context, objectID, objectName, methodID, methodName string) context.Context {
+	sc := load(ctx)
+
+	sc.methodID = methodID
+	sc.methodName = methodName
+	sc.methodObjectID = objectID
+	sc.methodObjectName = objectName
+
+	return store(ctx, sc)
+}
+
+func MethodID(ctx context.Context) string {
+	return load(ctx).methodID
+}
+
+func MethodName(ctx context.Context) string {
+	return load(ctx).methodName
+}
+
+func MethodObjectID(ctx context.Context) string {
+	return load(ctx).methodObjectID
+}
+
+func MethodObjectName(ctx context.Context) string {
+	return load(ctx).methodObjectName
+}
+
+func WithServiceSetAndName(ctx context.Context, set, name string) context.Context {
+	sc := load(ctx)
+
+	sc.serviceName = name
+	sc.serviceSet = set
+
+	return store(ctx, sc)
+}
+
+func ServiceSet(ctx context.Context) string {
+	return load(ctx).serviceSet
+}
+
+func ServiceName(ctx context.Context) string {
+	return load(ctx).serviceName
+}

--- a/server/method_service.go
+++ b/server/method_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 
+	srvctx "github.com/gopcua/opcua/server/context"
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uasc"
 )
@@ -18,6 +19,7 @@ type MethodService struct {
 
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.2
 func (s *MethodService) Call(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
+	ctx := srvctx.WithServiceSetAndName(context.Background(), "Method", "Call")
 	if s.srv.cfg.logger != nil {
 		s.srv.cfg.logger.Debug("Handling %T", r)
 	}
@@ -71,7 +73,10 @@ func (s *MethodService) Call(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 
 		res := &ua.CallMethodResult{}
 		res.OutputArguments, res.StatusCode = s.middleware(methodNode.CallMethod)(
-			context.Background(),
+			srvctx.WithMethodCall(ctx,
+				objectNode.ID().String(), objectNode.DisplayName().Text,
+				methodNode.ID().String(), methodNode.DisplayName().Text,
+			),
 			method.InputArguments...,
 		)
 

--- a/server/method_service.go
+++ b/server/method_service.go
@@ -12,7 +12,8 @@ import (
 //
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12
 type MethodService struct {
-	srv *Server
+	srv        *Server
+	middleware MethodMiddleware
 }
 
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.2
@@ -69,7 +70,7 @@ func (s *MethodService) Call(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 		}
 
 		res := &ua.CallMethodResult{}
-		res.OutputArguments, res.StatusCode = methodNode.CallMethod(
+		res.OutputArguments, res.StatusCode = s.middleware(methodNode.CallMethod)(
 			context.Background(),
 			method.InputArguments...,
 		)

--- a/server/method_service.go
+++ b/server/method_service.go
@@ -1,18 +1,21 @@
 package server
 
 import (
+	"context"
+	"slices"
+
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uasc"
 )
 
 // MethodService implements the Method Service Set.
 //
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.11
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12
 type MethodService struct {
 	srv *Server
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.11.2
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.2
 func (s *MethodService) Call(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.srv.cfg.logger != nil {
 		s.srv.cfg.logger.Debug("Handling %T", r)
@@ -22,5 +25,75 @@ func (s *MethodService) Call(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 	if err != nil {
 		return nil, err
 	}
-	return serviceUnsupported(req.RequestHeader), nil
+
+	results := make([]*ua.CallMethodResult, 0, len(req.MethodsToCall))
+	status := ua.StatusOK
+
+	// Check if the method has a non forward reference to this object
+	methodBelongsToObject := func(method *Node, object *Node) bool {
+		return slices.ContainsFunc(
+			method.refs,
+			func(e *ua.ReferenceDescription) bool {
+				if !e.IsForward && e.NodeID.NodeID.IntID() == object.id.IntID() {
+					return true
+				}
+				return false
+			},
+		)
+	}
+
+	for _, method := range req.MethodsToCall {
+		ns, err := s.srv.Namespace(int(method.ObjectID.Namespace()))
+		if err != nil {
+			return &ua.CallResponse{
+				ResponseHeader: responseHeader(req.RequestHeader.RequestHandle, ua.StatusBadMethodInvalid),
+			}, nil
+		}
+
+		objectNode := ns.Node(method.ObjectID)
+		if objectNode == nil {
+			return &ua.CallResponse{
+				ResponseHeader: responseHeader(req.RequestHeader.RequestHandle, ua.StatusBadNodeIDUnknown),
+			}, nil
+		}
+
+		methodNode := ns.Node(method.MethodID)
+
+		if methodNode == nil || !methodBelongsToObject(methodNode, objectNode) {
+			s.srv.cfg.logger.Error("no method %s found on object %s",
+				methodNode.DisplayName().Text, objectNode.DisplayName().Text,
+			)
+			return &ua.CallResponse{
+				ResponseHeader: responseHeader(req.RequestHeader.RequestHandle, ua.StatusBadMethodInvalid),
+			}, nil
+		}
+
+		res := &ua.CallMethodResult{}
+		res.OutputArguments, res.StatusCode = methodNode.CallMethod(
+			context.Background(),
+			method.InputArguments...,
+		)
+
+		s.srv.cfg.logger.Info("called method %s on object %s (status: %v)",
+			methodNode.DisplayName().Text, objectNode.DisplayName().Text,
+			res.StatusCode,
+		)
+
+		if res.StatusCode != ua.StatusOK && status == ua.StatusOK {
+			status = res.StatusCode
+		}
+
+		results = append(results, res)
+	}
+
+	response := &ua.CallResponse{
+		ResponseHeader: responseHeader(req.RequestHeader.RequestHandle, status),
+		// TODO: Support result data ...
+	}
+
+	if status == ua.StatusOK {
+		response.Results = results
+	}
+
+	return response, nil
 }

--- a/server/node.go
+++ b/server/node.go
@@ -18,6 +18,8 @@ type Attributes map[ua.AttributeID]*ua.DataValue
 type References []*ua.ReferenceDescription
 
 type MethodFunc func(context.Context, ...*ua.Variant) ([]*ua.Variant, ua.StatusCode)
+type MethodMiddleware func(MethodFunc) MethodFunc
+
 type ValueFunc func() *ua.DataValue
 
 type AttrValue struct {

--- a/server/node_method.go
+++ b/server/node_method.go
@@ -6,17 +6,36 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
-func SetMethod(n *Node, fn func(context.Context) ua.StatusCode) {
+func SetMethod(n *Node, fn func(context.Context) error) {
 	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
 		if len(args) > 0 {
 			return nil, ua.StatusBadTooManyArguments
 		}
 
-		return nil, fn(ctx)
+		return nil, mapError(fn(ctx))
 	}
 }
 
-func SetMethod1[T any](n *Node, fn func(context.Context, T) ua.StatusCode) {
+func SetMethod1S[T any](n *Node, fn func(context.Context, []T) error) {
+	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
+		if len(args) == 0 {
+			return nil, ua.StatusBadArgumentsMissing
+		}
+
+		if len(args) > 1 {
+			return nil, ua.StatusBadTooManyArguments
+		}
+
+		argVal, ok := decodeInputParameterSlice[T](args[0])
+		if !ok {
+			return nil, ua.StatusBadTypeMismatch
+		}
+
+		return nil, mapError(fn(ctx, argVal))
+	}
+}
+
+func SetMethod1[T any](n *Node, fn func(context.Context, T) error) {
 	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
 		if len(args) == 0 {
 			return nil, ua.StatusBadArgumentsMissing
@@ -31,11 +50,11 @@ func SetMethod1[T any](n *Node, fn func(context.Context, T) ua.StatusCode) {
 			return nil, ua.StatusBadTypeMismatch
 		}
 
-		return nil, fn(ctx, argVal)
+		return nil, mapError(fn(ctx, argVal))
 	}
 }
 
-func SetMethod2[T, U any](n *Node, fn func(context.Context, T, U) ua.StatusCode) {
+func SetMethod2[T, U any](n *Node, fn func(context.Context, T, U) error) {
 	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
 		if len(args) < 2 {
 			return nil, ua.StatusBadArgumentsMissing
@@ -51,11 +70,11 @@ func SetMethod2[T, U any](n *Node, fn func(context.Context, T, U) ua.StatusCode)
 			return nil, ua.StatusBadTypeMismatch
 		}
 
-		return nil, fn(ctx, arg0Val, arg1Val)
+		return nil, mapError(fn(ctx, arg0Val, arg1Val))
 	}
 }
 
-func SetMethod3[T, U, V any](n *Node, fn func(context.Context, T, U, V) ua.StatusCode) {
+func SetMethod3[T, U, V any](n *Node, fn func(context.Context, T, U, V) error) {
 	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
 		if len(args) < 3 {
 			return nil, ua.StatusBadArgumentsMissing
@@ -72,7 +91,7 @@ func SetMethod3[T, U, V any](n *Node, fn func(context.Context, T, U, V) ua.Statu
 			return nil, ua.StatusBadTypeMismatch
 		}
 
-		return nil, fn(ctx, arg0Val, arg1Val, arg2Val)
+		return nil, mapError(fn(ctx, arg0Val, arg1Val, arg2Val))
 	}
 }
 
@@ -95,4 +114,43 @@ func decodeInputParameter[T any](v *ua.Variant) (val T, ok bool) {
 	}
 
 	return
+}
+
+func decodeInputParameterSlice[T any](v *ua.Variant) (val []T, ok bool) {
+	if val, ok = v.Value().([]T); ok {
+		return
+	}
+
+	if extObj := v.ExtensionObject(); extObj != nil {
+		if val, ok = extObj.Value.([]T); ok {
+			return
+		}
+	}
+
+	if v.ArrayLength() > 0 {
+		var eos []*ua.ExtensionObject
+		if eos, ok = v.Value().([]*ua.ExtensionObject); ok {
+			val = make([]T, 0, v.ArrayLength())
+			for idx := range eos {
+				if t, ok := eos[idx].Value.(T); ok {
+					val = append(val, t)
+				}
+			}
+			ok = len(val) == int(v.ArrayLength())
+		}
+	}
+
+	return
+}
+
+func mapError(err error) ua.StatusCode {
+	if err == nil {
+		return ua.StatusOK
+	}
+
+	if code, ok := err.(ua.StatusCode); ok {
+		return code
+	}
+
+	return ua.StatusBadUnexpectedError
 }

--- a/server/node_method.go
+++ b/server/node_method.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+
+	"github.com/gopcua/opcua/ua"
+)
+
+func SetMethod(n *Node, fn func(context.Context) ua.StatusCode) {
+	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
+		if len(args) > 0 {
+			return nil, ua.StatusBadTooManyArguments
+		}
+
+		return nil, fn(ctx)
+	}
+}
+
+func SetMethod1[T any](n *Node, fn func(context.Context, T) ua.StatusCode) {
+	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
+		if len(args) == 0 {
+			return nil, ua.StatusBadArgumentsMissing
+		}
+
+		if len(args) > 1 {
+			return nil, ua.StatusBadTooManyArguments
+		}
+
+		argVal, ok := decodeInputParameter[T](args[0])
+		if !ok {
+			return nil, ua.StatusBadTypeMismatch
+		}
+
+		return nil, fn(ctx, argVal)
+	}
+}
+
+func SetMethod2[T, U any](n *Node, fn func(context.Context, T, U) ua.StatusCode) {
+	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
+		if len(args) < 2 {
+			return nil, ua.StatusBadArgumentsMissing
+		}
+
+		if len(args) > 2 {
+			return nil, ua.StatusBadTooManyArguments
+		}
+
+		arg0Val, ok0 := decodeInputParameter[T](args[0])
+		arg1Val, ok1 := decodeInputParameter[U](args[1])
+		if !ok0 || !ok1 {
+			return nil, ua.StatusBadTypeMismatch
+		}
+
+		return nil, fn(ctx, arg0Val, arg1Val)
+	}
+}
+
+func SetMethod3[T, U, V any](n *Node, fn func(context.Context, T, U, V) ua.StatusCode) {
+	n.call = func(ctx context.Context, args ...*ua.Variant) ([]*ua.Variant, ua.StatusCode) {
+		if len(args) < 3 {
+			return nil, ua.StatusBadArgumentsMissing
+		}
+
+		if len(args) > 3 {
+			return nil, ua.StatusBadTooManyArguments
+		}
+
+		arg0Val, ok0 := decodeInputParameter[T](args[0])
+		arg1Val, ok1 := decodeInputParameter[U](args[1])
+		arg2Val, ok2 := decodeInputParameter[V](args[1])
+		if !ok0 || !ok1 || !ok2 {
+			return nil, ua.StatusBadTypeMismatch
+		}
+
+		return nil, fn(ctx, arg0Val, arg1Val, arg2Val)
+	}
+}
+
+func decodeInputParameter[T any](v *ua.Variant) (val T, ok bool) {
+	if val, ok = v.Value().(T); ok {
+		return
+	}
+
+	if extObj := v.ExtensionObject(); extObj != nil {
+		if val, ok = extObj.Value.(T); ok {
+			return
+		}
+
+		var ptr *T
+		if ptr, ok = extObj.Value.(*T); ok {
+			if ptr != nil {
+				val = *ptr
+			}
+		}
+	}
+
+	return
+}

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -215,11 +216,13 @@ func (srv *Server) nodesImportNodeSet(nodes *schema.UANodeSet) error {
 	for i := range nodes.UAMethod {
 		ot := nodes.UAMethod[i]
 		nid := ua.MustParseNodeID(ot.NodeIdAttr)
+
 		var attrs Attributes = make(map[ua.AttributeID]*ua.DataValue)
 		attrs[ua.AttributeIDAccessRestrictions] = DataValueFromValue(ot.AccessRestrictionsAttr)
 		attrs[ua.AttributeIDBrowseName] = DataValueFromValue(&ua.QualifiedName{NamespaceIndex: nid.Namespace(), Name: ot.BrowseNameAttr})
 		attrs[ua.AttributeIDUserWriteMask] = DataValueFromValue(ot.UserWriteMaskAttr)
 		attrs[ua.AttributeIDWriteMask] = DataValueFromValue(ot.WriteMaskAttr)
+
 		if len(ot.DisplayName) > 0 {
 			attrs[ua.AttributeIDDisplayName] = DataValueFromValue(ua.NewLocalizedText(ot.DisplayName[0].Value))
 		}
@@ -231,6 +234,9 @@ func (srv *Server) nodesImportNodeSet(nodes *schema.UANodeSet) error {
 		var refs References = make([]*ua.ReferenceDescription, 0)
 
 		n := NewNode(nid, attrs, refs, nil)
+
+		SetMethod(n, func(_ context.Context) ua.StatusCode { return ua.StatusBadNotImplemented })
+
 		ns, err := srv.Namespace(int(nid.Namespace()))
 		if err != nil {
 			// This namespace doesn't exist.

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -235,7 +235,7 @@ func (srv *Server) nodesImportNodeSet(nodes *schema.UANodeSet) error {
 
 		n := NewNode(nid, attrs, refs, nil)
 
-		SetMethod(n, func(_ context.Context) ua.StatusCode { return ua.StatusBadNotImplemented })
+		SetMethod(n, func(_ context.Context) error { return ua.StatusBadNotImplemented })
 
 		ns, err := srv.Namespace(int(nid.Namespace()))
 		if err != nil {

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"slices"
@@ -256,9 +257,10 @@ func (srv *Server) nodesImportNodeSet(nodes *schema.UANodeSet) error {
 			} else if ot.Value.BoolAttr != nil {
 				valueFunc = newValueFuncFromData(ot.Value.BoolAttr.Data)
 			} else if ot.Value.ByteStringAttr != nil {
-				valueFunc = newValueFuncFromData(
-					strings.ReplaceAll(ot.Value.ByteStringAttr.Data, " ", ""),
-				)
+				bs := ot.Value.ByteStringAttr.Data
+				if b64b, err := base64.StdEncoding.DecodeString(bs); err == nil {
+					valueFunc = newValueFuncFromData(b64b)
+				}
 			} else if ot.Value.TextAttr != nil {
 				v := ua.NewLocalizedTextWithLocale(ot.Value.TextAttr.Text, ot.Value.TextAttr.Locale)
 				valueFunc = newValueFuncFromData(v)

--- a/server/nodeset2_import.go
+++ b/server/nodeset2_import.go
@@ -255,6 +255,10 @@ func (srv *Server) nodesImportNodeSet(nodes *schema.UANodeSet) error {
 				valueFunc = newValueFuncFromData(data)
 			} else if ot.Value.BoolAttr != nil {
 				valueFunc = newValueFuncFromData(ot.Value.BoolAttr.Data)
+			} else if ot.Value.ByteStringAttr != nil {
+				valueFunc = newValueFuncFromData(
+					strings.ReplaceAll(ot.Value.ByteStringAttr.Data, " ", ""),
+				)
 			} else if ot.Value.TextAttr != nil {
 				v := ua.NewLocalizedTextWithLocale(ot.Value.TextAttr.Text, ot.Value.TextAttr.Locale)
 				valueFunc = newValueFuncFromData(v)

--- a/server/server.go
+++ b/server/server.go
@@ -69,6 +69,8 @@ type serverConfig struct {
 
 	cap ServerCapabilities
 
+	methodCallMiddleware MethodMiddleware
+
 	logger Logger
 }
 
@@ -99,11 +101,12 @@ type security struct {
 // Call Start() afterwards to begin listening and serving connections
 func New(opts ...Option) *Server {
 	cfg := &serverConfig{
-		cap:              capabilities,
-		applicationName:  "GOPCUA",               // override with the ServerName option
-		manufacturerName: "The gopcua Team",      // override with the ManufacturerName option
-		productName:      "gopcua OPC/UA Server", // override with the ProductName option
-		softwareVersion:  "0.0.0-dev",            // override with the SoftwareVersion option
+		cap:                  capabilities,
+		applicationName:      "GOPCUA",               // override with the ServerName option
+		manufacturerName:     "The gopcua Team",      // override with the ManufacturerName option
+		productName:          "gopcua OPC/UA Server", // override with the ProductName option
+		softwareVersion:      "0.0.0-dev",            // override with the SoftwareVersion option
+		methodCallMiddleware: func(fn MethodFunc) MethodFunc { return fn },
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -149,6 +149,12 @@ func SoftwareVersion(name string) Option {
 	}
 }
 
+func WithMethodMiddleware(mw MethodMiddleware) Option {
+	return func(s *serverConfig) {
+		s.methodCallMiddleware = mw
+	}
+}
+
 // this logger interface is used to allow the user to provide their own logger
 // it is compatible with slog.Logger
 type Logger interface {

--- a/server/server_nodes.go
+++ b/server/server_nodes.go
@@ -66,7 +66,7 @@ func RootNode() *Node {
 	)
 }
 
-func ServerStatusNodes(s *Server, ServerNode *Node) []*Node {
+func ServerStatusNodes(s *Server, serverNode *Node) []*Node {
 
 	/*
 		Server_ServerArray                                                                                                                                                    = 2254
@@ -234,7 +234,7 @@ func ServerStatusNodes(s *Server, ServerNode *Node) []*Node {
 	for i := range nodes {
 		sStatus.AddRef(nodes[i], id.HasComponent, true)
 	}
-	ServerNode.AddRef(sStatus, id.HasComponent, true)
+	serverNode.AddRef(sStatus, id.HasComponent, true)
 
 	nodes = append(nodes, sStatus)
 

--- a/server/service_handlers.go
+++ b/server/service_handlers.go
@@ -58,7 +58,7 @@ func (s *Server) initHandlers() {
 	s.RegisterHandler(id.WriteRequest_Encoding_DefaultBinary, attr.Write)
 	s.RegisterHandler(id.HistoryUpdateRequest_Encoding_DefaultBinary, attr.HistoryUpdate)
 
-	method := &MethodService{s}
+	method := &MethodService{s, s.cfg.methodCallMiddleware}
 	// s.registerHandler(id.CallMethodRequest_Encoding_DefaultBinary, method.CallMethod) // todo(fs): I think this is bogus
 	s.RegisterHandler(id.CallRequest_Encoding_DefaultBinary, method.Call)
 

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -173,7 +173,7 @@ func (s *ViewService) TranslateBrowsePathsToNodeIDs(sc *uasc.SecureChannel, r ua
 		},
 		Results: make([]*ua.BrowsePathResult, len(req.BrowsePaths)),
 
-		DiagnosticInfos: []*ua.DiagnosticInfo{{}},
+		DiagnosticInfos: []*ua.DiagnosticInfo{},
 	}
 
 	findTarget := func(n *Node, pathElements []*ua.RelativePathElement) (*ua.BrowsePathResult, error) {

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"math"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/gopcua/opcua/id"
@@ -149,7 +151,7 @@ func (s *ViewService) BrowseNext(sc *uasc.SecureChannel, r ua.Request, reqID uin
 	return serviceUnsupported(req.RequestHeader), nil
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.4
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.9.4
 func (s *ViewService) TranslateBrowsePathsToNodeIDs(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.srv.cfg.logger != nil {
 		s.srv.cfg.logger.Debug("Handling %T", r)
@@ -159,7 +161,54 @@ func (s *ViewService) TranslateBrowsePathsToNodeIDs(sc *uasc.SecureChannel, r ua
 	if err != nil {
 		return nil, err
 	}
-	return serviceUnsupported(req.RequestHeader), nil
+
+	resp := &ua.TranslateBrowsePathsToNodeIDsResponse{
+		ResponseHeader: &ua.ResponseHeader{
+			Timestamp:          time.Now(),
+			RequestHandle:      req.RequestHeader.RequestHandle,
+			ServiceResult:      ua.StatusOK,
+			ServiceDiagnostics: &ua.DiagnosticInfo{},
+			StringTable:        []string{},
+			AdditionalHeader:   ua.NewExtensionObject(nil),
+		},
+		Results: make([]*ua.BrowsePathResult, len(req.BrowsePaths)),
+
+		DiagnosticInfos: []*ua.DiagnosticInfo{{}},
+	}
+
+	findTarget := func(n *Node, pathElements []*ua.RelativePathElement) (*ua.BrowsePathResult, error) {
+		for _, elem := range pathElements {
+			var e *ua.RelativePathElement = elem
+			for _, ref := range n.refs {
+				if ref.ReferenceTypeID.Equal(e.ReferenceTypeID) && ref.IsForward == !e.IsInverse {
+					referenceTarget := s.srv.Node(ref.NodeID.NodeID)
+					if strings.Compare(referenceTarget.DisplayName().Text, e.TargetName.Name) == 0 {
+						return &ua.BrowsePathResult{
+							StatusCode: ua.StatusOK,
+							Targets: []*ua.BrowsePathTarget{
+								{TargetID: ref.NodeID, RemainingPathIndex: math.MaxUint32},
+							},
+						}, nil
+					}
+				}
+			}
+		}
+
+		return &ua.BrowsePathResult{
+			StatusCode: ua.StatusBadNoMatch,
+			Targets:    []*ua.BrowsePathTarget{},
+		}, nil
+	}
+
+	for _, path := range req.BrowsePaths {
+		if n := s.srv.Node(path.StartingNode); n != nil && path.RelativePath != nil {
+			if bpr, err := findTarget(n, path.RelativePath.Elements); err == nil {
+				resp.Results = append(resp.Results, bpr)
+			}
+		}
+	}
+
+	return resp, nil
 }
 
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.5

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -200,10 +200,10 @@ func (s *ViewService) TranslateBrowsePathsToNodeIDs(sc *uasc.SecureChannel, r ua
 		}, nil
 	}
 
-	for _, path := range req.BrowsePaths {
+	for idx, path := range req.BrowsePaths {
 		if n := s.srv.Node(path.StartingNode); n != nil && path.RelativePath != nil {
 			if bpr, err := findTarget(n, path.RelativePath.Elements); err == nil {
-				resp.Results = append(resp.Results, bpr)
+				resp.Results[idx] = bpr
 			}
 		}
 	}

--- a/ua/buffer.go
+++ b/ua/buffer.go
@@ -294,7 +294,7 @@ func (b *Buffer) WriteByteString(d []byte) {
 	b.Write(d)
 }
 
-func (b *Buffer) WriteStruct(w interface{}) {
+func (b *Buffer) WriteStruct(w any) {
 	if b.err != nil {
 		return
 	}

--- a/ua/variant.go
+++ b/ua/variant.go
@@ -64,7 +64,7 @@ type Variant struct {
 func NewVariant(v interface{}) (*Variant, error) {
 	va := &Variant{}
 	if !isBuiltinType(v) {
-		return nil, fmt.Errorf("trying to create a variant from a type that it is not supported: %s", reflect.ValueOf(v).Type().Name())
+		return nil, fmt.Errorf("trying to create a variant from a type that is not supported: %s", reflect.ValueOf(v).Type().Name())
 	}
 	if err := va.set(v); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a draft PR to be used for discussions about how the Call feature in the Method service set could/should be implemented. Feel free to comment, but please understand that this is a quick proof of concept that will need more work and some more interface changes.

The basic idea is that the server side code should be able to register callback functions using generic SetMethod functions, that take care of mapping incoming InputArguments to the expected types.

Right now everything lives in the server package scope but I expect that to change shortly.