### PR TITLE
fix restoreSession closing the session it just re-activated

### DIFF
--- a/client.go
+++ b/client.go
@@ -430,6 +430,10 @@ func (c *Client) monitor(ctx context.Context) {
 							continue
 						}
 
+						// clear the session from the client to prevent
+						// ActivateSession from closing it via CloseSession
+						c.setSession(nil)
+
 						dlog.Printf("trying to restore session")
 						if err := c.ActivateSession(ctx, s); err != nil {
 							dlog.Printf("restore session failed: %v", err)

--- a/client.go
+++ b/client.go
@@ -445,6 +445,10 @@ func (c *Client) monitor(ctx context.Context) {
 							continue
 						}
 
+						// clear the session from the client to prevent
+						// ActivateSession from closing it via CloseSession
+						c.setSession(nil)
+
 						dlog.Printf("trying to restore session")
 						if err := c.ActivateSession(ctx, s); err != nil {
 							dlog.Printf("restore session failed: %v", err)


### PR DESCRIPTION
During reconnect, the restoreSession path calls ActivateSession with the existing session. ActivateSession's internal callback always calls CloseSession before setting the new session. Since the old and new session are the same object, this sends CloseSessionRequest with DeleteSubscriptions: true, destroying all subscriptions on the server.

Clear the session reference before calling ActivateSession, matching the fix applied to recreateSession in #700. The session object is still held by the local variable and gets re-set inside the callback.

Fixes #854