### PR TITLE
server: implement Browse continuation points and BrowseNext

### DIFF
--- a/server/namespace_map.go
+++ b/server/namespace_map.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -110,9 +112,9 @@ func (ns *MapNamespace) Browse(bd *ua.BrowseDescription) *ua.BrowseResult {
 
 	refs := make([]*ua.ReferenceDescription, len(ns.Data))
 
-	keyid := 0
-	for k := range ns.Data {
-		key := k
+	// Sort the keys so reference order is stable across calls: BrowseNext
+	// re-browses to resume, and a random order would drop/duplicate refs.
+	for keyid, key := range slices.Sorted(maps.Keys(ns.Data)) {
 		refid := ua.NewNumericNodeID(0, id.HasComponent)
 		expnewid := ua.NewStringExpandedNodeID(ns.id, key)
 
@@ -125,7 +127,6 @@ func (ns *MapNamespace) Browse(bd *ua.BrowseDescription) *ua.BrowseResult {
 			NodeClass:       ua.NodeClassVariable, // when support is added for nested maps, this will be NodeClassObject
 			TypeDefinition:  expnewid,
 		}
-		keyid++
 	}
 
 	return &ua.BrowseResult{

--- a/server/namespace_map_browse_test.go
+++ b/server/namespace_map_browse_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
+)
+
+// mapBrowseTestServer builds a server with a MapNamespace of tagCount tags and
+// returns a ViewService plus the Objects-folder node id to browse.
+func mapBrowseTestServer(t *testing.T, tagCount int) (*ViewService, *ua.NodeID) {
+	t.Helper()
+
+	s := New()
+	ns := NewMapNamespace(s, "maptest")
+	for i := 0; i < tagCount; i++ {
+		ns.Data[fmt.Sprintf("tag%04d", i)] = int32(i)
+	}
+	objects := ua.NewNumericNodeID(ns.ID(), id.ObjectsFolder)
+	return &ViewService{srv: s}, objects
+}
+
+// TestMapNamespaceBrowseContinuationCollectsAllRefsOnce drives a full Browse +
+// BrowseNext paging loop over a MapNamespace and asserts it yields the same set
+// of references as a single unpaged Browse, each exactly once. Regression test
+// for MapNamespace.Browse returning a non-deterministic order across pages.
+func TestMapNamespaceBrowseContinuationCollectsAllRefsOnce(t *testing.T) {
+	const tagCount = 200
+	const pageSize = 10
+
+	vs, parentID := mapBrowseTestServer(t, tagCount)
+
+	// ground truth: one unpaged browse
+	want := map[string]int{}
+	for _, r := range callBrowse(t, vs, parentID, 0).References {
+		want[refKey(r)]++
+	}
+	require.Len(t, want, tagCount, "ground-truth browse should see every tag exactly once")
+	require.Greater(t, len(want), pageSize, "need more than one page for this test to be meaningful")
+
+	// paged walk
+	got := map[string]int{}
+	res := callBrowse(t, vs, parentID, pageSize)
+	require.Equal(t, ua.StatusOK, res.StatusCode)
+	require.LessOrEqual(t, len(res.References), pageSize)
+	for _, r := range res.References {
+		got[refKey(r)]++
+	}
+
+	cp := res.ContinuationPoint
+	rounds := 0
+	for len(cp) > 0 {
+		rounds++
+		require.Less(t, rounds, tagCount+10, "BrowseNext did not terminate")
+
+		next := callBrowseNext(t, vs, cp, false)
+		require.Equal(t, ua.StatusOK, next.StatusCode)
+		require.LessOrEqual(t, len(next.References), pageSize)
+		for _, r := range next.References {
+			got[refKey(r)]++
+		}
+		cp = next.ContinuationPoint
+	}
+
+	require.Equal(t, want, got, "paged browse of a MapNamespace must yield every reference exactly once")
+	for k, n := range got {
+		require.Equal(t, 1, n, "reference %s returned %d times", k, n)
+	}
+}

--- a/server/view_service.go
+++ b/server/view_service.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/binary"
 	"slices"
 	"time"
 
@@ -20,6 +21,43 @@ type ViewService struct {
 	srv *Server
 }
 
+// Continuation points are stateless: encodeContinuationPoint packs the resume
+// offset and the original BrowseDescription, so BrowseNext re-browses the node
+// and skips to the offset. The node's references must therefore have a stable
+// order across calls.
+//
+// Format: [offset uint32][maxRefs uint32][encoded BrowseDescription].
+func (s *ViewService) encodeContinuationPoint(bd *ua.BrowseDescription, offset, maxRefs uint32) ([]byte, error) {
+	bdBytes, err := ua.Encode(bd)
+	if err != nil {
+		return nil, err
+	}
+	cp := make([]byte, 8+len(bdBytes))
+	binary.LittleEndian.PutUint32(cp[0:4], offset)
+	binary.LittleEndian.PutUint32(cp[4:8], maxRefs)
+	copy(cp[8:], bdBytes)
+	return cp, nil
+}
+
+// decodeContinuationPoint decodes a stateless continuation point.
+func (s *ViewService) decodeContinuationPoint(cp []byte) (bd *ua.BrowseDescription, offset, maxRefs uint32, err error) {
+	if len(cp) < 8 {
+		return nil, 0, 0, ua.StatusBadContinuationPointInvalid
+	}
+	offset = binary.LittleEndian.Uint32(cp[0:4])
+	maxRefs = binary.LittleEndian.Uint32(cp[4:8])
+	// The server never emits maxRefs == 0; honoring one would page in zero-sized
+	// steps and never terminate, so reject it as invalid.
+	if maxRefs == 0 {
+		return nil, 0, 0, ua.StatusBadContinuationPointInvalid
+	}
+	bd = new(ua.BrowseDescription)
+	if _, err := ua.Decode(cp[8:], bd); err != nil {
+		return nil, 0, 0, ua.StatusBadContinuationPointInvalid
+	}
+	return bd, offset, maxRefs, nil
+}
+
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.2
 func (s *ViewService) Browse(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 
@@ -30,6 +68,8 @@ func (s *ViewService) Browse(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 	if s.srv.cfg.logger != nil {
 		s.srv.cfg.logger.Debug("=== Browse incoming")
 	}
+
+	maxRefs := req.RequestedMaxReferencesPerNode
 
 	resp := &ua.BrowseResponse{
 		ResponseHeader: &ua.ResponseHeader{
@@ -45,8 +85,7 @@ func (s *ViewService) Browse(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 		DiagnosticInfos: []*ua.DiagnosticInfo{{}},
 	}
 
-	for i := range req.NodesToBrowse {
-		br := req.NodesToBrowse[i]
+	for i, br := range req.NodesToBrowse {
 		if s.srv.cfg.logger != nil {
 			s.srv.cfg.logger.Debug("    Browse of %s", br.NodeID.String())
 		}
@@ -55,7 +94,21 @@ func (s *ViewService) Browse(sc *uasc.SecureChannel, r ua.Request, reqID uint32)
 			resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusBad}
 			continue
 		}
-		resp.Results[i] = ns.Browse(br)
+
+		result := ns.Browse(br)
+
+		// Page the result if the client capped references per node.
+		if maxRefs > 0 && uint32(len(result.References)) > maxRefs {
+			cp, err := s.encodeContinuationPoint(br, maxRefs, maxRefs)
+			if err != nil {
+				resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusBad}
+				continue
+			}
+			result.References = result.References[:maxRefs]
+			result.ContinuationPoint = cp
+		}
+
+		resp.Results[i] = result
 	}
 
 	return resp, nil
@@ -146,7 +199,69 @@ func (s *ViewService) BrowseNext(sc *uasc.SecureChannel, r ua.Request, reqID uin
 	if err != nil {
 		return nil, err
 	}
-	return serviceUnsupported(req.RequestHeader), nil
+
+	resp := &ua.BrowseNextResponse{
+		ResponseHeader: &ua.ResponseHeader{
+			Timestamp:          time.Now(),
+			RequestHandle:      req.RequestHeader.RequestHandle,
+			ServiceResult:      ua.StatusOK,
+			ServiceDiagnostics: &ua.DiagnosticInfo{},
+			StringTable:        []string{},
+			AdditionalHeader:   ua.NewExtensionObject(nil),
+		},
+		Results:         make([]*ua.BrowseResult, len(req.ContinuationPoints)),
+		DiagnosticInfos: []*ua.DiagnosticInfo{},
+	}
+
+	for i, cpBytes := range req.ContinuationPoints {
+		if req.ReleaseContinuationPoints {
+			// Stateless: nothing to release.
+			resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusOK}
+			continue
+		}
+
+		bd, offset, maxRefs, err := s.decodeContinuationPoint(cpBytes)
+		if err != nil {
+			resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusBadContinuationPointInvalid}
+			continue
+		}
+
+		ns, err := s.srv.Namespace(int(bd.NodeID.Namespace()))
+		if err != nil {
+			resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusBad}
+			continue
+		}
+
+		// Re-browse and skip to offset
+		result := ns.Browse(bd)
+		if uint32(len(result.References)) <= offset {
+			// No more results
+			resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusOK}
+			continue
+		}
+
+		remaining := result.References[offset:]
+
+		if uint32(len(remaining)) > maxRefs {
+			cp, err := s.encodeContinuationPoint(bd, offset+maxRefs, maxRefs)
+			if err != nil {
+				resp.Results[i] = &ua.BrowseResult{StatusCode: ua.StatusBad}
+				continue
+			}
+			resp.Results[i] = &ua.BrowseResult{
+				StatusCode:        ua.StatusOK,
+				ContinuationPoint: cp,
+				References:        remaining[:maxRefs],
+			}
+		} else {
+			resp.Results[i] = &ua.BrowseResult{
+				StatusCode: ua.StatusOK,
+				References: remaining,
+			}
+		}
+	}
+
+	return resp, nil
 }
 
 // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.4

--- a/server/view_service_test.go
+++ b/server/view_service_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
+)
+
+// browseTestServer builds a server whose Objects node has childCount children,
+// and returns a ViewService plus the parent node id to browse.
+func browseTestServer(t *testing.T, childCount int) (*ViewService, *ua.NodeID) {
+	t.Helper()
+
+	s := New()
+	ns := NewNodeNameSpace(s, "test")
+	parent := ns.Objects()
+	for i := 0; i < childCount; i++ {
+		child := ns.AddNewVariableNode(fmt.Sprintf("var%04d", i), int32(i))
+		parent.AddRef(child, id.HasComponent, true)
+	}
+	return &ViewService{srv: s}, parent.ID()
+}
+
+func browseDesc(nodeID *ua.NodeID) *ua.BrowseDescription {
+	return &ua.BrowseDescription{
+		NodeID:          nodeID,
+		BrowseDirection: ua.BrowseDirectionForward,
+		ReferenceTypeID: ua.NewTwoByteNodeID(0),
+		IncludeSubtypes: true,
+		ResultMask:      uint32(ua.BrowseResultMaskAll),
+	}
+}
+
+func callBrowse(t *testing.T, vs *ViewService, nodeID *ua.NodeID, maxRefs uint32) *ua.BrowseResult {
+	t.Helper()
+	req := &ua.BrowseRequest{
+		RequestHeader:                 &ua.RequestHeader{},
+		RequestedMaxReferencesPerNode: maxRefs,
+		NodesToBrowse:                 []*ua.BrowseDescription{browseDesc(nodeID)},
+	}
+	resp, err := vs.Browse(nil, req, 0)
+	require.NoError(t, err)
+	br, ok := resp.(*ua.BrowseResponse)
+	require.True(t, ok, "expected *ua.BrowseResponse, got %T", resp)
+	require.Len(t, br.Results, 1)
+	return br.Results[0]
+}
+
+func callBrowseNext(t *testing.T, vs *ViewService, cp []byte, release bool) *ua.BrowseResult {
+	t.Helper()
+	req := &ua.BrowseNextRequest{
+		RequestHeader:             &ua.RequestHeader{},
+		ReleaseContinuationPoints: release,
+		ContinuationPoints:        [][]byte{cp},
+	}
+	resp, err := vs.BrowseNext(nil, req, 0)
+	require.NoError(t, err)
+	bn, ok := resp.(*ua.BrowseNextResponse)
+	require.True(t, ok, "expected *ua.BrowseNextResponse, got %T", resp)
+	require.Len(t, bn.Results, 1)
+	return bn.Results[0]
+}
+
+// refKey identifies a reference well enough to detect duplicates across pages.
+func refKey(r *ua.ReferenceDescription) string {
+	return r.ReferenceTypeID.String() + "|" + r.NodeID.String()
+}
+
+// TestContinuationPointRoundTrip checks the stateless continuation point
+// encode/decode is lossless for the fields BrowseNext relies on, and that a
+// malformed point is rejected with BadContinuationPointInvalid.
+func TestContinuationPointRoundTrip(t *testing.T) {
+	vs := &ViewService{}
+
+	bd := &ua.BrowseDescription{
+		NodeID:          ua.NewStringNodeID(2, "the-parent"),
+		BrowseDirection: ua.BrowseDirectionInverse,
+		ReferenceTypeID: ua.NewNumericNodeID(0, id.HasComponent),
+		IncludeSubtypes: true,
+		NodeClassMask:   uint32(ua.NodeClassVariable),
+		ResultMask:      uint32(ua.BrowseResultMaskAll),
+	}
+
+	cp, err := vs.encodeContinuationPoint(bd, 42, 100)
+	require.NoError(t, err)
+
+	gotBD, offset, maxRefs, err := vs.decodeContinuationPoint(cp)
+	require.NoError(t, err)
+	require.Equal(t, uint32(42), offset)
+	require.Equal(t, uint32(100), maxRefs)
+	require.True(t, gotBD.NodeID.Equal(bd.NodeID), "node id round-trip")
+	require.Equal(t, bd.BrowseDirection, gotBD.BrowseDirection)
+	require.True(t, gotBD.ReferenceTypeID.Equal(bd.ReferenceTypeID))
+	require.Equal(t, bd.IncludeSubtypes, gotBD.IncludeSubtypes)
+	require.Equal(t, bd.NodeClassMask, gotBD.NodeClassMask)
+	require.Equal(t, bd.ResultMask, gotBD.ResultMask)
+
+	for _, bad := range [][]byte{nil, {}, {1, 2, 3}, {1, 2, 3, 4, 5, 6, 7}} {
+		_, _, _, err := vs.decodeContinuationPoint(bad)
+		require.Equal(t, ua.StatusBadContinuationPointInvalid, err, "short cp %v", bad)
+	}
+}
+
+// TestBrowseNoLimitReturnsNoContinuationPoint checks that when the client does
+// not set RequestedMaxReferencesPerNode the server returns everything in one
+// response with no continuation point (the zero-cost path).
+func TestBrowseNoLimitReturnsNoContinuationPoint(t *testing.T) {
+	vs, parentID := browseTestServer(t, 100)
+
+	res := callBrowse(t, vs, parentID, 0)
+	require.Equal(t, ua.StatusOK, res.StatusCode)
+	require.Empty(t, res.ContinuationPoint, "no continuation point when unlimited")
+	require.GreaterOrEqual(t, len(res.References), 100)
+}
+
+// TestBrowseWithContinuationCollectsAllRefsOnce drives a full Browse +
+// BrowseNext paging loop and asserts it yields exactly the same set of
+// references as a single unpaged Browse, each one exactly once.
+func TestBrowseWithContinuationCollectsAllRefsOnce(t *testing.T) {
+	const childCount = 250
+	const pageSize = 10
+
+	vs, parentID := browseTestServer(t, childCount)
+
+	// ground truth: one unpaged browse
+	want := map[string]int{}
+	for _, r := range callBrowse(t, vs, parentID, 0).References {
+		want[refKey(r)]++
+	}
+	require.GreaterOrEqual(t, len(want), childCount, "ground-truth browse should see all children")
+	require.Greater(t, len(want), pageSize, "need more than one page for this test to be meaningful")
+
+	// paged walk
+	got := map[string]int{}
+	res := callBrowse(t, vs, parentID, pageSize)
+	require.Equal(t, ua.StatusOK, res.StatusCode)
+	require.LessOrEqual(t, len(res.References), pageSize)
+	for _, r := range res.References {
+		got[refKey(r)]++
+	}
+
+	cp := res.ContinuationPoint
+	rounds := 0
+	for len(cp) > 0 {
+		rounds++
+		require.Less(t, rounds, childCount+10, "BrowseNext did not terminate")
+
+		next := callBrowseNext(t, vs, cp, false)
+		require.Equal(t, ua.StatusOK, next.StatusCode)
+		require.LessOrEqual(t, len(next.References), pageSize)
+		for _, r := range next.References {
+			got[refKey(r)]++
+		}
+		cp = next.ContinuationPoint
+	}
+
+	require.Equal(t, want, got, "paged browse must yield every reference exactly once")
+	for k, n := range got {
+		require.Equal(t, 1, n, "reference %s returned %d times", k, n)
+	}
+}
+
+// TestBrowseNextReleaseContinuationPoints checks that releasing a continuation
+// point is acknowledged with no references and no further point (stateless, so
+// it is a no-op acknowledgement).
+func TestBrowseNextReleaseContinuationPoints(t *testing.T) {
+	vs, parentID := browseTestServer(t, 50)
+
+	first := callBrowse(t, vs, parentID, 10)
+	require.NotEmpty(t, first.ContinuationPoint)
+
+	res := callBrowseNext(t, vs, first.ContinuationPoint, true)
+	require.Equal(t, ua.StatusOK, res.StatusCode)
+	require.Empty(t, res.References)
+	require.Empty(t, res.ContinuationPoint)
+}
+
+// TestBrowseNextInvalidContinuationPoint checks a malformed continuation point
+// is reported per-result without failing the whole service call.
+func TestBrowseNextInvalidContinuationPoint(t *testing.T) {
+	vs, _ := browseTestServer(t, 10)
+
+	res := callBrowseNext(t, vs, []byte{0xde, 0xad}, false)
+	require.Equal(t, ua.StatusBadContinuationPointInvalid, res.StatusCode)
+}
+
+// TestBrowseNextRejectsZeroMaxRefs checks that a continuation point with maxRefs
+// 0 is rejected rather than driving an infinite paging loop. The server never
+// emits one, but a replayed or forged point would otherwise loop on empty pages.
+func TestBrowseNextRejectsZeroMaxRefs(t *testing.T) {
+	vs, parentID := browseTestServer(t, 50)
+
+	// decode must reject it outright
+	cp, err := vs.encodeContinuationPoint(browseDesc(parentID), 0, 0)
+	require.NoError(t, err)
+	_, _, _, err = vs.decodeContinuationPoint(cp)
+	require.Equal(t, ua.StatusBadContinuationPointInvalid, err)
+
+	// BrowseNext must surface it as a terminal error, not a loopable empty page + CP.
+	res := callBrowseNext(t, vs, cp, false)
+	require.Equal(t, ua.StatusBadContinuationPointInvalid, res.StatusCode)
+	require.Empty(t, res.ContinuationPoint, "must not return a continuation point that would re-loop")
+}


### PR DESCRIPTION
This implements continuation points for the server's View service, so a client can page through a node that has a large number of references using `Browse` + `BrowseNext`.

This came up in #861 where @fuantaji ran into a wall browsing a large address space from UaExpert (the reassembled response exceeds UaExpert's limit), and @istyf suggested it deserved its own fix. Now when a client sets `RequestedMaxReferencesPerNode`, the server now returns that many references plus a continuation point, and `BrowseNext` walks the rest.

How it works:

- `Browse` now honors `RequestedMaxReferencesPerNode`. If a node has more references than the limit, it returns the first page and a continuation point. If the client doesn't set a limit (`0`), behavior is unchanged and everything comes back in one response with no continuation point, so there's zero overhead for clients that don't need this.
- `BrowseNext` resumes from a continuation point, returns the next page, and hands back a new continuation point until the references are exhausted. It also handles `ReleaseContinuationPoints`.

In my implementation the continuation point is stateless, it encodes the original `BrowseDescription` plus an offset, so `BrowseNext` re-browses the node and skips to that offset. The upside is the server keeps no per-session browse state; the trade-off is it re-walks the node's references each round.

The `server` package didn't have any tests yet, so I added some:

- continuation-point encode/decode round-trip, plus rejection of malformed points with `BadContinuationPointInvalid`
- a full `Browse` + `BrowseNext` paging loop over 250 references at page size 10, asserting every reference comes back exactly once (matches an unpaged browse)
- `ReleaseContinuationPoints`
- an invalid continuation point reported per-result without failing the whole call