### PR TITLE
uasc: chunk large server responses across all message writes

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -813,6 +813,7 @@ func (s *SecureChannel) handleOpenSecureChannelRequest(reqID uint32, svc ua.Requ
 	if err != nil {
 		return err
 	}
+	instance.SetMaximumBodySize(int(s.c.SendBufSize()))
 
 	instance.state = channelActive // todo(fs): is this correct?
 	// s.setState(secureChannelOpen)

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -11,7 +11,6 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"io"
-	"log"
 	"math"
 	"net"
 	"strings"
@@ -1056,6 +1055,58 @@ func (s *SecureChannel) sendAsyncWithTimeout(
 	return resp, nil
 }
 
+func (s *SecureChannel) writeMessageChunks(ctx context.Context, instance *channelInstance, reqID uint32, m *Message, body any) (int, error) {
+	// Large service payloads may exceed a single UASC message body. Encode the
+	// full logical message up front, then stream each chunk in sequence while the
+	// caller holds the channel-instance lock.
+	chunks, err := m.EncodeChunks(instance.maxBodySize)
+	if err != nil {
+		return 0, err
+	}
+
+	var bytesSent int
+	for i, chunk := range chunks {
+		select {
+		case <-ctx.Done():
+			return bytesSent, ctx.Err()
+		default:
+		}
+
+		if i > 0 {
+			// newMessage/newRequestMessage assigned the first sequence number when
+			// the message header was created. Each additional chunk must advance it
+			// before signing so the on-wire sequence remains monotonic.
+			number := instance.nextSequenceNumber()
+			binary.LittleEndian.PutUint32(chunk[16:], uint32(number))
+		}
+
+		// Sign and encrypt after the final chunk bytes are in place, since the
+		// security footer covers the whole encoded chunk.
+		chunk, err = instance.signAndEncrypt(m, chunk)
+		if err != nil {
+			return bytesSent, err
+		}
+
+		// UASC writes are expected to flush complete chunks. Treat short writes as
+		// a hard error instead of silently truncating the response stream.
+		n, err := s.c.Write(chunk)
+		if err != nil {
+			return bytesSent, err
+		}
+		if len(chunk) != n {
+			return bytesSent, errors.Errorf("uasc: incomplete message %T sent len=%d sent=%d", body, len(chunk), n)
+		}
+
+		bytesSent += n
+		atomic.AddUint64(&instance.bytesSent, uint64(n))
+		atomic.AddUint32(&instance.messagesSent, 1)
+	}
+
+	debug.Printf("uasc %d/%d: send %T with %d bytes in %d chunks", s.c.ID(), reqID, body, bytesSent, len(chunks))
+
+	return bytesSent, nil
+}
+
 func (s *SecureChannel) SendResponseWithContext(ctx context.Context, reqID uint32, resp ua.Response) error {
 	return s.sendResponseWithContext(ctx, nil, reqID, resp)
 }
@@ -1075,35 +1126,13 @@ func (s *SecureChannel) SendMsgWithContext(ctx context.Context, instance *channe
 	}
 
 	// we need to get a lock on the sequence number so we are sure to send them in the correct order.
-	// encode the message
+	instance.Lock()
+	defer instance.Unlock()
+
 	m := instance.newMessage(resp, typeID, reqID)
-	b, err := m.Encode()
-	if err != nil {
+	if _, err := s.writeMessageChunks(ctx, instance, reqID, m, resp); err != nil {
 		return err
 	}
-
-	// encrypt the message prior to sending it
-	// if SecurityMode == None, this returns the byte stream untouched
-	b, err = instance.signAndEncrypt(m, b)
-	if err != nil {
-		return err
-	}
-
-	// send the message
-	n, err := s.c.Write(b)
-	if err != nil {
-		return err
-	}
-
-	// todo(fs): what if len(b) != n? Can this happen?
-	if len(b) != n {
-		return errors.Errorf("uasc: incomplete message %T sent len=%d sent=%d", resp, len(b), n)
-	}
-
-	atomic.AddUint64(&instance.bytesSent, uint64(n))
-	atomic.AddUint32(&instance.messagesSent, 1)
-
-	debug.Printf("uasc %d/%d: send %T with %d bytes", s.c.ID(), reqID, resp, len(b))
 
 	return nil
 }
@@ -1124,36 +1153,10 @@ func (s *SecureChannel) sendResponseWithContext(ctx context.Context, instance *c
 	instance.Lock()
 	defer instance.Unlock()
 
-	// encode the message
 	m := instance.newMessage(resp, typeID, reqID)
-	b, err := m.Encode()
-	if err != nil {
-		log.Printf("Error encoding msg: %v", err)
+	if _, err := s.writeMessageChunks(ctx, instance, reqID, m, resp); err != nil {
 		return err
 	}
-
-	// encrypt the message prior to sending it
-	// if SecurityMode == None, this returns the byte stream untouched
-	b, err = instance.signAndEncrypt(m, b)
-	if err != nil {
-		return err
-	}
-
-	// send the message
-	n, err := s.c.Write(b)
-	if err != nil {
-		return err
-	}
-
-	// todo(fs): what if len(b) != n? Can this happen?
-	if len(b) != n {
-		return errors.Errorf("uasc: incomplete message %T sent len=%d sent=%d", resp, len(b), n)
-	}
-
-	atomic.AddUint64(&instance.bytesSent, uint64(n))
-	atomic.AddUint32(&instance.messagesSent, 1)
-
-	debug.Printf("uasc %d/%d: send %T with %d bytes", s.c.ID(), reqID, resp, len(b))
 
 	return nil
 }

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -1060,6 +1060,12 @@ func (s *SecureChannel) writeMessageChunks(ctx context.Context, instance *channe
 	// Large service payloads may exceed a single UASC message body. Encode the
 	// full logical message up front, then stream each chunk in sequence while the
 	// caller holds the channel-instance lock.
+	//
+	// TODO: enforce the negotiated MaxMessageSize / MaxChunkCount here and abort
+	// with Bad_ResponseTooLarge instead of writing an over-limit chunk stream.
+	// These limits are already enforced on the receive path (see the chunk-count
+	// and message-size checks in Receive) but not on send (OPC UA Part 6 §6.7.2;
+	// cf. open62541 adjustCheckMessageLimitsSym, .NET MessageLimitsExceeded).
 	chunks, err := m.EncodeChunks(instance.maxBodySize)
 	if err != nil {
 		return 0, err
@@ -1074,9 +1080,10 @@ func (s *SecureChannel) writeMessageChunks(ctx context.Context, instance *channe
 		}
 
 		if i > 0 {
-			// newMessage/newRequestMessage assigned the first sequence number when
-			// the message header was created. Each additional chunk must advance it
-			// before signing so the on-wire sequence remains monotonic.
+			// newMessage assigned the first sequence number when the message header
+			// was created, and EncodeChunks copies it into every chunk. Each chunk
+			// after the first must advance it before signing so the on-wire sequence
+			// remains monotonic.
 			number := instance.nextSequenceNumber()
 			binary.LittleEndian.PutUint32(chunk[16:], uint32(number))
 		}

--- a/uasc/secure_channel_chunk_encrypted_test.go
+++ b/uasc/secure_channel_chunk_encrypted_test.go
@@ -1,0 +1,125 @@
+package uasc
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uacp"
+	"github.com/gopcua/opcua/uapolicy"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: extend chunked-send test coverage:
+//   - round-trip: feed the multi-chunk stream back through Receive/mergeChunks/
+//     verifyAndDecrypt and assert the decoded payload is byte-identical (the
+//     tests below assert framing and size, not payload integrity);
+//   - Sign-only mode (MessageSecurityModeSign): only None (see
+//     TestSendResponseWithContextWritesAllChunks) and SignAndEncrypt are covered;
+//   - boundary body sizes: exactly maxBodySize, maxBodySize+1, and an exact
+//     multiple of maxBodySize (which yields an empty final chunk);
+//   - concurrent SendResponseWithContext calls must not interleave chunks (the
+//     per-instance lock added alongside writeMessageChunks).
+
+// TestServerChunkedResponseEncryptedFitsChunk_Part6_672 drives the real server
+// send path (SendResponseWithContext -> sendResponseWithContext ->
+// writeMessageChunks) under an encrypting security policy and reads the framing
+// off a TCP socket. PR #861's own regression test runs SecurityMode None, so it
+// never exercises the per-chunk sign/encrypt path where the #781/#824 padding
+// math lives; this covers it for every symmetric policy.
+//
+// OPC UA Part 6 v1.05 §6.7.2: a Message larger than one MessageChunk is split
+// into multiple chunks; each chunk including its security footer must not exceed
+// the negotiated chunk size (SendBufferSize), intermediate chunks are 'C' and the
+// last is 'F'. (The per-chunk SequenceNumber is monotonic but is inside the
+// encrypted region here, so TestSendResponseWithContextWritesAllChunks asserts
+// that in None mode; this test asserts the size/framing invariant under crypto.)
+func TestServerChunkedResponseEncryptedFitsChunk_Part6_672(t *testing.T) {
+	const bufSize = 64 * 1024
+	nonce := bytes.Repeat([]byte{0x5a}, 32)
+
+	for _, uri := range symmetricPolicyURIs {
+		t.Run(uri, func(t *testing.T) {
+			serverTCP, clientTCP := newTestTCPConnPair(t)
+			defer serverTCP.Close()
+			defer clientTCP.Close()
+
+			uacpConn, err := uacp.NewConn(serverTCP, &uacp.Acknowledge{
+				ReceiveBufSize: bufSize,
+				SendBufSize:    bufSize,
+				MaxMessageSize: 8 * 1024 * 1024,
+				MaxChunkCount:  1024,
+			})
+			require.NoError(t, err)
+
+			algo, err := uapolicy.Symmetric(uri, nonce, nonce)
+			require.NoError(t, err)
+
+			s := &SecureChannel{
+				c: uacpConn,
+				cfg: &Config{
+					SecurityPolicyURI: uri,
+					SecurityMode:      ua.MessageSecurityModeSignAndEncrypt,
+					RequestTimeout:    time.Second,
+				},
+				instances: make(map[uint32][]*channelInstance),
+			}
+			instance := newChannelInstance(s)
+			instance.algo = algo
+			instance.state = channelActive
+			instance.secureChannelID = 1
+			instance.securityTokenID = 1
+			instance.SetMaximumBodySize(int(s.c.SendBufSize()))
+			s.activeInstance = instance
+
+			readDone := make(chan readChunksResult, 1)
+			go func() { readDone <- readChunksUntilFinal(clientTCP) }()
+
+			// A response a few times larger than one body forces several chunks.
+			valueBytes := make([]byte, int(instance.maxBodySize)*3)
+			for i := range valueBytes {
+				valueBytes[i] = byte(i)
+			}
+			v, err := ua.NewVariant(valueBytes)
+			require.NoError(t, err)
+			dv := &ua.DataValue{Value: v}
+			dv.UpdateMask()
+			resp := &ua.ReadResponse{
+				ResponseHeader: &ua.ResponseHeader{
+					Timestamp:          time.Now(),
+					RequestHandle:      1,
+					ServiceDiagnostics: &ua.DiagnosticInfo{},
+					StringTable:        []string{},
+					AdditionalHeader:   ua.NewExtensionObject(nil),
+				},
+				Results: []*ua.DataValue{dv},
+			}
+
+			require.NoError(t, s.SendResponseWithContext(context.Background(), 1, resp))
+
+			select {
+			case result := <-readDone:
+				require.NoError(t, result.err)
+				chunks := result.chunks
+				require.Greater(t, len(chunks), 1, "response should span multiple chunks")
+				for i, chunk := range chunks {
+					require.Equal(t, MessageTypeMessage, string(chunk[:3]))
+					wantType := byte(ChunkTypeIntermediate)
+					if i == len(chunks)-1 {
+						wantType = ChunkTypeFinal
+					}
+					require.Equal(t, wantType, chunk[3], "chunk type")
+					// The core #824-interaction invariant on the server multi-chunk
+					// path: every encrypted chunk fits the negotiated chunk size.
+					require.LessOrEqual(t, len(chunk), bufSize, "encrypted chunk exceeds negotiated chunk size")
+					require.EqualValues(t, len(chunk), binary.LittleEndian.Uint32(chunk[4:8]), "MessageSize header must equal chunk length")
+				}
+			case <-time.After(chunkedResponseTestTimeout):
+				t.Fatal("timed out waiting for response chunks")
+			}
+		})
+	}
+}

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -1,11 +1,16 @@
 package uasc
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/binary"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"math"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -331,4 +336,190 @@ func TestNewSecureChannel(t *testing.T) {
 		_, err := NewSecureChannel("", &uacp.Conn{}, cfg, make(chan error))
 		require.ErrorContains(t, err, "invalid channel config: Security policy 'http://opcfoundation.org/UA/SecurityPolicy#Basic256' requires a private key")
 	})
+}
+
+const chunkedResponseTestTimeout = 2 * time.Second
+
+func TestSendResponseWithContextWritesAllChunks(t *testing.T) {
+	// Use a real TCP pair here so we exercise the exact chunk framing that a
+	// peer would see on the wire, not just the internal message encoder.
+	serverTCP, clientTCP := newTestTCPConnPair(t)
+	defer serverTCP.Close()
+	defer clientTCP.Close()
+
+	uacpConn, err := uacp.NewConn(serverTCP, &uacp.Acknowledge{
+		ReceiveBufSize: 64 * 1024,
+		SendBufSize:    64 * 1024,
+		MaxMessageSize: 2 * 1024 * 1024,
+		MaxChunkCount:  512,
+	})
+	require.NoError(t, err)
+
+	s := &SecureChannel{
+		c: uacpConn,
+		cfg: &Config{
+			SecurityPolicyURI: ua.SecurityPolicyURINone,
+			SecurityMode:      ua.MessageSecurityModeNone,
+			RequestTimeout:    time.Second,
+		},
+		instances: make(map[uint32][]*channelInstance),
+	}
+
+	instance := newChannelInstance(s)
+	instance.state = channelActive
+	instance.secureChannelID = 1
+	instance.securityTokenID = 1
+	instance.maxBodySize = 256
+	s.activeInstance = instance
+
+	readDone := make(chan readChunksResult, 1)
+	go func() {
+		// Collect raw chunks until the final one arrives so the assertions below
+		// can validate framing and sequence progression end-to-end.
+		readDone <- readChunksUntilFinal(clientTCP)
+	}()
+
+	valueBytes := make([]byte, 4096)
+	for i := range valueBytes {
+		valueBytes[i] = byte(i)
+	}
+
+	v, err := ua.NewVariant(valueBytes)
+	require.NoError(t, err)
+
+	dv := &ua.DataValue{Value: v}
+	dv.UpdateMask()
+
+	resp := &ua.ReadResponse{
+		ResponseHeader: &ua.ResponseHeader{
+			Timestamp:          time.Now(),
+			RequestHandle:      42,
+			ServiceDiagnostics: &ua.DiagnosticInfo{},
+			StringTable:        []string{},
+			AdditionalHeader:   ua.NewExtensionObject(nil),
+		},
+		Results: []*ua.DataValue{dv},
+	}
+
+	require.NoError(t, s.SendResponseWithContext(context.Background(), 42, resp))
+
+	select {
+	case result := <-readDone:
+		require.NoError(t, result.err)
+		assertChunkedResponse(t, result.chunks)
+	case <-time.After(chunkedResponseTestTimeout):
+		t.Fatal("timed out waiting for response chunks")
+	}
+}
+
+type readChunksResult struct {
+	chunks [][]byte
+	err    error
+}
+
+func readChunksUntilFinal(conn *net.TCPConn) readChunksResult {
+	if err := conn.SetReadDeadline(time.Now().Add(chunkedResponseTestTimeout)); err != nil {
+		return readChunksResult{err: err}
+	}
+
+	var chunks [][]byte
+	for {
+		// Read the fixed UACP/UASC header first so we know how large the current
+		// chunk is before reading the remainder of its payload.
+		hdr := make([]byte, 8)
+		if _, err := io.ReadFull(conn, hdr); err != nil {
+			return readChunksResult{err: err}
+		}
+
+		messageSize := binary.LittleEndian.Uint32(hdr[4:8])
+		if messageSize < 12 {
+			return readChunksResult{err: io.ErrUnexpectedEOF}
+		}
+
+		chunk := make([]byte, int(messageSize))
+		copy(chunk, hdr)
+		if _, err := io.ReadFull(conn, chunk[8:]); err != nil {
+			return readChunksResult{err: err}
+		}
+
+		chunks = append(chunks, chunk)
+		if chunk[3] == ChunkTypeFinal {
+			return readChunksResult{chunks: chunks}
+		}
+	}
+}
+
+func assertChunkedResponse(t *testing.T, chunks [][]byte) {
+	t.Helper()
+
+	require.GreaterOrEqual(t, len(chunks), 2)
+
+	var previousSequence uint32
+	for i, chunk := range chunks {
+		require.Equal(t, MessageTypeMessage, string(chunk[:3]))
+
+		// Every chunk but the last should be marked intermediate so the test
+		// proves the response was actually split, not just sent once.
+		wantChunkType := byte(ChunkTypeIntermediate)
+		if i == len(chunks)-1 {
+			wantChunkType = ChunkTypeFinal
+		}
+		require.Equal(t, wantChunkType, chunk[3])
+
+		messageSize := binary.LittleEndian.Uint32(chunk[4:8])
+		require.Equal(t, len(chunk), int(messageSize))
+
+		secureChannelID := binary.LittleEndian.Uint32(chunk[8:12])
+		require.EqualValues(t, 1, secureChannelID)
+
+		// Additional chunks must advance the sequence number; reusing the same
+		// value would make the stream invalid for receivers.
+		sequenceNumber := binary.LittleEndian.Uint32(chunk[16:20])
+		if i > 0 {
+			require.Greater(t, sequenceNumber, previousSequence)
+		}
+		previousSequence = sequenceNumber
+	}
+}
+
+func newTestTCPConnPair(t *testing.T) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+
+	// Keep the transport setup tiny and local so this regression test stays
+	// close to the real wire behavior without dragging in a full listener stack.
+	ln, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		if strings.Contains(err.Error(), "operation not permitted") {
+			t.Skipf("tcp listen not permitted in this environment: %v", err)
+		}
+		t.Fatalf("ListenTCP() failed: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan *net.TCPConn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := ln.AcceptTCP()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+
+	client, err := net.DialTCP("tcp", nil, ln.Addr().(*net.TCPAddr))
+	require.NoError(t, err)
+
+	select {
+	case server := <-accepted:
+		return server, client
+	case err := <-acceptErr:
+		client.Close()
+		t.Fatalf("AcceptTCP() failed: %v", err)
+	case <-time.After(chunkedResponseTestTimeout):
+		client.Close()
+		t.Fatal("timed out waiting for accepted TCP connection")
+	}
+
+	return nil, nil
 }


### PR DESCRIPTION
SendMsgWithContext and sendResponseWithContext were still encoding and writing server messages as a single buffer, which broke larger responses even though request sending already supported chunked writes.

Factor the chunked write path into a shared helper, use it for both server response send paths, and keep per-chunk sequence numbers/signing consistent with the existing async request flow.

Add a regression test that verifies a large ReadResponse is written as multiple UASC chunks with increasing sequence numbers and a final chunk marker.

Fixes #860 