### PR TITLE
config: robust key/cert loading (content-sniff, PEM fullchains, PKCS#1 error)

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/gopcua/opcua/errors"
@@ -270,11 +269,10 @@ func loadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 		return nil, errors.Errorf("Failed to load private key: %s", err)
 	}
 
-	if strings.HasSuffix(filename, ".pem") {
-		block, _ := pem.Decode(b)
-		if block == nil {
-			return nil, errors.Errorf("Failed to decode PEM block with private key")
-		}
+	// Content-sniff: pem.Decode returns nil for non-PEM (raw DER) input,
+	// so dispatch on content, not file extension. A PKCS#8 key in a .key
+	// file (openssl genpkey default) loads correctly regardless of suffix.
+	if block, _ := pem.Decode(b); block != nil {
 		switch block.Type {
 		case "RSA PRIVATE KEY":
 			// PKCS#1 – the classic "openssl genrsa" output
@@ -297,11 +295,21 @@ func loadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 // parseRSAPrivateKeyDER tries to parse der as a PKCS#1 RSA key first and,
 // if that fails, as a PKCS#8 key. This is necessary for DER-encoded files
 // because there is no block-type header to identify the format.
+//
+// When both parses fail the errors are joined so a corrupt PKCS#1 key surfaces
+// both the PKCS#1 and PKCS#8 parse failures rather than only the (misleading)
+// PKCS#8 "asn1: structure error". A valid PKCS#8 RSA key returns cleanly from
+// parsePKCS8RSAPrivateKey without reaching the join.
 func parseRSAPrivateKeyDER(der []byte) (*rsa.PrivateKey, error) {
-	if pk, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+	pk, errPKCS1 := x509.ParsePKCS1PrivateKey(der)
+	if errPKCS1 == nil {
 		return pk, nil
 	}
-	return parsePKCS8RSAPrivateKey(der)
+	pk, err8 := parsePKCS8RSAPrivateKey(der)
+	if err8 != nil {
+		return nil, errors.Join(errors.Errorf("Failed to parse private key as PKCS#1: %s", errPKCS1), err8)
+	}
+	return pk, nil
 }
 
 // parsePKCS8RSAPrivateKey parses a PKCS#8-encoded RSA private key.
@@ -350,15 +358,31 @@ func loadCertificate(filename string) ([]byte, error) {
 		return nil, errors.Errorf("Failed to load certificate: %s", err)
 	}
 
-	if !strings.HasSuffix(filename, ".pem") {
-		return b, nil
+	// Content-sniff: dispatch on content, not file extension. A PEM-encoded
+	// certificate in a .crt file loads correctly; a raw DER certificate (any
+	// suffix) is returned as-is. pem.Decode returns nil for non-PEM input.
+	// For a PEM fullchain (leaf + intermediate/CA, the common fullchain.pem
+	// layout), concatenate every CERTIFICATE block so the whole chain is sent
+	// on the wire — matching the raw-DER path, which passes a concatenated
+	// chain through whole.
+	rest := b
+	var chain []byte
+	for {
+		block, r := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		rest = r
+		if block.Type != "CERTIFICATE" {
+			return nil, errors.Errorf("Failed to decode PEM block with certificate: unsupported type %q", block.Type)
+		}
+		chain = append(chain, block.Bytes...)
+	}
+	if chain != nil {
+		return chain, nil
 	}
 
-	block, _ := pem.Decode(b)
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errors.Errorf("Failed to decode PEM block with certificate")
-	}
-	return block.Bytes, nil
+	return b, nil
 }
 
 func setCertificate(cert []byte, cfg *Config) error {

--- a/config_pkcs8_test.go
+++ b/config_pkcs8_test.go
@@ -1,0 +1,178 @@
+// Copyright 2018-2026 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package opcua
+
+// Fast unit coverage for PR #871 (PKCS#8 private key support) branches that
+// the integration capstone (tests/go/private_key_pkcs8_test.go) does not pin
+// in isolation and that lack fast unit coverage in TestOptions. Each row names
+// the branch it pins.
+//
+// Row A pins parseRSAPrivateKeyDER -> parsePKCS8RSAPrivateKey type-assert
+// rejection for a non-RSA (EC) PKCS#8 key delivered as raw DER (no PEM
+// header), the path a .der EC key takes. The joined PKCS#1/PKCS#8 error still
+// carries the "Private key is not an RSA key" message.
+//
+// Row B pins the default branch of the loadPrivateKey PEM switch
+// ("unsupported type %q") for a SEC1 EC key whose PEM block Type is
+// "EC PRIVATE KEY". This branch had zero coverage before this row (the
+// existing TestOptions rows only exercise the PKCS#8 "PRIVATE KEY" case).
+// The content-sniff loader routes by block.Type, so this row uses a .pem file
+// to pin the default branch directly.
+//
+// Row C pins suffix-independence: a PKCS#8 RSA key written as PEM to a .key
+// file (openssl genpkey default) loads cleanly. With extension-based
+// dispatch this failed (the .key suffix skipped PEM decoding and the loader
+// handed PEM-armored text to the DER parser). This row is the permanent pin
+// for the content-sniff change.
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadPrivateKeyPKCS8Coverage(t *testing.T) {
+	// Shared RSA key for the success row.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaPKCS8DER, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+	rsaPKCS8PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: rsaPKCS8DER})
+
+	// Shared EC key for the rejection rows.
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecPKCS8DER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+	ecSEC1DER, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	ecSEC1PEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: ecSEC1DER})
+
+	tests := []struct {
+		name      string
+		write     func(t *testing.T) string
+		wantError string // non-empty => expect an error containing this substring
+	}{
+		{
+			// Row A: DER-EC rejection. Pins parseRSAPrivateKeyDER ->
+			// parsePKCS8RSAPrivateKey type-assert branch for a non-RSA PKCS#8
+			// key delivered as raw DER. The PKCS#1/PKCS#8 errors are joined,
+			// but the "not an RSA key" message is preserved.
+			name: "DER EC key rejected as not-RSA",
+			write: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "ec.der")
+				require.NoError(t, os.WriteFile(p, ecPKCS8DER, 0600))
+				return p
+			},
+			wantError: "Private key is not an RSA key",
+		},
+		{
+			// Row B: default-branch unsupported PEM type. Pins the default
+			// branch of the loadPrivateKey switch for a SEC1 EC key whose PEM
+			// block Type is "EC PRIVATE KEY". This branch was previously
+			// untested; the content-sniff loader routes by block.Type.
+			name: "PEM EC PRIVATE KEY rejected as unsupported type",
+			write: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "ec.pem")
+				require.NoError(t, os.WriteFile(p, ecSEC1PEM, 0600))
+				return p
+			},
+			wantError: "unsupported type",
+		},
+		{
+			// Row C: suffix-independence. Pins the content-sniff change: a
+			// PKCS#8 RSA key as PEM in a .key file loads cleanly. With
+			// extension-based dispatch this failed (the .key suffix skipped
+			// PEM decoding). This is the permanent pin for the suffix fix.
+			name: "PKCS#8 RSA PEM in .key file loads",
+			write: func(t *testing.T) string {
+				p := filepath.Join(t.TempDir(), "key.key")
+				require.NoError(t, os.WriteFile(p, rsaPKCS8PEM, 0600))
+				return p
+			},
+			wantError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyPath := tt.write(t)
+			cfg, err := ApplyConfig(PrivateKeyFile(keyPath))
+			if tt.wantError != "" {
+				require.Error(t, err)
+				require.True(t,
+					strings.Contains(err.Error(), tt.wantError),
+					"error %q does not contain %q", err.Error(), tt.wantError,
+				)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, cfg, "config must be non-nil on success")
+			require.NotNil(t, cfg.sechan.LocalKey, "LocalKey must be set on success")
+			require.Equal(t, rsaKey.N, cfg.sechan.LocalKey.N, "loaded key must match generated key")
+		})
+	}
+}
+
+// TestLoadCertificateContentSniff pins the certificate side of the content-sniff
+// change, which the key-side rows above do not cover. Two behaviors:
+//
+//   - Suffix-independence: a PEM certificate in a .crt file (openssl's default
+//     PEM output suffix) loads. With extension-based dispatch a .crt file
+//     skipped PEM decoding and the raw armored text was returned as "DER".
+//
+//   - Fullchain preservation: a PEM fullchain (leaf + intermediate, the common
+//     fullchain.pem layout) loads the whole chain, not just the first block.
+//     loadCertificate concatenates every CERTIFICATE block so the full chain is
+//     sent on the wire, matching the raw-DER path.
+func TestLoadCertificateContentSniff(t *testing.T) {
+	// A second self-signed cert to stand in for an intermediate.
+	secondDER := genSelfSignedCertDER(t)
+
+	t.Run("PEM cert in .crt file loads", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "cert.crt")
+		require.NoError(t, os.WriteFile(p, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0600))
+		cfg, err := ApplyConfig(CertificateFile(p))
+		require.NoError(t, err)
+		require.Equal(t, certDER, cfg.sechan.Certificate, "loaded cert DER must match the PEM-decoded bytes")
+	})
+
+	t.Run("PEM fullchain loads the whole chain", func(t *testing.T) {
+		chainPEM := bytes.NewBuffer(nil)
+		chainPEM.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+		chainPEM.Write(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: secondDER}))
+		p := filepath.Join(t.TempDir(), "fullchain.pem")
+		require.NoError(t, os.WriteFile(p, chainPEM.Bytes(), 0600))
+		cfg, err := ApplyConfig(CertificateFile(p))
+		require.NoError(t, err)
+		// The whole chain (leaf + intermediate) must be on the wire, not just
+		// the first block. Concatenated DER: certDER || secondDER.
+		want := append(append([]byte{}, certDER...), secondDER...)
+		require.Equal(t, want, cfg.sechan.Certificate, "fullchain must load both certs, not just the leaf")
+	})
+}
+
+// genSelfSignedCertDER returns a fresh self-signed certificate as raw DER, for
+// use as a second chain entry in tests.
+func genSelfSignedCertDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), IsCA: false}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}


### PR DESCRIPTION
## What

Hardens the private-key and certificate loaders, building on #871 (PKCS#8 support). Three fixes, all in `config.go`:

1. **Content-sniff instead of extension dispatch.** `loadPrivateKey` and `loadCertificate` dispatched PEM vs DER on a case-sensitive `strings.HasSuffix(filename, ".pem")` check, so a key or cert stored under `.key`/`.crt` (the `openssl genpkey` / default PEM output suffix) or `.PEM` misrouted to the DER parser and failed with an opaque `asn1: structure error`. The `PrivateKeyFile`/`CertificateFile` godoc say "PEM or DER encoded file" with no extension requirement, so the implementation violated its own contract. Replaced with `pem.Decode` unconditionally (returns nil for raw DER, which begins `0x30`, never the PEM sentinel), dispatching on `block.Type` when a block is found and falling back to raw-DER parsing otherwise. Matches how open62541 (`PEM_read_bio_PrivateKey`) and .NET load keys. Behavior unchanged for `.pem`/`.der`; `.key`/`.crt` PEM files now load.

2. **Preserve PEM cert fullchains.** With content-sniffing, `loadCertificate` returned only the first `CERTIFICATE` block, silently dropping intermediate/CA blocks in a PEM fullchain (the common `fullchain.pem` layout). Only the leaf went on the wire, so a peer without a cached intermediate failed cert validation at handshake with a confusing "bad certificate". Loops `pem.Decode` over the remaining bytes and concatenates every `CERTIFICATE` block, matching the raw-DER path (which already passes a concatenated chain through). Behavior change: a PEM cert in a `.crt`/`.key` file now loads where it previously failed.

3. **Surface the PKCS#1 parse error.** `parseRSAPrivateKeyDER` tried `ParsePKCS1PrivateKey` and, on error, discarded that error before falling back to `parsePKCS8RSAPrivateKey`, returning only the PKCS#8 error. A corrupt or truncated PKCS#1 DER key surfaced `asn1: structure error` (the PKCS#8 attempt) instead of the PKCS#1 cause. Captures `errPKCS1` and `errors.Join`s it with the PKCS#8 error when both parses fail. A valid PKCS#8 RSA key returns cleanly without reaching the join.

## Why separate from #871

These are pre-existing loader issues (true on `main` before #871), broader than Stefan's PKCS#8 feature. Kept in a separate PR so #871 stays a focused feature + conformance test, and this hardening gets its own review and changelog entry.

## Verification

- Full unit suite + the #871 conformance test pass with `-race`.
- `gremlins unleash -D main` (mutation testing scoped to the diff): 8/8 mutants in the touched functions killed, zero survivors, 100% efficacy.
- Content-sniff is behavior-preserving for every previously-working case (traced: `.pem`/`.der` PKCS#1 and PKCS#8 all identical before/after).
- New unit rows pin every branch: PKCS#8-EC-as-DER rejection, SEC1 unsupported-type, `.key` suffix loading, cert-in-`.crt` loading, PEM fullchain preservation.

## Notes

- `config_test.go` is unchanged.
- Follow-ups (not in this PR): encrypted PKCS#8 support, the `parsePKCS8RSAPrivateKey` doc comment ("OPC UA only supports RSA" is spec-incorrect; ECC policies exist since v1.04, gopcua just doesn't implement them), non-RSA error message naming the concrete key type.
