### PR TITLE
allow Node to work on a client interface instead of a concrete implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,6 +122,16 @@ func (a bySecurityLevel) Len() int           { return len(a) }
 func (a bySecurityLevel) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a bySecurityLevel) Less(i, j int) bool { return a[i].SecurityLevel < a[j].SecurityLevel }
 
+type ClientInterface interface {
+	Browse(context.Context, *ua.BrowseRequest) (*ua.BrowseResponse, error)
+	BrowseNext(context.Context, *ua.BrowseNextRequest) (*ua.BrowseNextResponse, error)
+
+	NodeFromExpandedNodeID(*ua.ExpandedNodeID) *Node
+
+	Read(context.Context, *ua.ReadRequest) (*ua.ReadResponse, error)
+	Send(context.Context, ua.Request, func(ua.Response) error) error
+}
+
 // Client is a high-level client for an OPC/UA server.
 // It establishes a secure channel and a session.
 type Client struct {

--- a/client.go
+++ b/client.go
@@ -126,10 +126,16 @@ type ClientInterface interface {
 	Browse(context.Context, *ua.BrowseRequest) (*ua.BrowseResponse, error)
 	BrowseNext(context.Context, *ua.BrowseNextRequest) (*ua.BrowseNextResponse, error)
 
+	Node(*ua.NodeID) *Node
 	NodeFromExpandedNodeID(*ua.ExpandedNodeID) *Node
 
 	Read(context.Context, *ua.ReadRequest) (*ua.ReadResponse, error)
 	Send(context.Context, ua.Request, func(ua.Response) error) error
+
+	ForgetSubscription(context.Context, uint32)
+	RegisterSubscription_NeedsSubMuxLock(*Subscription) error
+
+	RequestTimeout() time.Duration
 }
 
 // Client is a high-level client for an OPC/UA server.
@@ -1350,6 +1356,10 @@ func (c *Client) UpdateNamespaces(ctx context.Context) error {
 	}
 	c.setNamespaces(ns)
 	return nil
+}
+
+func (c *Client) RequestTimeout() time.Duration {
+	return c.cfg.sechan.RequestTimeout
 }
 
 // safeAssign implements a type-safe assign from T to *T.

--- a/client.go
+++ b/client.go
@@ -1005,14 +1005,14 @@ func (c *Client) sendWithTimeout(ctx context.Context, req ua.Request, timeout ti
 // Node returns a node object which accesses its attributes
 // through this client connection.
 func (c *Client) Node(id *ua.NodeID) *Node {
-	return &Node{ID: id, c: c}
+	return NewNode(id, c)
 }
 
 // NodeFromExpandedNodeID returns a node object which accesses its attributes
 // through this client connection. This is usually needed when working with node ids returned
 // from browse responses by the server.
 func (c *Client) NodeFromExpandedNodeID(id *ua.ExpandedNodeID) *Node {
-	return &Node{ID: ua.NewNodeIDFromExpandedNodeID(id), c: c}
+	return NewNode(ua.NewNodeIDFromExpandedNodeID(id), c)
 }
 
 // FindServers finds the servers available at an endpoint

--- a/client.go
+++ b/client.go
@@ -133,7 +133,6 @@ type ClientInterface interface {
 	Send(context.Context, ua.Request, func(ua.Response) error) error
 
 	ForgetSubscription(context.Context, uint32)
-	RegisterSubscription_NeedsSubMuxLock(*Subscription) error
 
 	RequestTimeout() time.Duration
 }

--- a/client_sub.go
+++ b/client_sub.go
@@ -211,8 +211,8 @@ func (c *Client) sendRepublishRequests(ctx context.Context, sub *Subscription, a
 	}
 }
 
-// registerSubscription_NeedsSubMuxLock registers a subscription
-func (c *Client) registerSubscription_NeedsSubMuxLock(sub *Subscription) error {
+// RegisterSubscription_NeedsSubMuxLock registers a subscription
+func (c *Client) RegisterSubscription_NeedsSubMuxLock(sub *Subscription) error {
 	if sub.SubscriptionID == 0 {
 		return ua.StatusBadSubscriptionIDInvalid
 	}
@@ -225,7 +225,7 @@ func (c *Client) registerSubscription_NeedsSubMuxLock(sub *Subscription) error {
 	return nil
 }
 
-func (c *Client) forgetSubscription(ctx context.Context, id uint32) {
+func (c *Client) ForgetSubscription(ctx context.Context, id uint32) {
 	c.subMux.Lock()
 	c.forgetSubscription_NeedsSubMuxLock(ctx, id)
 	c.subMux.Unlock()

--- a/client_sub.go
+++ b/client_sub.go
@@ -101,7 +101,15 @@ func (c *Client) recreateSubscription(ctx context.Context, id uint32) error {
 
 	sub.recreate_delete(ctx)
 	c.forgetSubscription_NeedsSubMuxLock(ctx, id)
-	return sub.recreate_create(ctx)
+	if err := sub.recreate_create(ctx); err != nil {
+		return err
+	}
+
+	if err := c.registerSubscription_NeedsSubMuxLock(sub); err != nil {
+		return err
+	}
+
+	return sub.recreate_monitoredItems(ctx)
 }
 
 // transferSubscriptions ask the server to transfer the given subscriptions
@@ -211,8 +219,8 @@ func (c *Client) sendRepublishRequests(ctx context.Context, sub *Subscription, a
 	}
 }
 
-// RegisterSubscription_NeedsSubMuxLock registers a subscription
-func (c *Client) RegisterSubscription_NeedsSubMuxLock(sub *Subscription) error {
+// registerSubscription_NeedsSubMuxLock registers a subscription while subMux is held.
+func (c *Client) registerSubscription_NeedsSubMuxLock(sub *Subscription) error {
 	if sub.SubscriptionID == 0 {
 		return ua.StatusBadSubscriptionIDInvalid
 	}

--- a/node.go
+++ b/node.go
@@ -19,7 +19,7 @@ type Node struct {
 	// ID is the node id of the node.
 	ID *ua.NodeID
 
-	c *Client
+	c ClientInterface
 }
 
 func (n *Node) String() string {

--- a/node.go
+++ b/node.go
@@ -22,6 +22,10 @@ type Node struct {
 	c ClientInterface
 }
 
+func NewNode(id *ua.NodeID, c ClientInterface) *Node {
+	return &Node{ID: id, c: c}
+}
+
 func (n *Node) String() string {
 	return n.ID.String()
 }

--- a/subscription.go
+++ b/subscription.go
@@ -410,6 +410,7 @@ func (s *Subscription) recreate_delete(ctx context.Context) error {
 // recreate_create is called by the client when it is trying to
 // recreate an existing subscription. This function creates a
 // new subscription with the same parameters as the previous one.
+// The client registers the recreated subscription immediately afterwards.
 func (s *Subscription) recreate_create(ctx context.Context) error {
 	dlog := debug.NewPrefixLogger("sub %d: recreate_create: ", s.SubscriptionID)
 
@@ -447,10 +448,13 @@ func (s *Subscription) recreate_create(ctx context.Context) error {
 	s.lastSeq = 0
 	s.nextSeq = 1
 
-	if err := s.c.RegisterSubscription_NeedsSubMuxLock(s); err != nil {
-		return err
-	}
-	dlog.Printf("subscription registered")
+	return nil
+}
+
+// recreate_monitoredItems restores monitored items after the recreated
+// subscription has been registered by the client.
+func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
+	dlog := debug.NewPrefixLogger("sub %d: recreate_monitoredItems: ", s.SubscriptionID)
 
 	// Sort by timestamp to return
 	itemsByTimestamps := make(map[ua.TimestampsToReturn][]*ua.MonitoredItemCreateRequest)


### PR DESCRIPTION
This change improves the testability of Node by allowing the injected client to be a mock/fake/stub/whateveryouneed.

Fixes #846 