### PR TITLE
fix(server): return bad status instead of panicking on Write to unknown namespace

### DIFF
--- a/server/attribute_service.go
+++ b/server/attribute_service.go
@@ -82,8 +82,9 @@ func (s *AttributeService) Write(sc *uasc.SecureChannel, r ua.Request, reqID uin
 		}
 
 		ns, err := s.srv.Namespace(int(n.NodeID.Namespace()))
-		if err != nil {
+		if err != nil || ns == nil {
 			status[i] = ua.StatusBadNodeNotInView
+			continue
 		}
 
 		status[i] = ns.SetAttribute(n.NodeID, n.AttributeID, n.Value)


### PR DESCRIPTION
## Problem

  `server/AttributeService.Write` panics with SIGSEGV when a client sends
  a `WriteRequest` whose `NodeID` references a namespace index that does
  not exist on the server. The panic occurs in the listener goroutine and
  drops all in-flight sessions.

  Stack trace observed against v0.8.0:

  \`\`\`
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x58]
  github.com/gopcua/opcua/server.(*AttributeService).Write(...)
          server/attribute_service.go:89
  github.com/gopcua/opcua/server.(*Server).handleService(...)
          server/service_handlers.go:114
  github.com/gopcua/opcua/server.(*Server).monitorConnections(...)
          server/server.go:368
  \`\`\`

  ## Root cause

  `server/attribute_service.go`, current `main`:

  ```go
  ns, err := s.srv.Namespace(int(n.NodeID.Namespace()))
  if err != nil {
      status[i] = ua.StatusBadNodeNotInView
  }
  // missing continue — falls through with ns == nil
  status[i] = ns.SetAttribute(n.NodeID, n.AttributeID, n.Value)
  ```

  Per OPC-UA Part 4 §5.10.4, writes to unknown nodes must return a
  per-node status code in the response `Results` array, not a transport
  error.

  ## Fix

  Adds the missing `continue`, also guards against a typed-nil interface
  in case a future `Namespace()` impl returns `(nil-ptr-iface, nil)`
  
  ```go
  ns, err := s.srv.Namespace(int(n.NodeID.Namespace()))
  if err != nil || ns == nil {
      status[i] = ua.StatusBadNodeNotInView
      continue
  }   
  status[i] = ns.SetAttribute(n.NodeID, n.AttributeID, n.Value)
  ```