### PR TITLE
Fix server crash on Write requests to non-existing namespace

### DIFF
--- a/server/attribute_service.go
+++ b/server/attribute_service.go
@@ -84,6 +84,7 @@ func (s *AttributeService) Write(sc *uasc.SecureChannel, r ua.Request, reqID uin
 		ns, err := s.srv.Namespace(int(n.NodeID.Namespace()))
 		if err != nil {
 			status[i] = ua.StatusBadNodeNotInView
+			continue
 		}
 
 		status[i] = ns.SetAttribute(n.NodeID, n.AttributeID, n.Value)

--- a/server/attribute_service.go
+++ b/server/attribute_service.go
@@ -83,7 +83,7 @@ func (s *AttributeService) Write(sc *uasc.SecureChannel, r ua.Request, reqID uin
 
 		ns, err := s.srv.Namespace(int(n.NodeID.Namespace()))
 		if err != nil {
-			status[i] = ua.StatusBadNodeNotInView
+			status[i] = ua.StatusBadNodeIDUnknown
 			continue
 		}
 

--- a/tests/go/read_test.go
+++ b/tests/go/read_test.go
@@ -117,6 +117,8 @@ func TestReadPerms(t *testing.T) {
 		{ua.NewStringNodeID(1, "ReadWriteVariable"), ua.StatusOK, 12.34},
 		{ua.NewStringNodeID(1, "ReadOnlyVariable"), ua.StatusOK, 9.87},
 		{ua.NewStringNodeID(1, "NoAccessVariable"), ua.StatusBadUserAccessDenied, nil},
+		// non-existing namespace should not crash the server
+		{ua.NewNumericNodeID(132, 101), ua.StatusBad, nil},
 	}
 
 	ctx := context.Background()

--- a/tests/go/write_test.go
+++ b/tests/go/write_test.go
@@ -27,6 +27,8 @@ func TestWrite(t *testing.T) {
 
 		// error flows
 		{ua.NewStringNodeID(1, "ro_bool"), false, ua.StatusBadUserAccessDenied},
+		// non-existing namespace should not crash the server
+		{ua.NewNumericNodeID(132, 101), int32(42), ua.StatusBadNodeNotInView},
 	}
 
 	ctx := context.Background()

--- a/tests/go/write_test.go
+++ b/tests/go/write_test.go
@@ -27,8 +27,7 @@ func TestWrite(t *testing.T) {
 
 		// error flows
 		{ua.NewStringNodeID(1, "ro_bool"), false, ua.StatusBadUserAccessDenied},
-		// non-existing namespace should not crash the server
-		{ua.NewNumericNodeID(132, 101), int32(42), ua.StatusBadNodeNotInView},
+		// non-existing namespace: see TestWriteToUnknownNamespace_Part4_Write
 	}
 
 	ctx := context.Background()

--- a/tests/go/write_unknown_namespace_test.go
+++ b/tests/go/write_unknown_namespace_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+// +build integration
+
+package uatest2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteToUnknownNamespace_Part4_Write verifies that a Write whose target
+// NodeId references a namespace index that does not exist on the server returns
+// an operation-level Bad status, and never terminates the server.
+//
+// OPC UA Part 4 v1.05 §5.10.4 (Write): "This Service is used to write values to
+// one or more Attributes of one or more Nodes." Each NodesToWrite entry yields
+// its own operation-level StatusCode in Results; a target that does not exist in
+// the server AddressSpace is reported as Bad_NodeIdUnknown ("The node id refers
+// to a node that does not exist in the server address space."). Bad_NodeNotInView
+// is a View/Browse concept (§5.8) and does not apply to the Write Service.
+//
+// Cross-impl: open62541 (editNode -> UA_STATUSCODE_BADNODEIDUNKNOWN) and
+// UA-.NETStandard (MasterNodeManager.Write -> BadNodeIdUnknown) both return
+// Bad_NodeIdUnknown for this case.
+//
+// Regression for #841: AttributeService.Write omitted `continue` after a failed
+// namespace lookup and dereferenced a nil NameSpace, panicking the server.
+func TestWriteToUnknownNamespace_Part4_Write(t *testing.T) {
+	ctx := context.Background()
+
+	srv := startServer()
+	defer srv.Close()
+
+	time.Sleep(2 * time.Second)
+
+	c, err := opcua.NewClient("opc.tcp://localhost:4840", opcua.SecurityMode(ua.MessageSecurityModeNone))
+	require.NoError(t, err, "NewClient failed")
+
+	err = c.Connect(ctx)
+	require.NoError(t, err, "Connect failed")
+	defer c.Close(ctx)
+
+	// namespace 132 does not exist on the test server.
+	testWrite(t, ctx, c, ua.StatusBadNodeIDUnknown, &ua.WriteRequest{
+		NodesToWrite: []*ua.WriteValue{
+			{
+				NodeID:      ua.NewNumericNodeID(132, 101),
+				AttributeID: ua.AttributeIDValue,
+				Value: &ua.DataValue{
+					EncodingMask: ua.DataValueValue,
+					Value:        ua.MustVariant(int32(42)),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fix crash in `AttributeService.Write` when handling Write requests targeting a non-existing namespace.

See: #841

