### PR TITLE
fix(client): inherit channel SecurityPolicyURI when UserTokenPolicy URI is empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -348,7 +348,12 @@ func setCertificate(cert []byte, cfg *Config) error {
 }
 
 // SecurityFromEndpoint sets the server-related security parameters from
-// a chosen endpoint (received from GetEndpoints())
+// a chosen endpoint (received from GetEndpoints()).
+//
+// A UserTokenPolicy with an empty SecurityPolicyURI inherits the
+// SecureChannel's SecurityPolicy (OPC UA Part 4 §7.36), so this falls back to
+// ep.SecurityPolicyURI when the matching token advertises none.
+// EncryptUserPassword and NewUserTokenSignature apply the same fallback.
 func SecurityFromEndpoint(ep *ua.EndpointDescription, authType ua.UserTokenType) Option {
 	return func(cfg *Config) error {
 		cfg.sechan.SecurityPolicyURI = ep.SecurityPolicyURI
@@ -375,7 +380,8 @@ func SecurityFromEndpoint(ep *ua.EndpointDescription, authType ua.UserTokenType)
 			}
 
 			setPolicyID(cfg.session.UserIdentityToken, t.PolicyID)
-			if t.SecurityPolicyURI != "" {
+			// Empty or whitespace-only per-token URI resolves to the channel's.
+			if strings.TrimSpace(t.SecurityPolicyURI) != "" {
 				cfg.session.AuthPolicyURI = t.SecurityPolicyURI
 			} else {
 				cfg.session.AuthPolicyURI = ep.SecurityPolicyURI

--- a/config_test.go
+++ b/config_test.go
@@ -120,6 +120,21 @@ YqvGJP7ubbsR1YoQxQ8CQQCyCrltDYji5+KdxMOsDt0v7bCQWkQ3+pik09faK51Y
 				},
 			},
 		},
+		// username auth on a secured channel whose UserTokenPolicy
+		// advertises an empty SecurityPolicyURI (inherited from the
+		// channel), as some servers (e.g. node-opcua) do.
+		{
+			SecurityPolicyURI: "Basic256Sha256-uri", // stand-in channel URI
+			SecurityMode:      5,                    // random value for testing
+			ServerCertificate: certDER,
+			UserIdentityTokens: []*ua.UserTokenPolicy{
+				{
+					TokenType:         ua.UserTokenTypeUserName,
+					PolicyID:          "usernamePassword_0",
+					SecurityPolicyURI: "", // inherit from channel
+				},
+			},
+		},
 	}
 )
 
@@ -601,6 +616,31 @@ func TestOptions(t *testing.T) {
 					sc := DefaultSessionConfig()
 					sc.UserIdentityToken = &ua.IssuedIdentityToken{}
 					sc.AuthPolicyURI = "c"
+					return sc
+				}(),
+			},
+		},
+		{
+			// UserName token with empty SecurityPolicyURI
+			// must inherit the channel's SecurityPolicyURI for
+			// AuthPolicyURI (used downstream by EncryptUserPassword).
+			name: `SecurityFromEndpoint(username-no-auth-policy-uri)`,
+			opt:  SecurityFromEndpoint(endpoints[5], ua.UserTokenTypeUserName),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.SecurityPolicyURI = "Basic256Sha256-uri"
+					c.SecurityMode = 5
+					c.RemoteCertificate = certDER
+					c.Thumbprint = uapolicy.Thumbprint(certDER)
+					return c
+				}(),
+				session: func() *uasc.SessionConfig {
+					sc := DefaultSessionConfig()
+					sc.UserIdentityToken = &ua.UserNameIdentityToken{
+						PolicyID: "usernamePassword_0",
+					}
+					sc.AuthPolicyURI = "Basic256Sha256-uri"
 					return sc
 				}(),
 			},

--- a/uasc/secure_channel_crypto.go
+++ b/uasc/secure_channel_crypto.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/binary"
+	"strings"
 
 	"github.com/gopcua/opcua/ua"
 	"github.com/gopcua/opcua/uapolicy"
@@ -63,10 +64,12 @@ func (s *SecureChannel) VerifySessionSignature(cert, nonce, signature []byte) er
 	return nil
 }
 
-// EncryptUserPassword issues a new signature for the client to send in ActivateSessionRequest
+// EncryptUserPassword issues a new signature for the client to send in ActivateSessionRequest.
+// An empty/whitespace-only policyURI falls back to the channel's SecurityPolicy
+// (see SecurityFromEndpoint).
 func (s *SecureChannel) EncryptUserPassword(policyURI, password string, cert, nonce []byte) ([]byte, string, error) {
 	// If the User ID Token's policy was null, then default to the secure channel's policy
-	if policyURI == "" {
+	if strings.TrimSpace(policyURI) == "" {
 		policyURI = s.cfg.SecurityPolicyURI
 	}
 
@@ -103,7 +106,7 @@ func (s *SecureChannel) EncryptUserPassword(policyURI, password string, cert, no
 // The security policy for the SecureChannel is used if policyURI value is null or empty
 // https://reference.opcfoundation.org/Core/Part4/v104/docs/7.37
 func (s *SecureChannel) NewUserTokenSignature(policyURI string, cert, nonce []byte) ([]byte, string, error) {
-	if policyURI == "" {
+	if strings.TrimSpace(policyURI) == "" {
 		policyURI = s.cfg.SecurityPolicyURI
 	}
 

--- a/uasc/secure_channel_crypto_test.go
+++ b/uasc/secure_channel_crypto_test.go
@@ -1,0 +1,123 @@
+// Copyright 2018-2020 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package uasc
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/binary"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	uatest "github.com/gopcua/opcua/tests/python"
+	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uapolicy"
+	"github.com/stretchr/testify/require"
+)
+
+// When a UserTokenPolicy advertises an empty SecurityPolicyURI, the client's
+// encrypted UserName token construction must fall back to the SecureChannel's
+// negotiated SecurityPolicyURI. This test pins that contract end-to-end: the
+// encrypted password produced with policyURI="" on a Basic256Sha256 channel
+// matches the one produced with policyURI=Basic256Sha256, and the returned
+// EncryptionAlgorithm URI is the channel-policy algorithm URI.
+func TestEncryptUserPasswordFallsBackToChannelPolicy(t *testing.T) {
+	certPEM, keyPEM, err := uatest.GenerateCert("localhost", 2048, 24*time.Hour)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(keyPEM)
+	require.NotNil(t, block, "decode private key PEM")
+	localKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	require.NoError(t, err)
+
+	certBlock, _ := pem.Decode(certPEM)
+	require.NotNil(t, certBlock, "decode certificate PEM")
+	remoteCertDER := certBlock.Bytes
+
+	const (
+		channelPolicy = ua.SecurityPolicyURIBasic256Sha256
+		password      = "s3cret"
+	)
+	nonce := make([]byte, 32)
+	for i := range nonce {
+		nonce[i] = byte(i + 1)
+	}
+
+	sc := &SecureChannel{
+		cfg: &Config{
+			SecurityPolicyURI: channelPolicy,
+			SecurityMode:      ua.MessageSecurityModeSignAndEncrypt,
+			LocalKey:          localKey,
+		},
+	}
+
+	// Path A: explicit channel policy URI on the user-token policy.
+	explicitCipher, explicitAlg, err := sc.EncryptUserPassword(channelPolicy, password, remoteCertDER, nonce)
+	require.NoError(t, err, "EncryptUserPassword with explicit policy URI")
+
+	// Path B: empty user-token policy URI (legacy node-opcua-style
+	// usernamePassword_0 inherit-channel-policy semantics).
+	emptyCipher, emptyAlg, err := sc.EncryptUserPassword("", password, remoteCertDER, nonce)
+	require.NoError(t, err, "EncryptUserPassword with empty policy URI must fall back to channel policy")
+
+	require.Equal(t, explicitAlg, emptyAlg,
+		"empty policy URI must yield the same EncryptionAlgorithm URI as the channel policy")
+	require.Equal(t, "http://www.w3.org/2001/04/xmlenc#rsa-oaep", emptyAlg,
+		"Basic256Sha256 channel must produce RSA-OAEP-SHA1 EncryptionAlgorithm URI on the wire")
+
+	// Both ciphertexts must be the same length (key-size block) and
+	// must decrypt to the same plaintext under the server private key.
+	require.Equal(t, len(explicitCipher), len(emptyCipher),
+		"ciphertext length must match between explicit and inherit-from-channel paths")
+
+	plainExplicit := decryptUserPassword(t, channelPolicy, localKey, explicitCipher)
+	plainEmpty := decryptUserPassword(t, channelPolicy, localKey, emptyCipher)
+	require.Equal(t, plainExplicit, plainEmpty,
+		"decrypted secret payload must match between explicit and inherit-from-channel paths")
+	require.Equal(t, password, plainEmpty,
+		"decrypted password must equal the input plaintext")
+}
+
+// TestEncryptUserPasswordEmptyOnNoneChannelStaysNone pins that an
+// empty user-token policy on a SecurityPolicyURINone channel still
+// yields the cleartext-password / empty-algorithm form (the spec's
+// degenerate case). This is the regression guard against a too-eager
+// fallback accidentally encrypting on a None channel.
+func TestEncryptUserPasswordEmptyOnNoneChannelStaysNone(t *testing.T) {
+	sc := &SecureChannel{
+		cfg: &Config{
+			SecurityPolicyURI: ua.SecurityPolicyURINone,
+			SecurityMode:      ua.MessageSecurityModeNone,
+		},
+	}
+
+	password := "s3cret"
+	cipher, alg, err := sc.EncryptUserPassword("", password, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "", alg, "None channel must yield empty EncryptionAlgorithm")
+	require.Equal(t, []byte(password), cipher, "None channel must send cleartext password bytes")
+}
+
+// decryptUserPassword inverts EncryptUserPassword for assertion
+// purposes: parse [4-byte LE length][password][nonce], unpadded.
+func decryptUserPassword(t *testing.T, policyURI string, serverKey *rsa.PrivateKey, cipher []byte) string {
+	t.Helper()
+
+	enc, err := uapolicy.Asymmetric(policyURI, serverKey, &serverKey.PublicKey)
+	require.NoError(t, err)
+	plain, err := enc.Decrypt(cipher)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(plain), 4, "plaintext must include the 4-byte length prefix")
+
+	length := binary.LittleEndian.Uint32(plain[:4])
+	// length includes the trailing nonce; strip it off.
+	require.LessOrEqual(t, int(length)+4, len(plain), "encoded length must fit in plaintext")
+	// Caller knows nonce length is 32; subtract.
+	const nonceLen = 32
+	pwLen := int(length) - nonceLen
+	require.GreaterOrEqual(t, pwLen, 0, "decoded password length must be non-negative")
+	return string(plain[4 : 4+pwLen])
+}


### PR DESCRIPTION
Per OPC UA Part 4 §7.36, a UserTokenPolicy whose SecurityPolicyURI is empty or
null inherits the SecureChannel's SecurityPolicy. SecurityFromEndpoint and the
EncryptUserPassword / NewUserTokenSignature paths already handled this, but used
a strict "" comparison that missed whitespace-only values advertised by some
servers (e.g. legacy node-opcua endpoints).

Treat a whitespace-only per-token SecurityPolicyURI as empty and fall back to
the channel's SecurityPolicyURI across SecurityFromEndpoint, EncryptUserPassword
and NewUserTokenSignature, with the Part 4 §7.36 contract documented in the doc
comments. Adds regression tests for the username-token / empty-policy-URI case.