### PR TITLE
feat: add PKCS#8 private key support

### DIFF
--- a/config.go
+++ b/config.go
@@ -270,18 +270,51 @@ func loadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 		return nil, errors.Errorf("Failed to load private key: %s", err)
 	}
 
-	derBytes := b
 	if strings.HasSuffix(filename, ".pem") {
 		block, _ := pem.Decode(b)
-		if block == nil || block.Type != "RSA PRIVATE KEY" {
+		if block == nil {
 			return nil, errors.Errorf("Failed to decode PEM block with private key")
 		}
-		derBytes = block.Bytes
+		switch block.Type {
+		case "RSA PRIVATE KEY":
+			// PKCS#1 – the classic "openssl genrsa" output
+			pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, errors.Errorf("Failed to parse PKCS#1 private key: %s", err)
+			}
+			return pk, nil
+		case "PRIVATE KEY":
+			// PKCS#8 – the modern "openssl genpkey" default
+			return parsePKCS8RSAPrivateKey(block.Bytes)
+		default:
+			return nil, errors.Errorf("Failed to decode PEM block with private key: unsupported type %q", block.Type)
+		}
 	}
 
-	pk, err := x509.ParsePKCS1PrivateKey(derBytes)
+	return parseRSAPrivateKeyDER(b)
+}
+
+// parseRSAPrivateKeyDER tries to parse der as a PKCS#1 RSA key first and,
+// if that fails, as a PKCS#8 key. This is necessary for DER-encoded files
+// because there is no block-type header to identify the format.
+func parseRSAPrivateKeyDER(der []byte) (*rsa.PrivateKey, error) {
+	if pk, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return pk, nil
+	}
+	return parsePKCS8RSAPrivateKey(der)
+}
+
+// parsePKCS8RSAPrivateKey parses a PKCS#8-encoded RSA private key.
+// It returns an explicit error when the key is not RSA, because OPC UA
+// only supports RSA for channel security and user authentication.
+func parsePKCS8RSAPrivateKey(der []byte) (*rsa.PrivateKey, error) {
+	key, err := x509.ParsePKCS8PrivateKey(der)
 	if err != nil {
 		return nil, errors.Errorf("Failed to parse private key: %s", err)
+	}
+	pk, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.Errorf("Private key is not an RSA key")
 	}
 	return pk, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package opcua
 import (
 	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"net"
@@ -37,8 +38,9 @@ GY1Q+sfu64IRjFdhnbL97a6GL+MgEVIvT9cl/DDcXtNZIl28Xk4KwAp3/lB1XrgK
 cdqKnNkOBU19ulD8SOKzAPch5ydHPFfXCw==
 -----END CERTIFICATE-----
 `)
+	certDER = derBytes(certPEM)
 
-	keyPEM = []byte(`-----BEGIN RSA PRIVATE KEY-----
+	keyPKCS1PEM = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQCfHH3peKuI3F65hsYl5j6yc4NGmcSnVpTxNt36/SsKWJK0Gecp
 M7OrBrrlxDmLaiDUDQT/+VVwop5wzmaaSOEB5W1K1nyqBoCVNsEGbgEO/j8+Jfeh
 DOQ5yAQK25YkqebNi2YlS4MOr/bUusrvwouUMn7sjM+CS4NuVbdShxQg/QIDAQAB
@@ -54,10 +56,35 @@ YqvGJP7ubbsR1YoQxQ8CQQCyCrltDYji5+KdxMOsDt0v7bCQWkQ3+pik09faK51Y
 4upIBnmHPbJ80DfFIj/93JXna5JQpnIZGn/hitRixBWU
 -----END RSA PRIVATE KEY-----
 `)
+	keyPKCS1DER = derBytes(keyPKCS1PEM)
+	cert        = x509Cert(certPEM, keyPKCS1PEM)
 
-	certDER = derBytes(certPEM)
-	keyDER  = derBytes(keyPEM)
-	cert    = x509Cert(certPEM, keyPEM)
+	keyPKCS8PEM = []byte(`-----BEGIN PRIVATE KEY-----
+MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBANUocwaux45f6JhU
+QHygnO/UfitJFEFd/CeztncyAQtW1Sja19s8w/Xf5YZSSnsp96N7Op1SFE+0dAKc
+dZT5KF6H0bAlcx1YMQWRaRc17523Ft3fkzikPL1dRrUprrnz2MhhyqlL1UiB3CEg
+7m1yly3ut1feE+zuGTnvP7ETiuY5AgMBAAECgYEAjE/oB8odSjcP4NX07RS8uZJi
+yxN75dt8FJZT0fp0fYZXImGMHaDOTZdoexbIOHLTtCV13AEfpaffhaiALeQlEYA4
+3eo+YEbFNtRs3BtxLoDc82McH70RFKjXudtsXDdq6eea0I34GvpWHEKfRJSdmEB9
+jna0pI5XV4cXJJ+qBdECQQD9psF5qnGnXjU7f4SA3nNo67pT1sz/TJLsMd3pxqmS
+w6VR25Y+LcU/iJEeBzPzCgH5wpuWcAHZiEVeYee1hwbPAkEA1yG1tVMESvv8yN71
+qec2BOWKnDA9EN0qjIreBQbB9F+vnalJpJ2b4h1/rRkTi0OzmXzlLTP07+TIPC6K
+WnyEdwJAWROBqF9h8FvWJ+HdP4BfWT5HPgAWF6XlhsrwWpOoo2DPotKRjZ53QZuN
+EtWGudgO344nI4qMK79+VOne/FHB4wJBALLzbIY3VyPUtrKUnH9HP+0Uz5canUFQ
+59rejM5bj6zqh1e7gPG41PljFlhzuokmuNfdR3mxdXaztUgyYo3gdAMCQQC/TMqc
+94ZVfT5WHoLDd86J0G4Eatl/xoA+NdHs9WRxN11RrAhH/9tdK5jV9xeMa9tncHwY
+qVM50NTCCBbetzVG
+-----END PRIVATE KEY-----
+`)
+	keyPKCS8DER = derBytes(keyPKCS8PEM)
+	keyPKCS8    = rsaKeyFromPKCS8PEM(keyPKCS8PEM)
+
+	keyPKCS8ECPem = []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiM2hA0sCCaNxhwPy
+E0GxKISgpTDWaL/h8FmM/PuprqihRANCAAQHtEMlgfUrDdt24KJRQihb5PsjOVB+
+17YDvxN/otim+q8xEacXbb7MlY6N1Vx5bbzFUDw00jVHOfWjbppru98b
+-----END PRIVATE KEY-----
+`)
 
 	endpoints = []*ua.EndpointDescription{
 		// anonymous auth
@@ -136,6 +163,24 @@ func x509Cert(c, k []byte) tls.Certificate {
 	return cert
 }
 
+// rsaKeyFromPKCS8PEM parses a PKCS#8 PEM-encoded RSA private key.
+// It is used to produce the expected *rsa.PrivateKey value in tests.
+func rsaKeyFromPKCS8PEM(pemBytes []byte) *rsa.PrivateKey {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		panic("rsaKeyFromPKCS8PEM: failed to decode PEM block")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		panic("rsaKeyFromPKCS8PEM: " + err.Error())
+	}
+	pk, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		panic("rsaKeyFromPKCS8PEM: key is not an RSA key")
+	}
+	return pk
+}
+
 func TestOptions(t *testing.T) {
 	randomRequestID = func() uint32 { return 125 }
 	defer func() { randomRequestID = nil }()
@@ -143,10 +188,13 @@ func TestOptions(t *testing.T) {
 	d := t.TempDir()
 
 	var (
-		certDERFile = filepath.Join(d, "cert.der")
-		certPEMFile = filepath.Join(d, "cert.pem")
-		keyDERFile  = filepath.Join(d, "key.der")
-		keyPEMFile  = filepath.Join(d, "key.pem")
+		certDERFile     = filepath.Join(d, "cert.der")
+		certPEMFile     = filepath.Join(d, "cert.pem")
+		keyDERFile      = filepath.Join(d, "key.der")
+		keyPEMFile      = filepath.Join(d, "key.pem")
+		keyPKCS8PEMFile = filepath.Join(d, "key-pkcs8.pem")
+		keyPKCS8DERFile = filepath.Join(d, "key-pkcs8.der")
+		keyPKCS8ECFile  = filepath.Join(d, "key-pkcs8-ec.pem")
 	)
 
 	// the error message for "file not found" is platform dependent.
@@ -165,12 +213,20 @@ func TestOptions(t *testing.T) {
 	err = os.WriteFile(certPEMFile, certPEM, 0644)
 	require.NoError(t, err, "WriteFile(certPEMFile) failed")
 
-	err = os.WriteFile(keyDERFile, keyDER, 0644)
+	err = os.WriteFile(keyDERFile, keyPKCS1DER, 0644)
 	require.NoError(t, err, "WriteFile(keyDERFile) failed")
 
-	err = os.WriteFile(keyPEMFile, keyPEM, 0644)
+	err = os.WriteFile(keyPEMFile, keyPKCS1PEM, 0644)
 	require.NoError(t, err, "WriteFile(keyPEMFile) failed")
-	defer os.Remove(keyPEMFile)
+
+	err = os.WriteFile(keyPKCS8PEMFile, keyPKCS8PEM, 0644)
+	require.NoError(t, err, "WriteFile(keyPKCS8PEMFile) failed")
+
+	err = os.WriteFile(keyPKCS8DERFile, keyPKCS8DER, 0644)
+	require.NoError(t, err, "WriteFile(keyPKCS8DERFile) failed")
+
+	err = os.WriteFile(keyPKCS8ECFile, keyPKCS8ECPem, 0644)
+	require.NoError(t, err, "WriteFile(keyPKCS8ECFile) failed")
 
 	connStateCh := make(chan ConnState)
 	connStateFunc := func(ConnState) {}
@@ -389,6 +445,34 @@ func TestOptions(t *testing.T) {
 					return c
 				}(),
 			},
+		},
+		{
+			name: `PrivateKeyFile("key-pkcs8.pem")`,
+			opt:  PrivateKeyFile(keyPKCS8PEMFile),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.LocalKey = keyPKCS8
+					return c
+				}(),
+			},
+		},
+		{
+			name: `PrivateKeyFile("key-pkcs8.der")`,
+			opt:  PrivateKeyFile(keyPKCS8DERFile),
+			cfg: &Config{
+				sechan: func() *uasc.Config {
+					c := DefaultClientConfig()
+					c.LocalKey = keyPKCS8
+					return c
+				}(),
+			},
+		},
+		{
+			name: `PrivateKeyFile("key-pkcs8-ec.pem") error`,
+			opt:  PrivateKeyFile(keyPKCS8ECFile),
+			cfg:  &Config{},
+			err:  fmt.Errorf("opcua: Private key is not an RSA key"),
 		},
 		{
 			name: `PrivateKeyFile() error`,

--- a/tests/go/private_key_pkcs8_test.go
+++ b/tests/go/private_key_pkcs8_test.go
@@ -76,18 +76,14 @@ func TestPrivateKeyFilePKCS8Handshake(t *testing.T) {
 
 	addr := fmt.Sprintf("opc.tcp://localhost:%d", port)
 
-	// Discovery: poll until the listener is ready, bounded by a 15s context,
-	// then locate the Basic256Sha256/SignAndEncrypt endpoint the way a real
-	// client does so the connection uses the server-provided certificate chain.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
 	// Discovery: poll until the listener is ready AND the target
 	// Basic256Sha256/SignAndEncrypt endpoint is present, bounded by a 15s
 	// context. Breaking on a nil error alone is insufficient: GetEndpoints can
 	// succeed with an empty or partial endpoint list during startup, so the
 	// endpoint search happens inside the loop and the loop only breaks when the
 	// target endpoint is actually found.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 	var ep *ua.EndpointDescription
 	var lastErr error
 	for {

--- a/tests/go/private_key_pkcs8_test.go
+++ b/tests/go/private_key_pkcs8_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+// +build integration
+
+// Copyright 2018-2026 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package uatest2
+
+// Capstone regression test for PR #871 (PKCS#8 private key support).
+//
+// This test pins gopcua's acceptance of PKCS#8-encoded RSA private keys loaded
+// from a file via opcua.PrivateKeyFile, exercised through a real SignAndEncrypt
+// (Basic256Sha256) handshake plus one symmetric request against the in-process
+// gopcua server.
+//
+// What this pins: PKCS#8 RSA keys (PEM "PRIVATE KEY" and raw DER) loaded from
+// disk complete a full OPN + session handshake and a symmetric GetEndpoints.
+// On main (pre-PR), loadPrivateKey rejected PKCS#8 PEM (requires block.Type
+// "RSA PRIVATE KEY") and called x509.ParsePKCS1PrivateKey on the DER bytes
+// (which fails on PKCS#8 input), so the test fails at config (ApplyConfig,
+// before Connect). On the PR branch the same rows are green.
+//
+// Cross-implementation note (NOT a universal invariant): gopcua eagerly rejects
+// non-RSA keys at load time (parsePKCS8RSAPrivateKey asserts *rsa.PrivateKey).
+// This matches UA-.NETStandard (the OPC Foundation reference, RSA-only by
+// construction) and is stricter than open62541, which defers the RSA check to
+// security-policy-use time. The test therefore pins gopcua's .NET-aligned
+// choice, not a cross-implementation rule.
+//
+// What this does NOT verify: cross-stack interop. Both peers here are gopcua,
+// so a regression that broke PKCS#8 only against an open62541 or .NET peer
+// would not be caught. A hardware or reference-server interop run is the
+// gold-standard gate for that (out of scope here; mirrors the limitation noted
+// in TestSecurityModeRoundtrip_Part6_674). There is no OPC UA spec clause
+// governing local private-key encoding (Part 6 covers the on-wire X.509
+// certificate, not how the application stores its key), so this test is
+// behavior-named without a _Part6_§X suffix per the gopcua testing convention.
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/ua"
+)
+
+func TestPrivateKeyFilePKCS8Handshake(t *testing.T) {
+	// Shared in-process server: the server config is identical for both rows,
+	// and the only variable under test is the client's key file, which the
+	// server never sees. A per-row server would be redundant (unlike
+	// TestSecurityModeRoundtrip_Part6_674, where each row varies the
+	// server-side security mode).
+	srvCert, srvKey := genSelfSignedCert(t, "urn:gopcua:conformance:server")
+	s := server.New(
+		server.EnableSecurity("Basic256Sha256", ua.MessageSecurityModeSignAndEncrypt),
+		server.EnableAuthMode(ua.UserTokenTypeAnonymous),
+		server.EndPoint("localhost", 48680),
+		server.PrivateKey(srvKey),
+		server.Certificate(srvCert),
+	)
+	require.NoError(t, s.Start(context.Background()))
+	defer s.Close()
+
+	const port = 48680
+	addr := fmt.Sprintf("opc.tcp://localhost:%d", port)
+
+	// Discovery: poll until the listener is ready, bounded by a 15s context,
+	// then locate the Basic256Sha256/SignAndEncrypt endpoint the way a real
+	// client does so the connection uses the server-provided certificate chain.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var (
+		eps []*ua.EndpointDescription
+		err error
+	)
+	for {
+		eps, err = opcua.GetEndpoints(ctx, addr)
+		if err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			require.NoError(t, err, "discovery (server never became ready)")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	var ep *ua.EndpointDescription
+	for _, e := range eps {
+		if e.SecurityMode == ua.MessageSecurityModeSignAndEncrypt &&
+			e.SecurityPolicyURI == ua.SecurityPolicyURIBasic256Sha256 {
+			ep = e
+			break
+		}
+	}
+	require.NotNil(t, ep, "no Basic256Sha256/SignAndEncrypt endpoint")
+
+	tests := []struct {
+		name   string
+		format string
+		// write writes the PKCS#8-encoded cliKey to a temp file and returns
+		// the path. The structural self-assertions that anchor the red-on-main
+		// guarantee live inside write, so they cannot be silently dropped
+		// without dropping the row's setup.
+		write func(t *testing.T, cliKey interface{}) string
+	}{
+		{
+			name:   "PEM",
+			format: "PEM",
+			write: func(t *testing.T, cliKey interface{}) string {
+				der, err := x509.MarshalPKCS8PrivateKey(cliKey)
+				require.NoError(t, err, "marshal PKCS#8")
+				keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+				// Structural guarantee: pin block.Type to "PRIVATE KEY" so
+				// the PR's switch routes through parsePKCS8RSAPrivateKey
+				// (the PKCS#8 PEM branch under test). A flip to
+				// "RSA PRIVATE KEY" would route to the PKCS#1 case, where
+				// ParsePKCS1PrivateKey errors on the PKCS#8 bytes and the
+				// row would fail without exercising the branch under test.
+				// Red-on-main is guaranteed independently by the bytes
+				// being PKCS#8: main rejects "PRIVATE KEY" at the type
+				// gate, and even a PKCS#1-typed PKCS#8 block would fail at
+				// ParsePKCS1PrivateKey. The bytes are independently
+				// guaranteed PKCS#8 by x509.MarshalPKCS8PrivateKey above.
+				block, _ := pem.Decode(keyPEM)
+				require.NotNil(t, block, "decoded PEM")
+				require.Equal(t, "PRIVATE KEY", block.Type)
+				keyPath := filepath.Join(t.TempDir(), "key.pem")
+				require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+				return keyPath
+			},
+		},
+		{
+			name:   "DER",
+			format: "DER",
+			write: func(t *testing.T, cliKey interface{}) string {
+				der, err := x509.MarshalPKCS8PrivateKey(cliKey)
+				require.NoError(t, err, "marshal PKCS#8")
+				// Structural red guarantee: main's loadPrivateKey calls
+				// x509.ParsePKCS1PrivateKey on the raw .der bytes, which
+				// fails on PKCS#8 input (this IS the red-on-main invariant).
+				// The reciprocal NoError on ParsePKCS8PrivateKey confirms the
+				// bytes are well-formed PKCS#8. A wrong Marshal producing
+				// PKCS#1 DER would fail the ParsePKCS1PrivateKey-errors
+				// assertion. This couples to Go's x509 stdlib, correctly:
+				// main's red DER path calls the identical ParsePKCS1PrivateKey,
+				// so if a future Go release made it lenient on PKCS#8, the
+				// assertion and main's red behavior break together (the
+				// assertion failing is the canary that the red invariant is
+				// gone).
+				_, errPKCS1 := x509.ParsePKCS1PrivateKey(der)
+				require.Error(t, errPKCS1, "PKCS#1 parse must fail on PKCS#8 input")
+				_, err = x509.ParsePKCS8PrivateKey(der)
+				require.NoError(t, err, "PKCS#8 parse must succeed")
+				keyPath := filepath.Join(t.TempDir(), "key.der")
+				require.NoError(t, os.WriteFile(keyPath, der, 0600))
+				return keyPath
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cliCert, cliKey := genSelfSignedCert(t, "urn:gopcua:conformance:client")
+			keyPath := tt.write(t, cliKey)
+
+			opts := []opcua.Option{
+				opcua.SecurityFromEndpoint(ep, ua.UserTokenTypeAnonymous),
+				// Certificate is supplied in-memory (not via CertificateFile):
+				// the PR does not change cert loading, and using a file here
+				// would couple pre-existing cert-loading correctness into the
+				// red signal. Only the key uses the file path, isolating the
+				// PR's single variable.
+				opcua.Certificate(cliCert),
+				opcua.PrivateKeyFile(keyPath),
+			}
+
+			c, err := opcua.NewClient(addr, opts...)
+			require.NoError(t, err, "NewClient with PKCS#8 %s key", tt.format)
+			require.NoError(t, c.Connect(ctx), "handshake with PKCS#8 %s key", tt.format)
+			defer c.Close(ctx)
+
+			// One symmetric request over the established channel proves the
+			// PKCS#8 key is usable for ongoing sign+encrypt traffic, not just
+			// the asymmetric OPN.
+			_, err = c.GetEndpoints(ctx)
+			require.NoError(t, err, "symmetric request with PKCS#8 %s key", tt.format)
+		})
+	}
+}

--- a/tests/go/private_key_pkcs8_test.go
+++ b/tests/go/private_key_pkcs8_test.go
@@ -60,18 +60,20 @@ func TestPrivateKeyFilePKCS8Handshake(t *testing.T) {
 	// server never sees. A per-row server would be redundant (unlike
 	// TestSecurityModeRoundtrip_Part6_674, where each row varies the
 	// server-side security mode).
+	// Single source of truth for the server port: the const is declared above
+	// server.New so the same value flows into EndPoint and the client address.
+	const port = 48680
 	srvCert, srvKey := genSelfSignedCert(t, "urn:gopcua:conformance:server")
 	s := server.New(
 		server.EnableSecurity("Basic256Sha256", ua.MessageSecurityModeSignAndEncrypt),
 		server.EnableAuthMode(ua.UserTokenTypeAnonymous),
-		server.EndPoint("localhost", 48680),
+		server.EndPoint("localhost", port),
 		server.PrivateKey(srvKey),
 		server.Certificate(srvCert),
 	)
 	require.NoError(t, s.Start(context.Background()))
 	defer s.Close()
 
-	const port = 48680
 	addr := fmt.Sprintf("opc.tcp://localhost:%d", port)
 
 	// Discovery: poll until the listener is ready, bounded by a 15s context,
@@ -80,31 +82,39 @@ func TestPrivateKeyFilePKCS8Handshake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	var (
-		eps []*ua.EndpointDescription
-		err error
-	)
+	// Discovery: poll until the listener is ready AND the target
+	// Basic256Sha256/SignAndEncrypt endpoint is present, bounded by a 15s
+	// context. Breaking on a nil error alone is insufficient: GetEndpoints can
+	// succeed with an empty or partial endpoint list during startup, so the
+	// endpoint search happens inside the loop and the loop only breaks when the
+	// target endpoint is actually found.
+	var ep *ua.EndpointDescription
+	var lastErr error
 	for {
-		eps, err = opcua.GetEndpoints(ctx, addr)
+		eps, err := opcua.GetEndpoints(ctx, addr)
 		if err == nil {
+			for _, e := range eps {
+				if e.SecurityMode == ua.MessageSecurityModeSignAndEncrypt &&
+					e.SecurityPolicyURI == ua.SecurityPolicyURIBasic256Sha256 {
+					ep = e
+					break
+				}
+			}
+		} else {
+			lastErr = err
+		}
+		if ep != nil {
 			break
 		}
 		select {
 		case <-ctx.Done():
-			require.NoError(t, err, "discovery (server never became ready)")
+			if lastErr != nil {
+				require.NoError(t, lastErr, "discovery (server never became ready)")
+			}
+			require.NotNil(t, ep, "discovery timed out before target endpoint was available")
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
-
-	var ep *ua.EndpointDescription
-	for _, e := range eps {
-		if e.SecurityMode == ua.MessageSecurityModeSignAndEncrypt &&
-			e.SecurityPolicyURI == ua.SecurityPolicyURIBasic256Sha256 {
-			ep = e
-			break
-		}
-	}
-	require.NotNil(t, ep, "no Basic256Sha256/SignAndEncrypt endpoint")
 
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Closes #870

### Problem

`PrivateKeyFile` / `loadPrivateKey` only accepted PKCS#1 RSA keys (`BEGIN RSA PRIVATE KEY`). PKCS#8 keys (`BEGIN PRIVATE KEY`) — the default output of OpenSSL 3.x, Java, and .NET — were rejected with:

```
opcua: Failed to decode PEM block with private key
```

### Changes

**`config.go`**

Rewrote `loadPrivateKey` to handle both formats, and extracted two focused helpers:

`parsePKCS8RSAPrivateKey` explicitly rejects non-RSA PKCS#8 keys (EC, Ed25519 …) since OPC UA only supports RSA.

**`config_test.go`**

Three new table-driven test cases added to `TestOptions`:

| Test name | Expectation |
|---|---|
| `PrivateKeyFile("key-pkcs8.pem")` | succeeds, correct `*rsa.PrivateKey` loaded |
| `PrivateKeyFile("key-pkcs8.der")` | succeeds via DER fallback path |
| `PrivateKeyFile("key-pkcs8-ec.pem")` | fails: `"opcua: PKCS#8 private key is not an RSA key"` |

Test data is hardcoded (fresh keys, not derived from the existing `keyPEM`) so the two formats are independently verifiable.

### Backwards compatibility

Full — PKCS#1 keys continue to work exactly as before. No public API changes.

