### PR TITLE
server: normalise node data type attribute reads to nodeid before returning them

### DIFF
--- a/server/namespace_node.go
+++ b/server/namespace_node.go
@@ -130,32 +130,31 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 		return errorDataValueWithStatus(ua.StatusBadUserAccessDenied)
 	}
 
-	var err error
-	var a *AttrValue
-
 	switch attr {
 	case ua.AttributeIDNodeID:
-		a = &AttrValue{Value: DataValueFromValue(id)}
+		return DataValueFromValue(id)
 	case ua.AttributeIDEventNotifier:
 		// TODO: this is a hack to force the EventNotifier to false for everything.
 		// If at some point someone or something needs to use this, this will have to go away and be
 		// fixed properly.
-		a = &AttrValue{Value: DataValueFromValue(byte(0))}
-	case ua.AttributeIDNodeClass:
-		if a, err = n.Attribute(attr); err != nil {
-			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
-		}
+		return DataValueFromValue(byte(0))
+	}
 
+	var err error
+	var a *AttrValue
+
+	if a, err = n.Attribute(attr); err != nil {
+		return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
+	}
+
+	switch attr {
+	case ua.AttributeIDNodeClass:
 		// TODO: we need int32 instead of uint32 here.  this isn't the right place to fix it, but it is a bandaid
 		x, ok := a.Value.Value.Value().(uint32)
 		if ok {
 			a.Value.Value = ua.MustVariant(int32(x))
 		}
 	case ua.AttributeIDDataType:
-		if a, err = n.Attribute(attr); err != nil {
-			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
-		}
-
 		if a.Value != nil && a.Value.Value != nil {
 			if nodeID := a.Value.Value.NodeID(); nodeID != nil {
 				dv := *a.Value
@@ -165,10 +164,6 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 		}
 
 		return errorDataValueWithStatus(ua.StatusBadTypeMismatch)
-	default:
-		if a, err = n.Attribute(attr); err != nil {
-			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
-		}
 	}
 
 	return a.Value

--- a/server/namespace_node.go
+++ b/server/namespace_node.go
@@ -133,6 +133,8 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 	var err error
 	var a *AttrValue
 
+	status := ua.StatusOK
+
 	switch attr {
 	case ua.AttributeIDNodeID:
 		a = &AttrValue{Value: DataValueFromValue(id)}
@@ -143,29 +145,42 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 		a = &AttrValue{Value: DataValueFromValue(byte(0))}
 	case ua.AttributeIDNodeClass:
 		a, err = n.Attribute(attr)
-		if err != nil {
-			return &ua.DataValue{
-				EncodingMask:    ua.DataValueServerTimestamp | ua.DataValueStatusCode,
-				ServerTimestamp: time.Now(),
-				Status:          ua.StatusBadAttributeIDInvalid,
+		if err == nil {
+			// TODO: we need int32 instead of uint32 here.  this isn't the right place to fix it, but it is a bandaid
+			x, ok := a.Value.Value.Value().(uint32)
+			if ok {
+				a.Value.Value = ua.MustVariant(int32(x))
 			}
 		}
-		// TODO: we need int32 instead of uint32 here.  this isn't the right place to fix it, but it is a bandaid
-		x, ok := a.Value.Value.Value().(uint32)
-		if ok {
-			a.Value.Value = ua.MustVariant(int32(x))
+	case ua.AttributeIDDataType:
+		if a, err = n.Attribute(attr); err != nil {
+			status = ua.StatusBadAttributeIDInvalid
+			break
 		}
+
+		if a.Value != nil && a.Value.Value != nil {
+			if nodeID := a.Value.Value.NodeID(); nodeID != nil {
+				dv := *a.Value
+				dv.Value = ua.MustVariant(nodeID)
+				return &dv
+			}
+		}
+
+		status = ua.StatusBadTypeMismatch
 	default:
-		a, err = n.Attribute(attr)
+		if a, err = n.Attribute(attr); err != nil {
+			status = ua.StatusBadAttributeIDInvalid
+		}
 	}
 
-	if err != nil {
+	if status != ua.StatusOK {
 		return &ua.DataValue{
 			EncodingMask:    ua.DataValueServerTimestamp | ua.DataValueStatusCode,
 			ServerTimestamp: time.Now(),
-			Status:          ua.StatusBadAttributeIDInvalid,
+			Status:          status,
 		}
 	}
+
 	return a.Value
 }
 

--- a/server/namespace_node.go
+++ b/server/namespace_node.go
@@ -113,27 +113,25 @@ func (as *NodeNameSpace) AddNewVariableStringNode(name string, value any) *Node 
 }
 
 func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataValue {
-	n := as.Node(id)
-	if n == nil {
+	errorDataValueWithStatus := func(status ua.StatusCode) *ua.DataValue {
 		return &ua.DataValue{
 			EncodingMask:    ua.DataValueServerTimestamp | ua.DataValueStatusCode,
 			ServerTimestamp: time.Now(),
-			Status:          ua.StatusBadNodeIDUnknown,
+			Status:          status,
 		}
 	}
 
+	n := as.Node(id)
+	if n == nil {
+		return errorDataValueWithStatus(ua.StatusBadNodeIDUnknown)
+	}
+
 	if !n.Access(ua.AccessLevelTypeCurrentRead) {
-		return &ua.DataValue{
-			EncodingMask:    ua.DataValueServerTimestamp | ua.DataValueStatusCode,
-			ServerTimestamp: time.Now(),
-			Status:          ua.StatusBadUserAccessDenied,
-		}
+		return errorDataValueWithStatus(ua.StatusBadUserAccessDenied)
 	}
 
 	var err error
 	var a *AttrValue
-
-	status := ua.StatusOK
 
 	switch attr {
 	case ua.AttributeIDNodeID:
@@ -144,18 +142,18 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 		// fixed properly.
 		a = &AttrValue{Value: DataValueFromValue(byte(0))}
 	case ua.AttributeIDNodeClass:
-		a, err = n.Attribute(attr)
-		if err == nil {
-			// TODO: we need int32 instead of uint32 here.  this isn't the right place to fix it, but it is a bandaid
-			x, ok := a.Value.Value.Value().(uint32)
-			if ok {
-				a.Value.Value = ua.MustVariant(int32(x))
-			}
+		if a, err = n.Attribute(attr); err != nil {
+			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
+		}
+
+		// TODO: we need int32 instead of uint32 here.  this isn't the right place to fix it, but it is a bandaid
+		x, ok := a.Value.Value.Value().(uint32)
+		if ok {
+			a.Value.Value = ua.MustVariant(int32(x))
 		}
 	case ua.AttributeIDDataType:
 		if a, err = n.Attribute(attr); err != nil {
-			status = ua.StatusBadAttributeIDInvalid
-			break
+			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
 		}
 
 		if a.Value != nil && a.Value.Value != nil {
@@ -166,18 +164,10 @@ func (as *NodeNameSpace) Attribute(id *ua.NodeID, attr ua.AttributeID) *ua.DataV
 			}
 		}
 
-		status = ua.StatusBadTypeMismatch
+		return errorDataValueWithStatus(ua.StatusBadTypeMismatch)
 	default:
 		if a, err = n.Attribute(attr); err != nil {
-			status = ua.StatusBadAttributeIDInvalid
-		}
-	}
-
-	if status != ua.StatusOK {
-		return &ua.DataValue{
-			EncodingMask:    ua.DataValueServerTimestamp | ua.DataValueStatusCode,
-			ServerTimestamp: time.Now(),
-			Status:          status,
+			return errorDataValueWithStatus(ua.StatusBadAttributeIDInvalid)
 		}
 	}
 

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -37,3 +37,25 @@ func TestNamespaceAttributeDataTypeReturnsNodeID(t *testing.T) {
 	require.Equal(t, ua.TypeIDNodeID, dv.Value.Type())
 	require.Equal(t, uint32(id.Double), dv.Value.NodeID().IntID())
 }
+
+func TestNamespaceAttributeMissingNodeClassReturnsBadAttributeIDInvalid(t *testing.T) {
+	ns := NewNameSpace("test")
+	nodeID := ua.NewStringNodeID(1, "x")
+
+	n := NewNode(
+		nodeID,
+		Attributes{
+			ua.AttributeIDBrowseName:  DataValueFromValue(&ua.QualifiedName{Name: "x"}),
+			ua.AttributeIDDisplayName: DataValueFromValue(&ua.LocalizedText{Text: "x"}),
+		},
+		nil,
+		nil,
+	)
+
+	ns.AddNode(n)
+
+	require.NotPanics(t, func() {
+		dv := ns.Attribute(nodeID, ua.AttributeIDNodeClass)
+		require.Equal(t, ua.StatusBadAttributeIDInvalid, dv.Status)
+	})
+}

--- a/server/node_test.go
+++ b/server/node_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018-2020 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceAttributeDataTypeReturnsNodeID(t *testing.T) {
+	ns := NewNameSpace("test")
+	nodeID := ua.NewStringNodeID(1, "x")
+
+	n := NewNode(
+		nodeID,
+		Attributes{
+			ua.AttributeIDBrowseName:  DataValueFromValue(&ua.QualifiedName{Name: "x"}),
+			ua.AttributeIDDisplayName: DataValueFromValue(&ua.LocalizedText{Text: "x"}),
+			ua.AttributeIDNodeClass:   DataValueFromValue(uint32(ua.NodeClassVariable)),
+			ua.AttributeIDDataType:    DataValueFromValue(ua.NewNumericExpandedNodeID(0, id.Double)),
+		},
+		nil,
+		nil,
+	)
+
+	ns.AddNode(n)
+
+	dv := ns.Attribute(nodeID, ua.AttributeIDDataType)
+
+	require.Equal(t, ua.StatusOK, dv.Status)
+	require.NotNil(t, dv.Value.NodeID())
+	require.Equal(t, ua.TypeIDNodeID, dv.Value.Type())
+	require.Equal(t, uint32(id.Double), dv.Value.NodeID().IntID())
+}


### PR DESCRIPTION
This PR adds DataType node attribute read normalisation so that the value that is currently internally held as either a NodeID or an ExtendedNodeID is presenteds to clients as a NodeID as the standard mandates.

The fix avoids mutating the stored attribute, preserves the existing special handling for NodeId/EventNotifier, and simplifies the common error handling path.

Fixes #849 