### PR TITLE
feat: adding pre-resolver to allow the caller to translate hosts to IPs via non-DNS

### DIFF
--- a/config.go
+++ b/config.go
@@ -539,6 +539,15 @@ func DialTimeout(d time.Duration) Option {
 	}
 }
 
+// PreResolver gives the caller a chance to resolve endpoint URLs to IPs
+// before the dialer attempts a DNS lookup.
+func PreResolver(pr uacp.PreResolver) Option {
+	return func(cfg *Config) error {
+		cfg.dialer.PreResolver = pr
+		return nil
+	}
+}
+
 // MaxMessageSize sets the maximum message size for the UACP handshake.
 func MaxMessageSize(n uint32) Option {
 	return func(cfg *Config) error {

--- a/uacp/conn.go
+++ b/uacp/conn.go
@@ -56,6 +56,13 @@ func nextid() uint32 {
 	return atomic.AddUint32(&connid, 1)
 }
 
+// PreResolver gives the caller a chance to resolve endpoint URLs to IPs before the dialer attempts a DNS lookup.
+// `nil, nil` means no resolution was done.
+// `*, err` means resolution failed.
+type PreResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
 // Dialer establishes a connection to an endpoint.
 type Dialer struct {
 	// Dialer establishes the TCP connection. Defaults to net.Dialer.
@@ -64,12 +71,16 @@ type Dialer struct {
 	// ClientACK defines the connection parameters requested by the client.
 	// Defaults to DefaultClientACK.
 	ClientACK *Acknowledge
+
+	// PreResolver allows the caller to resolve endpoint URLs to IPs
+	// before the dialer attempts a DNS lookup.
+	PreResolver PreResolver
 }
 
 func (d *Dialer) Dial(ctx context.Context, endpoint string) (*Conn, error) {
 	debug.Printf("uacp: connecting to %s", endpoint)
 
-	_, raddr, err := ResolveEndpoint(ctx, endpoint)
+	_, raddr, err := ResolveEndpoint(ctx, endpoint, d.PreResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +135,7 @@ func Listen(ctx context.Context, endpoint string, ack *Acknowledge) (*Listener, 
 	if ack == nil {
 		ack = DefaultServerACK
 	}
-	_, laddr, err := ResolveEndpoint(ctx, endpoint)
+	_, laddr, err := ResolveEndpoint(ctx, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/uacp/endpoint.go
+++ b/uacp/endpoint.go
@@ -6,6 +6,7 @@ package uacp
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
 
@@ -17,7 +18,7 @@ const defaultPort = "4840"
 // ResolveEndpoint returns network type, address, and error split from EndpointURL.
 //
 // Expected format of input is "opc.tcp://<addr[:port]/path/to/somewhere"
-func ResolveEndpoint(ctx context.Context, endpoint string) (network string, u *url.URL, err error) {
+func ResolveEndpoint(ctx context.Context, endpoint string, preResolver PreResolver) (network string, u *url.URL, err error) {
 	u, err = url.Parse(endpoint)
 	if err != nil {
 		return
@@ -35,11 +36,24 @@ func ResolveEndpoint(ctx context.Context, endpoint string) (network string, u *u
 		port = defaultPort
 	}
 
-	var resolver net.Resolver
+	// Attempt the pre-resolver first
+	var addrs []net.IPAddr
+	if preResolver != nil {
+		addrs, err = preResolver.LookupIPAddr(ctx, u.Hostname())
+		if err != nil {
+			err = fmt.Errorf("pre-resolver failed: %w", err)
+			return
+		}
+	}
 
-	addrs, err := resolver.LookupIPAddr(ctx, u.Hostname())
-	if err != nil {
-		return
+	// If no address was presolved, fall back to the default resolver
+	if len(addrs) == 0 {
+		var resolver net.Resolver
+
+		addrs, err = resolver.LookupIPAddr(ctx, u.Hostname())
+		if err != nil {
+			return
+		}
 	}
 
 	if len(addrs) == 0 {

--- a/uacp/endpoint_test.go
+++ b/uacp/endpoint_test.go
@@ -6,18 +6,22 @@ package uacp
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
-	_ "github.com/stretchr/testify/require"
+	"fmt"
+	"net"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "github.com/stretchr/testify/require"
 )
 
 func TestResolveEndpoint(t *testing.T) {
 	cases := []struct {
-		input   string
-		network string
-		u       *url.URL
-		errStr  string
+		input       string
+		network     string
+		u           *url.URL
+		errStr      string
+		preResolver PreResolver
 	}{
 		{ // Valid, full EndpointURL
 			"opc.tcp://10.0.0.1:4840/foo/bar",
@@ -28,6 +32,7 @@ func TestResolveEndpoint(t *testing.T) {
 				Path:   "/foo/bar",
 			},
 			"",
+			nil,
 		},
 		{ // Valid, port number omitted
 			"opc.tcp://10.0.0.1/foo/bar",
@@ -38,6 +43,7 @@ func TestResolveEndpoint(t *testing.T) {
 				Path:   "/foo/bar",
 			},
 			"",
+			nil,
 		},
 		{ // Valid, hostname resolved
 			// note: see https://github.com/cunnie/sslip.io
@@ -49,23 +55,44 @@ func TestResolveEndpoint(t *testing.T) {
 				Path:   "/foo/bar",
 			},
 			"",
+			nil,
+		},
+		{ // Valid, hostname resolved by pre-resolver
+			"opc.tcp://preresolver-known:4840/foo/bar",
+			"tcp",
+			&url.URL{
+				Scheme: "opc.tcp",
+				Host:   "1.2.3.4:4840",
+				Path:   "/foo/bar",
+			},
+			"",
+			&mockPreResolver{},
 		},
 		{ // Invalid, schema is not "opc.tcp://"
 			"tcp://10.0.0.1:4840/foo/bar",
 			"",
 			nil,
 			"opcua: unsupported scheme tcp",
+			nil,
 		},
 		{ // Invalid, bad formatted schema
 			"opc.tcp:/10.0.0.1:4840/foo1337bar/baz",
 			"",
 			nil,
 			"lookup : no such host",
+			nil,
+		},
+		{ // Invalid, pre-resolver fails
+			"opc.tcp://preresolver-fail:4840/foo/bar",
+			"",
+			nil,
+			"pre-resolver failed: pre-resolver error",
+			&mockPreResolver{},
 		},
 	}
 
 	for _, c := range cases {
-		network, u, err := ResolveEndpoint(context.Background(), c.input)
+		network, u, err := ResolveEndpoint(context.Background(), c.input, c.preResolver)
 		if c.errStr != "" {
 			require.EqualError(t, err, c.errStr)
 		} else {
@@ -73,4 +100,18 @@ func TestResolveEndpoint(t *testing.T) {
 			require.Equal(t, c.u, u)
 		}
 	}
+}
+
+type mockPreResolver struct{}
+
+func (m *mockPreResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	switch host {
+	case "preresolver-known":
+		return []net.IPAddr{{IP: net.ParseIP("1.2.3.4")}}, nil
+	case "preresolver-fail":
+		return nil, fmt.Errorf("pre-resolver error")
+	}
+
+	// Not a name we know about
+	return nil, nil
 }


### PR DESCRIPTION
We come across many OPC-UA servers that are only accessible via IP, but the endpoint discovery returns endpoints with hostnames (think "myserver"), despite the local DNS servers not being able to resolve "myserver".

This change adds a pre-resolver hook to allow the caller to do non-DNS resolution of server returned hostnames.