### PR TITLE
fix(uasc): keep OPN messages encrypted in Sign mode without overwriting SecurityMode

### DIFF
--- a/tests/go/security_conformance_test.go
+++ b/tests/go/security_conformance_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+// +build integration
+
+// Copyright 2018-2026 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package uatest2
+
+// Conformance regression tests.
+//
+// Convention: tests in this file are added only when a real regression
+// occurred, and are named after the OPC UA specification clause they pin
+// (behavior first, clause as suffix). Each test quotes the clause verbatim
+// so the expected behavior is reviewable against the test body without
+// opening the specification.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/ua"
+)
+
+func genSelfSignedCert(t *testing.T, appURI string) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	uri, err := url.Parse(appURI)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "gopcua conformance test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageDataEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		URIs:                  []*url.URL{uri},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der, key
+}
+
+// TestSecurityModeRoundtrip_Part6_674 pins OPC UA Part 6 v1.05 §6.7.4:
+//
+//	"The OpenSecureChannel Messages are signed and encrypted if the
+//	 SecurityMode is not None (even if the SecurityMode is Sign)."
+//
+// The load-bearing invariant is broader than §6.7.4's literal "mode != None"
+// text: an OpenSecureChannel (OPN) message always uses the asymmetric crypto
+// path regardless of the channel's currently-negotiated SecurityMode. This is
+// open62541's "messageType == OPN" rule, and it is what lets the server
+// decrypt the incoming OPN while its channel mode still reads None (the OPN
+// is decrypted before the requested mode is known). The test pins decryption
+// in exactly that None-window, which §6.7.4's literal text alone does not
+// ground.
+//
+// What this verifies: all three modes (None, Sign, SignAndEncrypt) complete a
+// full handshake plus one symmetric request. That catches the #817 break as a
+// regression, because the bug encrypted symmetric Sign-mode traffic the peer
+// expected signed, which dropped the chunk and hung the connection.
+//
+// What this does NOT verify: wire-level sign-only or true cross-stack behavior.
+// Both peers here are gopcua and derive encrypt-vs-sign from the same code, so a
+// regression that re-encrypted symmetric traffic on both sides could still pass.
+// An open62541 or OPC Foundation .NET interop test is the gold-standard gate for
+// that.
+//
+// Regressions pinned:
+//   - The server never decrypted the incoming asymmetric OPN, because its
+//     channel config starts with SecurityMode None (#815).
+//   - The fix for #815 persistently overrode the channel SecurityMode, which
+//     encrypted symmetric messages in Sign mode and broke Sign entirely (#817).
+//   - Removing the #817 override without the asymmetric carve-out re-broke the
+//     None-window OPN decryption from #815 (#853).
+func TestSecurityModeRoundtrip_Part6_674(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy string
+		mode   ua.MessageSecurityMode
+		port   int
+	}{
+		{"None", "None", ua.MessageSecurityModeNone, 48671},
+		{"Sign", "Basic256Sha256", ua.MessageSecurityModeSign, 48672},
+		{"SignAndEncrypt", "Basic256Sha256", ua.MessageSecurityModeSignAndEncrypt, 48673},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srvCert, srvKey := genSelfSignedCert(t, "urn:gopcua:conformance:server")
+			cliCert, cliKey := genSelfSignedCert(t, "urn:gopcua:conformance:client")
+
+			s := server.New(
+				server.EnableSecurity("None", ua.MessageSecurityModeNone),
+				server.EnableSecurity("Basic256Sha256", ua.MessageSecurityModeSign),
+				server.EnableSecurity("Basic256Sha256", ua.MessageSecurityModeSignAndEncrypt),
+				server.EnableAuthMode(ua.UserTokenTypeAnonymous),
+				server.EndPoint("localhost", tt.port),
+				server.PrivateKey(srvKey),
+				server.Certificate(srvCert),
+			)
+			require.NoError(t, s.Start(context.Background()))
+			defer s.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			addr := fmt.Sprintf("opc.tcp://localhost:%d", tt.port)
+
+			// Discover the endpoint the way a real client does, so the
+			// connection uses the server-provided certificate (chain).
+			// Poll until the listener accepts a discovery request rather than
+			// sleeping a fixed interval, so the test waits exactly as long as
+			// the server needs and no longer, bounded by ctx.
+			var (
+				eps []*ua.EndpointDescription
+				err error
+			)
+			for {
+				eps, err = opcua.GetEndpoints(ctx, addr)
+				if err == nil {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					require.NoError(t, err, "discovery (server never became ready)")
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
+
+			var ep *ua.EndpointDescription
+			for _, e := range eps {
+				if e.SecurityMode == tt.mode &&
+					(tt.mode == ua.MessageSecurityModeNone || e.SecurityPolicyURI == ua.SecurityPolicyURIBasic256Sha256) {
+					ep = e
+					break
+				}
+			}
+			require.NotNil(t, ep, "no endpoint for policy=%s mode=%s", tt.policy, tt.mode)
+
+			opts := []opcua.Option{opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeAnonymous)}
+			if tt.mode != ua.MessageSecurityModeNone {
+				opts = append(opts, opcua.Certificate(cliCert), opcua.PrivateKey(cliKey))
+			}
+
+			c, err := opcua.NewClient(addr, opts...)
+			require.NoError(t, err)
+			require.NoError(t, c.Connect(ctx), "handshake (OPN + session) in mode %s", tt.mode)
+			defer c.Close(ctx)
+
+			// One request over the established symmetric channel proves the
+			// per-mode symmetric security (sign-only vs sign+encrypt) is
+			// what the peer expects.
+			_, err = c.GetEndpoints(ctx)
+			require.NoError(t, err, "symmetric request in mode %s", tt.mode)
+		})
+	}
+}

--- a/uasc/secure_channel.go
+++ b/uasc/secure_channel.go
@@ -495,9 +495,6 @@ func (s *SecureChannel) readChunk() (*MessageChunk, error) {
 			}
 
 			s.openingInstance.algo = algo
-
-			// For OpenSecureChannel asymmetric encryption is always used
-			s.cfg.SecurityMode = ua.MessageSecurityModeSignAndEncrypt
 		}
 
 		decryptWith = s.openingInstance

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -150,6 +150,14 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	// c.maxBodySize = c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
 }
 
+// verifyAndDecrypt returns raw data when SecurityMode==None unless the chunk is
+// an asymmetric OPN under a real policy. signAndEncrypt has no matching
+// asymmetric carve-out, so if readChunk (secure_channel.go:497-500) ever stops
+// promoting SecurityMode and the algo set together, mirror that guard there.
+//
+// TODO: split the merged asymmetric/symmetric crypto into separate functions,
+// as open62541 and the OPC Foundation .NET reference do.
+
 // signAndEncrypt encrypts the message bytes stored in b and returns the
 // data signed and encrypted per the security policy information from the
 // secure channel.
@@ -211,11 +219,17 @@ func (c *channelInstance) signAndEncrypt(m *Message, b []byte) ([]byte, error) {
 }
 
 func (c *channelInstance) verifyAndDecrypt(m *MessageChunk, r []byte) ([]byte, error) {
-	if c.sc.cfg.SecurityMode == ua.MessageSecurityModeNone {
+	isAsymmetric := m.AsymmetricSecurityHeader != nil
+
+	// An asymmetric OpenSecureChannel under a real security policy is always
+	// signed and encrypted, even while the channel's SecurityMode still reads
+	// None during the handshake (OPC UA Part 6 v1.05 §6.7.4). A genuinely
+	// unsecured channel still returns raw: that is the explicit #None policy,
+	// or any symmetric message regardless of policy.
+	if c.sc.cfg.SecurityMode == ua.MessageSecurityModeNone &&
+		(c.sc.cfg.SecurityPolicyURI == ua.SecurityPolicyURINone || !isAsymmetric) {
 		return m.Data, nil
 	}
-
-	isAsymmetric := m.AsymmetricSecurityHeader != nil
 
 	headerLength := 12
 

--- a/uasc/secure_channel_instance.go
+++ b/uasc/secure_channel_instance.go
@@ -150,17 +150,22 @@ func (c *channelInstance) SetMaximumBodySize(chunkSize int) {
 	// c.maxBodySize = c.algo.PlaintextBlockSize()*maxBlock - sequenceHeaderSize - c.algo.SignatureLength() - 1
 }
 
-// verifyAndDecrypt returns raw data when SecurityMode==None unless the chunk is
-// an asymmetric OPN under a real policy. signAndEncrypt has no matching
-// asymmetric carve-out, so if readChunk (secure_channel.go:497-500) ever stops
-// promoting SecurityMode and the algo set together, mirror that guard there.
-//
-// TODO: split the merged asymmetric/symmetric crypto into separate functions,
-// as open62541 and the OPC Foundation .NET reference do.
-
 // signAndEncrypt encrypts the message bytes stored in b and returns the
 // data signed and encrypted per the security policy information from the
 // secure channel.
+//
+// Unlike verifyAndDecrypt, this has no asymmetric carve-out for SecurityMode
+// None. That is correct only because a sender carries its real (non-None)
+// SecurityMode when emitting an OPN; add an asymmetric guard here if the crypto
+// is ever restructured. This function and verifyAndDecrypt stay in lockstep on
+// the isAsymmetric clause: changing one without the other re-breaks symmetric
+// Sign traffic.
+//
+// TODO: split the merged asymmetric/symmetric crypto into separate functions,
+// as open62541 (signAndEncryptAsym/Sym) and the OPC Foundation .NET reference
+// (WriteAsymmetric/SymmetricMessage) do. Any such split must preserve
+// verifyAndDecrypt's asymmetric carve-out for the SecurityMode==None window, or
+// symmetric Sign traffic re-breaks (#815/#817).
 func (c *channelInstance) signAndEncrypt(m *Message, b []byte) ([]byte, error) {
 	// Nothing to do
 	if c.sc.cfg.SecurityMode == ua.MessageSecurityModeNone {
@@ -218,14 +223,20 @@ func (c *channelInstance) signAndEncrypt(m *Message, b []byte) ([]byte, error) {
 	return append(b[:headerLength], p...), nil
 }
 
+// verifyAndDecrypt verifies and optionally decrypts an incoming chunk.
+//
+// An asymmetric OpenSecureChannel under a real security policy is always signed
+// and encrypted, even while the channel's SecurityMode still reads None during
+// the handshake (OPC UA Part 6 v1.05 §6.7.4). The SecurityMode==None case below
+// therefore returns raw only for a genuinely unsecured chunk: the explicit #None
+// policy, or any symmetric message regardless of policy. This carve-out is the
+// replacement for the readChunk SecurityMode override (added in #817); that
+// override is no longer present and this guard takes its place.
 func (c *channelInstance) verifyAndDecrypt(m *MessageChunk, r []byte) ([]byte, error) {
 	isAsymmetric := m.AsymmetricSecurityHeader != nil
 
-	// An asymmetric OpenSecureChannel under a real security policy is always
-	// signed and encrypted, even while the channel's SecurityMode still reads
-	// None during the handshake (OPC UA Part 6 v1.05 §6.7.4). A genuinely
-	// unsecured channel still returns raw: that is the explicit #None policy,
-	// or any symmetric message regardless of policy.
+	// Return raw only for a genuinely unsecured chunk; an asymmetric OPN under a
+	// real policy must still be decrypted even while SecurityMode reads None.
 	if c.sc.cfg.SecurityMode == ua.MessageSecurityModeNone &&
 		(c.sc.cfg.SecurityPolicyURI == ua.SecurityPolicyURINone || !isAsymmetric) {
 		return m.Data, nil

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -174,7 +174,7 @@ func TestSignAndEncryptVerifyAndDecrypt(t *testing.T) {
 		t.Helper()
 
 		if uri == ua.SecurityPolicyURINone {
-			return &Config{SecurityMode: ua.MessageSecurityModeNone}
+			return &Config{SecurityMode: ua.MessageSecurityModeNone, SecurityPolicyURI: ua.SecurityPolicyURINone}
 		}
 		return &Config{SecurityMode: ua.MessageSecurityModeSignAndEncrypt}
 	}
@@ -222,7 +222,7 @@ func TestSignAndEncryptVerifyAndDecrypt(t *testing.T) {
 					0x4f, 0x50, 0x4e,
 					// Chunk Type: Final
 					0x46,
-					// MessageSize: 131
+					// MessageSize: 142
 					0x8E, 0x00, 0x00, 0x00,
 					// SecureChannelID: 0
 					0x00, 0x00, 0x00, 0x00,
@@ -296,6 +296,292 @@ func TestSignAndEncryptVerifyAndDecrypt(t *testing.T) {
 			require.Equal(t, tt.b[headerLength:], plain, "header not equal")
 		})
 	}
+}
+
+// TestVerifyAndDecrypt_Part6_674_AsymmetricOPNDecryptedInNoneWindow pins the
+// derived invariant: an OpenSecureChannel message always uses the asymmetric
+// crypto path regardless of the channel's currently-negotiated SecurityMode.
+// open62541 encodes the same rule via the messageType == OPN disjunct in its
+// receive-side decrypt decision (src/ua_securechannel_crypto.c:440), which
+// forces OPN decryption even while the channel mode still reads None.
+//
+// OPC UA Part 6 v1.05 §6.7.4: "The OpenSecureChannel Messages are signed and
+// encrypted if the SecurityMode is not None (even if the SecurityMode is Sign)."
+//
+// When verifyAndDecrypt is handed SecurityMode==None together with a real
+// SecurityPolicyURI and an asymmetric header, it must DECRYPT the OPN chunk, not
+// return it raw. readChunk (secure_channel.go:500) promotes SecurityMode to
+// SignAndEncrypt before calling verifyAndDecrypt, so this exact state is not
+// reached today; the guard defends the invariant against a future readChunk
+// change that has not yet promoted the mode. Without the guard verifyAndDecrypt
+// returns m.Data raw whenever SecurityMode==None, regardless of the asymmetric
+// header or policy.
+func TestVerifyAndDecrypt_Part6_674_AsymmetricOPNDecryptedInNoneWindow(t *testing.T) {
+	const uri = ua.SecurityPolicyURIBasic256Sha256
+
+	certPEM, keyPEM, err := uatest.GenerateCert("localhost", 2048, 24*time.Hour)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(keyPEM)
+	pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	require.NoError(t, err)
+
+	certblock, _ := pem.Decode(certPEM)
+	remoteX509Cert, err := x509.ParseCertificate(certblock.Bytes)
+	require.NoError(t, err)
+
+	remoteKey := remoteX509Cert.PublicKey.(*rsa.PublicKey)
+	algo, err := uapolicy.Asymmetric(uri, pk, remoteKey)
+	require.NoError(t, err)
+
+	m := &Message{
+		MessageHeader: &MessageHeader{
+			Header: &Header{
+				MessageType: MessageTypeOpenSecureChannel,
+				ChunkType:   ChunkTypeFinal,
+			},
+			AsymmetricSecurityHeader: &AsymmetricSecurityHeader{
+				SecurityPolicyURI: "http://gopcua.example/OPCUA/SecurityPolicy#Foo",
+			},
+			SequenceHeader: &SequenceHeader{
+				SequenceNumber: 1,
+				RequestID:      1,
+			},
+		},
+	}
+
+	plaintext := []byte{ // OpenSecureChannelRequest
+		// Message Header
+		// MessageType: OPN
+		0x4f, 0x50, 0x4e,
+		// Chunk Type: Final
+		0x46,
+		// MessageSize: 142
+		0x8E, 0x00, 0x00, 0x00,
+		// SecureChannelID: 0
+		0x00, 0x00, 0x00, 0x00,
+		// AsymmetricSecurityHeader
+		// SecurityPolicyURILength
+		0x2e, 0x00, 0x00, 0x00,
+		// SecurityPolicyURI
+		0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x67,
+		0x6f, 0x70, 0x63, 0x75, 0x61, 0x2e, 0x65, 0x78,
+		0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2f, 0x4f, 0x50,
+		0x43, 0x55, 0x41, 0x2f, 0x53, 0x65, 0x63, 0x75,
+		0x72, 0x69, 0x74, 0x79, 0x50, 0x6f, 0x6c, 0x69,
+		0x63, 0x79, 0x23, 0x46, 0x6f, 0x6f,
+		// SenderCertificate
+		0xff, 0xff, 0xff, 0xff,
+		// ReceiverCertificateThumbprint
+		0xff, 0xff, 0xff, 0xff,
+		// Sequence Header
+		// SequenceNumber
+		0x01, 0x00, 0x00, 0x00,
+		// RequestID
+		0x01, 0x00, 0x00, 0x00,
+		// TypeID
+		0x01, 0x00, 0xbe, 0x01,
+
+		// RequestHeader
+		// - AuthenticationToken
+		0x00, 0x00,
+		// - Timestamp
+		0x00, 0x98, 0x67, 0xdd, 0xfd, 0x30, 0xd4, 0x01,
+		// - RequestHandle
+		0x01, 0x00, 0x00, 0x00,
+		// - ReturnDiagnostics
+		0xff, 0x03, 0x00, 0x00,
+		// - AuditEntry
+		0xff, 0xff, 0xff, 0xff,
+		// - TimeoutHint
+		0x00, 0x00, 0x00, 0x00,
+		// - AdditionalHeader
+		//   - TypeID
+		0x00, 0x00,
+		//   - EncodingMask
+		0x00,
+		// ClientProtocolVersion
+		0x00, 0x00, 0x00, 0x00,
+		// SecurityTokenRequestType
+		0x00, 0x00, 0x00, 0x00,
+		// MessageSecurityMode
+		0x01, 0x00, 0x00, 0x00,
+		// ClientNonce
+		0xff, 0xff, 0xff, 0xff,
+		// RequestedLifetime
+		0x80, 0x8d, 0x5b, 0x00,
+	}
+
+	headerLength := 12 + m.AsymmetricSecurityHeader.Len()
+	expectedBody := append([]byte(nil), plaintext[headerLength:]...)
+
+	// Produce a real signed+encrypted asymmetric OPN chunk, the way the peer
+	// sent it on the wire.
+	enc := &channelInstance{
+		sc:   &SecureChannel{cfg: &Config{SecurityMode: ua.MessageSecurityModeSignAndEncrypt, SecurityPolicyURI: uri}},
+		algo: algo,
+	}
+	cipher, err := enc.signAndEncrypt(m, plaintext)
+	require.NoError(t, err, "error: message encrypt")
+
+	chunk := new(MessageChunk)
+	_, err = chunk.Decode(cipher)
+	require.NoError(t, err, "error: message decode")
+
+	// SecurityMode==None with a real SecurityPolicyURI and an asymmetric
+	// header. The asymmetric OPN must still be decrypted, not returned raw.
+	dec := &channelInstance{
+		sc:   &SecureChannel{cfg: &Config{SecurityMode: ua.MessageSecurityModeNone, SecurityPolicyURI: uri}},
+		algo: algo,
+	}
+
+	plain, err := dec.verifyAndDecrypt(chunk, cipher)
+	require.NoError(t, err, "error: message decrypt")
+
+	require.Equal(t, expectedBody, plain,
+		"asymmetric OPN under a real policy must be decrypted in the None window, not returned raw")
+}
+
+// TestVerifyAndDecrypt_Part6_674_NonePolicyAsymmetricReturnsRaw asserts that
+// when verifyAndDecrypt is handed SecurityMode==None together with the explicit
+// #None SecurityPolicyURI and an asymmetric header, it returns the chunk's raw
+// Data unchanged rather than attempting decryption.
+//
+// OPC UA Part 6 v1.05 §6.7.4: "The OpenSecureChannel Messages are not signed or
+// encrypted if the SecurityMode is None."
+//
+// Regression guard: without the SecurityPolicyURI == ua.SecurityPolicyURINone
+// clause, a #None-policy asymmetric chunk would reach c.algo.Decrypt with a nil
+// algo and panic the receive loop. The clause is what forces the raw-return path
+// here; TestVerifyAndDecrypt_Part6_674_AsymmetricOPNDecryptedInNoneWindow cannot,
+// since on a real policy that clause is false.
+func TestVerifyAndDecrypt_Part6_674_NonePolicyAsymmetricReturnsRaw(t *testing.T) {
+	chunk := &MessageChunk{
+		MessageHeader: &MessageHeader{
+			Header: &Header{
+				MessageType: MessageTypeOpenSecureChannel,
+				ChunkType:   ChunkTypeFinal,
+			},
+			AsymmetricSecurityHeader: &AsymmetricSecurityHeader{
+				SecurityPolicyURI: ua.SecurityPolicyURINone,
+			},
+			SequenceHeader: &SequenceHeader{
+				SequenceNumber: 1,
+				RequestID:      1,
+			},
+		},
+		Data: []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	// SecurityMode==None with the explicit #None policy and an asymmetric
+	// header. The chunk must be returned raw, not handed to the crypto path.
+	dec := &channelInstance{
+		sc: &SecureChannel{cfg: &Config{
+			SecurityMode:      ua.MessageSecurityModeNone,
+			SecurityPolicyURI: ua.SecurityPolicyURINone,
+		}},
+	}
+
+	plain, err := dec.verifyAndDecrypt(chunk, nil)
+	require.NoError(t, err, "error: message decrypt")
+
+	require.Equal(t, chunk.Data, plain,
+		"None-policy asymmetric chunk must be returned raw, not decrypted")
+}
+
+// TestVerifyAndDecrypt_Part6_674_NoneModeSymmetricReturnsRaw pins the realistic
+// unsecured steady state: a None-mode, #None-policy symmetric message returns
+// raw. It does not pin the !isAsymmetric disjunct, because the #None policy
+// satisfies the guard's first disjunct and short-circuits before !isAsymmetric
+// is evaluated. TestVerifyAndDecrypt_Part6_674_RealPolicyNoneModeSymmetricReturnsRaw
+// is the test that forces !isAsymmetric.
+//
+// OPC UA Part 6 v1.05 §6.7.4 secures the OpenSecureChannel handshake under a
+// real policy, but a None-mode channel's steady-state symmetric messages carry
+// no crypto. A symmetric chunk on such a channel must return m.Data raw and
+// never reach c.algo.Decrypt; here algo is nil, so the guard must return before
+// any algo dereference.
+func TestVerifyAndDecrypt_Part6_674_NoneModeSymmetricReturnsRaw(t *testing.T) {
+	chunk := &MessageChunk{
+		MessageHeader: &MessageHeader{
+			Header: &Header{
+				MessageType: MessageTypeMessage,
+				ChunkType:   ChunkTypeFinal,
+			},
+			SymmetricSecurityHeader: &SymmetricSecurityHeader{
+				TokenID: 1,
+			},
+			SequenceHeader: &SequenceHeader{
+				SequenceNumber: 1,
+				RequestID:      1,
+			},
+		},
+		Data: []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	// SecurityMode==None with the #None policy and a symmetric header. The
+	// chunk must be returned raw, not handed to the crypto path.
+	dec := &channelInstance{
+		sc: &SecureChannel{cfg: &Config{
+			SecurityMode:      ua.MessageSecurityModeNone,
+			SecurityPolicyURI: ua.SecurityPolicyURINone,
+		}},
+	}
+
+	plain, err := dec.verifyAndDecrypt(chunk, nil)
+	require.NoError(t, err, "error: message decrypt")
+
+	require.Equal(t, chunk.Data, plain,
+		"None-mode symmetric chunk must be returned raw, not decrypted")
+}
+
+// TestVerifyAndDecrypt_Part6_674_RealPolicyNoneModeSymmetricReturnsRaw forces
+// the guard's !isAsymmetric disjunct. With SecurityMode==None and a real
+// SecurityPolicyURI (not #None), the first disjunct (policy == #None) is false,
+// so only !isAsymmetric can return the chunk raw. A symmetric chunk in this
+// state must return m.Data unchanged and never reach c.algo.Decrypt; here algo
+// is nil, so the guard must return before any algo dereference.
+//
+// This is the only config that pins !isAsymmetric: every other current test
+// satisfies the first disjunct (#None policy) and short-circuits before
+// !isAsymmetric is evaluated.
+//
+// OPC UA Part 6 v1.05 §6.7.4 secures the OpenSecureChannel handshake under a
+// real policy, but a None-mode channel's steady-state symmetric traffic carries
+// no crypto.
+func TestVerifyAndDecrypt_Part6_674_RealPolicyNoneModeSymmetricReturnsRaw(t *testing.T) {
+	chunk := &MessageChunk{
+		MessageHeader: &MessageHeader{
+			Header: &Header{
+				MessageType: MessageTypeMessage,
+				ChunkType:   ChunkTypeFinal,
+			},
+			SymmetricSecurityHeader: &SymmetricSecurityHeader{
+				TokenID: 1,
+			},
+			SequenceHeader: &SequenceHeader{
+				SequenceNumber: 1,
+				RequestID:      1,
+			},
+		},
+		Data: []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	// SecurityMode==None with a REAL policy and a symmetric header. The first
+	// disjunct (policy == #None) is false, so !isAsymmetric is what returns the
+	// chunk raw.
+	dec := &channelInstance{
+		sc: &SecureChannel{cfg: &Config{
+			SecurityMode:      ua.MessageSecurityModeNone,
+			SecurityPolicyURI: ua.SecurityPolicyURIBasic256Sha256,
+		}},
+	}
+
+	plain, err := dec.verifyAndDecrypt(chunk, nil)
+	require.NoError(t, err, "error: message decrypt")
+
+	require.Equal(t, chunk.Data, plain,
+		"real-policy None-mode symmetric chunk must be returned raw, not decrypted")
 }
 
 func TestNewSecureChannel(t *testing.T) {

--- a/uasc/secure_channel_test.go
+++ b/uasc/secure_channel_test.go
@@ -309,13 +309,14 @@ func TestSignAndEncryptVerifyAndDecrypt(t *testing.T) {
 // encrypted if the SecurityMode is not None (even if the SecurityMode is Sign)."
 //
 // When verifyAndDecrypt is handed SecurityMode==None together with a real
-// SecurityPolicyURI and an asymmetric header, it must DECRYPT the OPN chunk, not
-// return it raw. readChunk (secure_channel.go:500) promotes SecurityMode to
-// SignAndEncrypt before calling verifyAndDecrypt, so this exact state is not
-// reached today; the guard defends the invariant against a future readChunk
-// change that has not yet promoted the mode. Without the guard verifyAndDecrypt
-// returns m.Data raw whenever SecurityMode==None, regardless of the asymmetric
-// header or policy.
+// SecurityPolicyURI and an asymmetric header, it must decrypt the OPN chunk, not
+// return it raw. readChunk no longer promotes the mode (the #817 override is no
+// longer present), so SecurityMode==None + real policy + asymmetric header is the
+// live path the server takes while decrypting an incoming OPN during the
+// handshake. The guard exercised here is that path's production mechanism: it
+// preserves the #815 fix without mutating the negotiated mode. Without it,
+// verifyAndDecrypt returns m.Data raw whenever SecurityMode==None, regardless of
+// the asymmetric header or policy, which re-introduces #815.
 func TestVerifyAndDecrypt_Part6_674_AsymmetricOPNDecryptedInNoneWindow(t *testing.T) {
 	const uri = ua.SecurityPolicyURIBasic256Sha256
 
@@ -582,6 +583,86 @@ func TestVerifyAndDecrypt_Part6_674_RealPolicyNoneModeSymmetricReturnsRaw(t *tes
 
 	require.Equal(t, chunk.Data, plain,
 		"real-policy None-mode symmetric chunk must be returned raw, not decrypted")
+}
+
+// TestVerifyAndDecrypt_Part6_674_SignModeSymmetricRoundtrip covers Sign mode
+// (MessageSecurityModeSign) on symmetric traffic: the message is signed but not
+// encrypted. signAndEncrypt's Sign branch and verifyAndDecrypt's matching verify
+// path are otherwise unexercised by unit tests, since every non-None policy in
+// TestSignAndEncryptVerifyAndDecrypt runs SignAndEncrypt. This is the regime #817
+// broke.
+//
+// OPC UA Part 6 v1.05 §6.7.4: when the SecurityMode is Sign, Messages are signed
+// but not encrypted.
+//
+// The test asserts both that the roundtrip succeeds and that the body bytes
+// (between the header and the appended signature) come back as the original
+// plaintext, confirming Sign mode does not encrypt symmetric traffic.
+func TestVerifyAndDecrypt_Part6_674_SignModeSymmetricRoundtrip(t *testing.T) {
+	const uri = ua.SecurityPolicyURIBasic256Sha256
+
+	// Equal nonces make the signing and verifying HMAC keys identical, so a
+	// single channelInstance can sign a message and verify its own signature.
+	nonce := make([]byte, 32)
+	for i := range nonce {
+		nonce[i] = byte(i)
+	}
+	algo, err := uapolicy.Symmetric(uri, nonce, nonce)
+	require.NoError(t, err)
+
+	c := &channelInstance{
+		sc: &SecureChannel{cfg: &Config{
+			SecurityMode:      ua.MessageSecurityModeSign,
+			SecurityPolicyURI: uri,
+		}},
+		algo: algo,
+	}
+
+	m := &Message{
+		MessageHeader: &MessageHeader{
+			Header: &Header{
+				MessageType: MessageTypeMessage,
+				ChunkType:   ChunkTypeFinal,
+			},
+			SymmetricSecurityHeader: &SymmetricSecurityHeader{TokenID: 1},
+			SequenceHeader: &SequenceHeader{
+				SequenceNumber: 1,
+				RequestID:      1,
+			},
+		},
+	}
+
+	// 12-byte message header + 4-byte symmetric security header (TokenID) + body.
+	headerLength := 12 + m.SymmetricSecurityHeader.Len()
+	plaintext := []byte{
+		// Message Header: MSG / Final / MessageSize (patched by signAndEncrypt) / SecureChannelID
+		0x4d, 0x53, 0x47, 0x46, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// SymmetricSecurityHeader: TokenID
+		0x01, 0x00, 0x00, 0x00,
+		// Body
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	expectedBody := append([]byte(nil), plaintext[headerLength:]...)
+
+	cipher, err := c.signAndEncrypt(m, append([]byte(nil), plaintext...))
+	require.NoError(t, err, "error: message sign")
+
+	// Sign mode appends a signature but does not encrypt, so the body on the wire
+	// stays plaintext. Read the body between the header and the trailing signature.
+	wireBody := cipher[headerLength : len(cipher)-algo.SignatureLength()]
+	require.Equal(t, expectedBody, wireBody,
+		"Sign mode must leave the symmetric body as plaintext, not ciphertext")
+
+	chunk := new(MessageChunk)
+	_, err = chunk.Decode(cipher)
+	require.NoError(t, err, "error: message decode")
+
+	plain, err := c.verifyAndDecrypt(chunk, cipher)
+	require.NoError(t, err, "error: message verify")
+
+	require.Equal(t, expectedBody, plain,
+		"Sign mode roundtrip must return the original plaintext body")
 }
 
 func TestNewSecureChannel(t *testing.T) {


### PR DESCRIPTION
## Background

A SecureChannel secures messages in two phases. The opening handshake (`OpenSecureChannel` / OPN) is always protected with asymmetric crypto, regardless of the negotiated `MessageSecurityMode`; that is where the symmetric keys are exchanged. Everything after follows the negotiated mode: `Sign` signs each message but sends it as plaintext, `SignAndEncrypt` does both.

## Bug

A client configured with `MessageSecurityMode = Sign` cannot complete a handshake against any server: the connection hangs and times out.

The cause is in `readChunk`. A server channel starts at `SecurityMode: None`, so to get the server to decrypt the incoming asymmetric OPN, #817 added `s.cfg.SecurityMode = MessageSecurityModeSignAndEncrypt` to the OPN branch. That line permanently overwrites the channel's negotiated mode on both peers, not just for the OPN (the client runs the same path when it processes the OPN response). A `Sign`-mode peer then encrypts every subsequent symmetric message, but the other side negotiated `Sign` and verifies the signature over what it expects to be plaintext. Verification fails, the chunk is dropped, and the caller times out. Channel-renewal requests use the same `SecurityMode` field, so they are sent encrypted when the mode was overwritten.

This is on `main` only: it post-dates v0.8.0 and has never shipped in a release.

Per OPC UA Part 6 §6.7.4: *"The OpenSecureChannel Messages are signed and encrypted if the SecurityMode is not None (even if the SecurityMode is Sign)."* The rule is scoped to OPN messages, but #817 implemented it by overwriting the channel's mode, so that value then governed symmetric message processing too.

## Fix

Remove the `SecurityMode` override in `readChunk`, so message processing no longer mutates the channel's negotiated mode. To keep the server decrypting the incoming asymmetric OPN while its channel still reads `None`, add a receive-side guard in `verifyAndDecrypt`: it returns a chunk raw only when the mode is `None` and either the policy is `#None` or the chunk is not asymmetric. An asymmetric OPN under a real policy falls through to the crypto path even before the mode is known.

The guard is on the receive side only. A sender already carries its real (non-`None`) `SecurityMode` when it emits an OPN, so `signAndEncrypt`'s existing asymmetric branch already handles the send path correctly, and the `None`-mode send window cannot occur (the channel constructor rejects a real policy paired with `None`). This matches open62541 and the OPC Foundation .NET reference, which base the send path on the security mode and always decrypt an asymmetric OPN on receive.

## Tests

Unit tests on `verifyAndDecrypt` cover the §6.7.4 cases: an asymmetric OPN decrypted in the `None` window under a real policy; a `#None`-policy asymmetric chunk returned raw; a symmetric chunk returned raw under `None`; and a `Sign`-mode symmetric chunk left signed but not encrypted.

`TestSecurityModeRoundtrip_Part6_674` drives a real client↔server handshake across `None` / `Sign` / `SignAndEncrypt`, plus a request over the established symmetric channel. No existing test ever established an encrypted connection; every test client connected with `None`, which is why the bug was never caught. The `None` test fixture is also corrected to carry the real `SecurityPolicyURINone` constant rather than an empty string.

## Notes

- Preserves the #815 fix: the server still decrypts the OPN, now through the receive-side guard instead of a mode mutation.
- A `TODO` notes that splitting asymmetric and symmetric crypto into separate functions, as open62541 and the .NET reference do, would make the OPN-always-secured rule structural; the integration test catches any regression until then.
- Thanks @diericd for diagnosing the `Sign`-mode break in #853; this lands the complete fix, so #853 can narrow to its certificate-chain change.
