### PR TITLE
fix: make sure that the server returns a non zero revised session timeout

### DIFF
--- a/server/session_service.go
+++ b/server/session_service.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	sessionTimeoutMin     = 100            // 100ms
-	sessionTimeoutMax     = 30 * 60 * 1000 // 30 minutes
-	sessionTimeoutDefault = 60 * 1000      // 60s
+	sessionTimeoutMin     = 100 * time.Millisecond
+	sessionTimeoutMax     = 1 * time.Hour
+	sessionTimeoutDefault = 60 * time.Second
 
 	sessionNonceLength = 32
 )


### PR DESCRIPTION
    The session service created allowed range and default in milliseconds, but compared
    and divided with a time.Duration that is expressed in nanoseconds. The result was that 
    the returned revised timeout was always zero.

    Problem happened here: https://github.com/gopcua/opcua/blob/0d83d1cc736a5db59bfbb31a167d3e9c6b09c845/server/session_service.go#L76

Fixes #830