### PR TITLE
fix(monitor): return partial results from AddMonitorItems on per-node failures

### DIFF
--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -17,6 +18,45 @@ var (
 	// ErrSlowConsumer is returned when a subscriber does not keep up with the incoming messages
 	ErrSlowConsumer = errors.New("slow consumer. messages may be dropped")
 )
+
+// ItemError represents a single monitored item that failed to be created.
+// AddMonitorItems returns an errors.Join of *ItemError when one or more items
+// could not be created on the server. Callers can inspect failures with the
+// standard errors helpers:
+//
+//	items, err := sub.AddMonitorItems(ctx, requests...)
+//	if err != nil {
+//	    // items contains the successfully created monitors (nil if all failed)
+//
+//	    // Check for a specific status code across all failures:
+//	    if errors.Is(err, ua.StatusBadNodeIDUnknown) { ... }
+//
+//	    // Inspect the first failing item:
+//	    var ie *monitor.ItemError
+//	    if errors.As(err, &ie) { _ = ie.NodeID; _ = ie.Status }
+//
+//	    // Iterate over all failures:
+//	    if u, ok := err.(interface{ Unwrap() []error }); ok {
+//	        for _, e := range u.Unwrap() {
+//	            var ie *monitor.ItemError
+//	            if errors.As(e, &ie) { /* ie.NodeID, ie.Status */ }
+//	        }
+//	    }
+//	}
+type ItemError struct {
+	NodeID *ua.NodeID
+	Status ua.StatusCode
+}
+
+func (e *ItemError) Error() string {
+	return fmt.Sprintf("%s: %s", e.NodeID, e.Status)
+}
+
+// Unwrap exposes the underlying status code so that errors.Is can match on
+// values such as ua.StatusBadNodeIDUnknown.
+func (e *ItemError) Unwrap() error {
+	return e.Status
+}
 
 // ErrHandler is a function that is called when there is an out of band issue with delivery
 type ErrHandler func(*opcua.Client, *Subscription, error)
@@ -323,9 +363,16 @@ func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([
 		return nil, errors.Errorf("monitor items response length mismatch")
 	}
 	var monitoredItems []Item
+	var failedItems []error
 	for i, res := range resp.Results {
 		if res.StatusCode != ua.StatusOK {
-			return nil, res.StatusCode
+			failedItems = append(failedItems, &ItemError{
+				NodeID: toAdd[i].ItemToMonitor.NodeID,
+				Status: res.StatusCode,
+			})
+			// Clean up the handle for the failed item
+			delete(s.handles, nodes[i].handle)
+			continue
 		}
 		mn := Item{
 			id:     res.MonitoredItemID,
@@ -334,6 +381,13 @@ func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([
 		}
 		s.itemLookup[res.MonitoredItemID] = mn
 		monitoredItems = append(monitoredItems, mn)
+	}
+
+	if len(failedItems) > 0 {
+		// monitoredItems is nil when every item failed and non-nil when some
+		// items succeeded; either way the joined *ItemError values let
+		// callers use errors.Is / errors.As to inspect per-node failures.
+		return monitoredItems, errors.Join(failedItems...)
 	}
 
 	return monitoredItems, nil


### PR DESCRIPTION
## Problem

`AddMonitorItems` returns an error on the first node with a non-OK status code, discarding all successfully created monitored items in the same batch. This means a single stale or invalid node ID (e.g. `StatusBadNodeIDUnknown`) blocks monitoring of all other valid nodes in the chunk.

This is particularly problematic in production environments where:
- Devices are reconfigured and some node IDs become stale
- Large batches of nodes are monitored in chunks
- The all-or-nothing behavior causes cascading failures across the entire subscription

## Fix

`AddMonitorItems` now:
1. Registers all successful items in `itemLookup` and `handles`
2. Cleans up handles for failed items
3. Returns successfully created items alongside `errors.Join` that lists per-node failures

## New types

```go
// ItemError represents a single monitored item that failed to be created.
type ItemError struct {
    NodeID *ua.NodeID
    Status ua.StatusCode
}
```

## Usage

```go
	items, err := sub.AddMonitorItems(ctx, requests...)
	if err != nil {
	    // items contains the successfully created monitors (nil if all failed)

	    // Check for a specific status code across all failures:
	    if errors.Is(err, ua.StatusBadNodeIDUnknown) { ... }

	    // Inspect the first failing item:
	    var ie *monitor.ItemError
	    if errors.As(err, &ie) { _ = ie.NodeID; _ = ie.Status }

	    // Iterate over all failures:
	    if u, ok := err.(interface{ Unwrap() []error }); ok {
	        for _, e := range u.Unwrap() {
	            var ie *monitor.ItemError
	            if errors.As(e, &ie) { /* ie.NodeID, ie.Status */ }
	        }
	    }
	}
```

## Backward compatibility

This is backward compatible:
- Callers that only check `err != nil` still see the error on partial failure
- Callers that inspect the returned `[]Item` will now get the successfully created ones
- Total failures (service-level errors, transport errors) still return `nil, err` as before