### PR TITLE
fix(uasc): derive ReceiverCertificateThumbprint on the server OPN path

### DIFF
--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -479,6 +479,13 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 		s.cfg.SecurityPolicyURI = m.SecurityPolicyURI
 		if m.SecurityPolicyURI != ua.SecurityPolicyURINone {
 			s.cfg.RemoteCertificate = m.AsymmetricSecurityHeader.SenderCertificate
+			// Re-derive the receiver thumbprint from the peer certificate
+			// learned in the inbound OPN. No-op for the client path, where
+			// Thumbprint is already set from the endpoint's ServerCertificate
+			// at session open.
+			if len(s.cfg.RemoteCertificate) > 0 {
+				s.cfg.Thumbprint = uapolicy.Thumbprint(s.cfg.RemoteCertificate)
+			}
 			debug.Printf("uasc %d: setting securityPolicy to %s", s.c.ID(), m.SecurityPolicyURI)
 
 			remoteCert, err := x509.ParseCertificate(s.cfg.RemoteCertificate)


### PR DESCRIPTION
When a SecureChannel opens, readChunk() captures the peer's certificate
from the inbound OpenSecureChannel into cfg.RemoteCertificate but never
derives cfg.Thumbprint. Server-driven OPN responses therefore go out with
an empty ReceiverCertificateThumbprint, and strict clients (e.g. Prosys,
UaExpert) reject every Basic256Sha256 Sign / SignAndEncrypt channel with a
"certificate thumbprint mismatch".

Derive Thumbprint = SHA1(RemoteCertificate) on the shared readChunk path,
mirroring the client-side derivation in config.go (SecurityFromEndpoint).
This is gated by the existing SecurityPolicyURI != None guard plus a
defensive length check, so the None policy keeps emitting an empty
thumbprint as required. The client direction is unaffected: cfg.Thumbprint
is already initialised at session-open time from the endpoint's
ServerCertificate, so re-deriving here is a no-op there.

Per OPC UA Part 6 §6.7.2, the next outgoing asymmetric chunk must carry
ReceiverCertificateThumbprint = SHA1(receiverCertificate). This complements
the server-side Basic256Sha256 fix in #817, which forces SignAndEncrypt on
the OPN path but does not populate the thumbprint.