### PR TITLE
fix restoreSubscriptions leaving the client connected when a subscription fails to recreate

### DIFF
--- a/client.go
+++ b/client.go
@@ -585,6 +585,17 @@ func (c *Client) monitor(ctx context.Context) {
 						if action == restoreSubscriptions {
 							c.setState(ctx, Connected)
 							action = none
+						} else {
+							// a subscription failed to recreate and action is
+							// recreateSession. back off before retrying so we don't
+							// hot-loop hammering the server when a subscription can
+							// never be restored (e.g. a monitored node was permanently
+							// removed from the server's address space).
+							select {
+							case <-ctx.Done():
+								return
+							case <-time.After(c.cfg.sechan.ReconnectInterval):
+							}
 						}
 
 					case abortReconnect:

--- a/client.go
+++ b/client.go
@@ -576,8 +576,16 @@ func (c *Client) monitor(ctx context.Context) {
 							activeSubs++
 						}
 
-						c.setState(ctx, Connected)
-						action = none
+						// only mark the client connected once every subscription has
+						// been restored. if a subscription failed to recreate, action
+						// was set to recreateSession above so the outer loop rebuilds
+						// the session and retries. running these two lines
+						// unconditionally dropped the failed subscriptions and left the
+						// client in Connected state with a dead publish loop.
+						if action == restoreSubscriptions {
+							c.setState(ctx, Connected)
+							action = none
+						}
 
 					case abortReconnect:
 						dlog.Printf("action: abortReconnect")

--- a/client.go
+++ b/client.go
@@ -558,44 +558,21 @@ func (c *Client) monitor(ctx context.Context) {
 						// Assume that subsToRecreate and subsToRepublish have been
 						// populated in the previous step.
 
-						activeSubs = 0
-						for _, subID := range subsToRepublish {
-							if err := c.republishSubscription(ctx, subID, availableSeqs[subID]); err != nil {
-								dlog.Printf("republish of subscription %d failed", subID)
-								subsToRecreate = append(subsToRecreate, subID)
-							}
-							activeSubs++
-						}
-
-						for _, subID := range subsToRecreate {
-							if err := c.recreateSubscription(ctx, subID); err != nil {
-								dlog.Printf("recreate subscripitions failed: %v", err)
-								action = recreateSession
-								continue
-							}
-							activeSubs++
-						}
-
-						// only mark the client connected once every subscription has
-						// been restored. if a subscription failed to recreate, action
-						// was set to recreateSession above so the outer loop rebuilds
-						// the session and retries. running these two lines
-						// unconditionally dropped the failed subscriptions and left the
-						// client in Connected state with a dead publish loop.
-						if action == restoreSubscriptions {
+						action, activeSubs = c.republishOrRecreateSubscriptions(ctx, subsToRepublish, subsToRecreate, availableSeqs)
+						if action == none {
 							c.setState(ctx, Connected)
-							action = none
-						} else {
-							// a subscription failed to recreate and action is
-							// recreateSession. back off before retrying so we don't
-							// hot-loop hammering the server when a subscription can
-							// never be restored (e.g. a monitored node was permanently
-							// removed from the server's address space).
-							select {
-							case <-ctx.Done():
-								return
-							case <-time.After(c.cfg.sechan.ReconnectInterval):
-							}
+							break
+						}
+
+						// at least one subscription could not be recreated and action
+						// is recreateSession. back off before retrying so we don't
+						// hot-loop hammering the server when a subscription can never
+						// be restored (e.g. a monitored node was permanently removed
+						// from the server's address space).
+						select {
+						case <-ctx.Done():
+							return
+						case <-time.After(c.cfg.sechan.ReconnectInterval):
 						}
 
 					case abortReconnect:

--- a/client_sub.go
+++ b/client_sub.go
@@ -100,10 +100,15 @@ func (c *Client) recreateSubscription(ctx context.Context, id uint32) error {
 	}
 
 	sub.recreate_delete(ctx)
-	c.forgetSubscription_NeedsSubMuxLock(ctx, id)
+
+	// the subscription stays registered under its old id until the replacement
+	// exists, so that a failed create leaves it for the reconnect loop to retry
+	// instead of dropping it. recreate_create only assigns the new id on
+	// success, so the old id is still the key to forget here.
 	if err := sub.recreate_create(ctx); err != nil {
 		return err
 	}
+	c.forgetSubscription_NeedsSubMuxLock(ctx, id)
 
 	if err := c.registerSubscription_NeedsSubMuxLock(sub); err != nil {
 		return err

--- a/client_sub.go
+++ b/client_sub.go
@@ -112,6 +112,44 @@ func (c *Client) recreateSubscription(ctx context.Context, id uint32) error {
 	return sub.recreate_monitoredItems(ctx)
 }
 
+// republishOrRecreateSubscriptions performs the restoreSubscriptions step of
+// the reconnect state machine. It republishes the subscriptions the server has
+// transferred to the new session and recreates the ones which could not be
+// transferred. Subscriptions for which the republish fails are recreated as
+// well.
+//
+// It returns the next reconnect action and the number of subscriptions which
+// are active again.
+//
+// The next action is none when every subscription was restored. If at least
+// one subscription could not be recreated the next action is recreateSession
+// so that the reconnect loop rebuilds the session and tries again instead of
+// leaving the client connected with a subscription that is gone.
+func (c *Client) republishOrRecreateSubscriptions(ctx context.Context, subsToRepublish, subsToRecreate []uint32, availableSeqs map[uint32][]uint32) (reconnectAction, int) {
+	dlog := debug.NewPrefixLogger("client: restoreSubscriptions: ")
+
+	action, activeSubs := none, 0
+
+	for _, subID := range subsToRepublish {
+		if err := c.republishSubscription(ctx, subID, availableSeqs[subID]); err != nil {
+			dlog.Printf("republish of subscription %d failed", subID)
+			subsToRecreate = append(subsToRecreate, subID)
+		}
+		activeSubs++
+	}
+
+	for _, subID := range subsToRecreate {
+		if err := c.recreateSubscription(ctx, subID); err != nil {
+			dlog.Printf("recreate subscription %d failed: %v", subID, err)
+			action = recreateSession
+			continue
+		}
+		activeSubs++
+	}
+
+	return action, activeSubs
+}
+
 // transferSubscriptions ask the server to transfer the given subscriptions
 // of the previous session to the current one.
 func (c *Client) transferSubscriptions(ctx context.Context, ids []uint32) (*ua.TransferSubscriptionsResponse, error) {

--- a/client_sub_test.go
+++ b/client_sub_test.go
@@ -1,0 +1,209 @@
+package opcua
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
+)
+
+// stubClient is a ClientInterface which answers the requests a subscription
+// sends while it is being recreated. It lets the reconnect logic be tested
+// without a server.
+type stubClient struct {
+	mu       sync.Mutex
+	send     func(req ua.Request, h func(ua.Response) error) error
+	requests []ua.Request
+}
+
+var _ ClientInterface = (*stubClient)(nil)
+
+func (c *stubClient) Send(ctx context.Context, req ua.Request, h func(ua.Response) error) error {
+	c.mu.Lock()
+	c.requests = append(c.requests, req)
+	c.mu.Unlock()
+	return c.send(req, h)
+}
+
+func (c *stubClient) sentRequests() []ua.Request {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]ua.Request{}, c.requests...)
+}
+
+func (c *stubClient) Browse(context.Context, *ua.BrowseRequest) (*ua.BrowseResponse, error) {
+	return nil, ua.StatusBadNotImplemented
+}
+
+func (c *stubClient) BrowseNext(context.Context, *ua.BrowseNextRequest) (*ua.BrowseNextResponse, error) {
+	return nil, ua.StatusBadNotImplemented
+}
+
+func (c *stubClient) Read(context.Context, *ua.ReadRequest) (*ua.ReadResponse, error) {
+	return nil, ua.StatusBadNotImplemented
+}
+
+func (c *stubClient) Node(id *ua.NodeID) *Node { return NewNode(id, c) }
+func (c *stubClient) NodeFromExpandedNodeID(id *ua.ExpandedNodeID) *Node {
+	return NewNode(&ua.NodeID{}, c)
+}
+func (c *stubClient) ForgetSubscription(context.Context, uint32) {}
+func (c *stubClient) RequestTimeout() time.Duration              { return time.Second }
+
+// recreateResponder answers the DeleteSubscriptions, CreateSubscription and
+// CreateMonitoredItems requests which recreateSubscription sends. newSubID is
+// the subscription id the server assigns to the recreated subscription and
+// itemStatus is the operation level status code returned for every monitored
+// item.
+func recreateResponder(newSubID uint32, itemStatus ua.StatusCode) func(ua.Request, func(ua.Response) error) error {
+	return func(req ua.Request, h func(ua.Response) error) error {
+		switch req := req.(type) {
+		case *ua.DeleteSubscriptionsRequest:
+			return h(&ua.DeleteSubscriptionsResponse{
+				ResponseHeader: &ua.ResponseHeader{},
+				Results:        []ua.StatusCode{ua.StatusOK},
+			})
+
+		case *ua.CreateSubscriptionRequest:
+			return h(&ua.CreateSubscriptionResponse{
+				ResponseHeader: &ua.ResponseHeader{},
+				SubscriptionID: newSubID,
+			})
+
+		case *ua.CreateMonitoredItemsRequest:
+			res := &ua.CreateMonitoredItemsResponse{ResponseHeader: &ua.ResponseHeader{}}
+			for i := range req.ItemsToCreate {
+				res.Results = append(res.Results, &ua.MonitoredItemCreateResult{
+					StatusCode:      itemStatus,
+					MonitoredItemID: uint32(i + 1),
+				})
+			}
+			return h(res)
+
+		default:
+			return ua.StatusBadServiceUnsupported
+		}
+	}
+}
+
+// newTestSubscription registers a subscription with one monitored item on c.
+func newTestSubscription(t *testing.T, c *Client, stub *stubClient, id uint32) *Subscription {
+	t.Helper()
+
+	sub := &Subscription{
+		SubscriptionID: id,
+		params: &SubscriptionParameters{
+			Interval:          DefaultSubscriptionInterval,
+			LifetimeCount:     DefaultSubscriptionLifetimeCount,
+			MaxKeepAliveCount: DefaultSubscriptionMaxKeepAliveCount,
+		},
+		items: map[uint32]*monitoredItem{
+			1: {
+				req: NewMonitoredItemCreateRequestWithDefaults(ua.NewNumericNodeID(0, 2258), ua.AttributeIDValue, 1),
+				res: &ua.MonitoredItemCreateResult{MonitoredItemID: 1},
+				ts:  ua.TimestampsToReturnBoth,
+			},
+		},
+		c: stub,
+	}
+
+	c.subMux.Lock()
+	defer c.subMux.Unlock()
+	require.NoError(t, c.registerSubscription_NeedsSubMuxLock(sub))
+	return sub
+}
+
+// TestRepublishOrRecreateSubscriptions covers the restoreSubscriptions step of
+// the reconnect state machine.
+//
+// The regression it guards against is #876: when a subscription could not be
+// recreated the step used to return control to the reconnect loop with the
+// action cleared, which marked the client Connected while the subscription was
+// gone and the publish loop was dead.
+func TestRepublishOrRecreateSubscriptions(t *testing.T) {
+	// republish always fails here since the test client has neither a session
+	// nor a secure channel, so a subscription handed to it is recreated
+	// instead. See sendRepublishRequests.
+	t.Run("nothing to restore", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, nil, nil)
+		require.Equal(t, none, action)
+		require.Equal(t, 0, activeSubs)
+	})
+
+	t.Run("recreate succeeds", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: recreateResponder(4711, ua.StatusOK)}
+		newTestSubscription(t, c, stub, 1)
+
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, []uint32{1}, nil)
+		require.Equal(t, none, action)
+		require.Equal(t, 1, activeSubs)
+		require.Equal(t, []uint32{4711}, c.SubscriptionIDs())
+	})
+
+	// This is the #876 case. The server accepts the new subscription but
+	// rejects the monitored item because the node is gone from its address
+	// space, so recreateSubscription fails. The step has to hand
+	// recreateSession back to the reconnect loop instead of none, otherwise
+	// the loop marks the client Connected with no live subscription and never
+	// tries again.
+	t.Run("recreate fails", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		newTestSubscription(t, c, stub, 6647)
+
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, []uint32{6647}, nil)
+		require.Equal(t, recreateSession, action)
+		require.Equal(t, 0, activeSubs)
+	})
+
+	// One subscription restores fine and one does not. The failure has to win,
+	// otherwise the healthy subscription hides the broken one and the client
+	// comes up Connected with a subscription that no longer exists.
+	t.Run("one of two recreates fails", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		good := &stubClient{send: recreateResponder(4711, ua.StatusOK)}
+		bad := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		newTestSubscription(t, c, good, 1)
+		newTestSubscription(t, c, bad, 2)
+
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, []uint32{1, 2}, nil)
+		require.Equal(t, recreateSession, action)
+		require.Equal(t, 1, activeSubs)
+	})
+
+	// A subscription which the server transferred but could not republish is
+	// recreated. If that recreate fails as well the step must still ask for a
+	// new session.
+	t.Run("republish falls back to recreate", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		newTestSubscription(t, c, stub, 3)
+
+		action, _ := c.republishOrRecreateSubscriptions(context.Background(), []uint32{3}, nil, map[uint32][]uint32{3: {1}})
+		require.Equal(t, recreateSession, action)
+
+		// the subscription was recreated after the republish failed
+		var sawCreate bool
+		for _, req := range stub.sentRequests() {
+			if _, ok := req.(*ua.CreateSubscriptionRequest); ok {
+				sawCreate = true
+			}
+		}
+		require.True(t, sawCreate, "subscription was not recreated after republish failed")
+	})
+}

--- a/client_sub_test.go
+++ b/client_sub_test.go
@@ -89,6 +89,29 @@ func recreateResponder(newSubID uint32, itemStatus ua.StatusCode) func(ua.Reques
 	}
 }
 
+// rejectingRecreateResponder answers DeleteSubscriptions and then rejects
+// CreateSubscription with a service level status, so the recreate fails before
+// the replacement subscription exists.
+func rejectingRecreateResponder(status ua.StatusCode) func(ua.Request, func(ua.Response) error) error {
+	return func(req ua.Request, h func(ua.Response) error) error {
+		switch req.(type) {
+		case *ua.DeleteSubscriptionsRequest:
+			return h(&ua.DeleteSubscriptionsResponse{
+				ResponseHeader: &ua.ResponseHeader{},
+				Results:        []ua.StatusCode{ua.StatusOK},
+			})
+
+		case *ua.CreateSubscriptionRequest:
+			return h(&ua.CreateSubscriptionResponse{
+				ResponseHeader: &ua.ResponseHeader{ServiceResult: status},
+			})
+
+		default:
+			return ua.StatusBadServiceUnsupported
+		}
+	}
+}
+
 // newTestSubscription registers a subscription with one monitored item on c.
 func newTestSubscription(t *testing.T, c *Client, stub *stubClient, id uint32) *Subscription {
 	t.Helper()
@@ -205,5 +228,21 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 			}
 		}
 		require.True(t, sawCreate, "subscription was not recreated after republish failed")
+	})
+
+	// The retry the failure above asks for is only useful if the subscription
+	// is still there to retry. recreateSubscription used to forget it before
+	// creating the replacement, so a rejected create dropped it for good and
+	// the next round had nothing to transfer.
+	t.Run("failed create keeps the subscription registered", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: rejectingRecreateResponder(ua.StatusBadTooManySubscriptions)}
+		newTestSubscription(t, c, stub, 6647)
+
+		action, _ := c.republishOrRecreateSubscriptions(context.Background(), nil, []uint32{6647}, nil)
+		require.Equal(t, recreateSession, action)
+		require.Equal(t, []uint32{6647}, c.SubscriptionIDs())
 	})
 }


### PR DESCRIPTION
Resolves #876.

During auto-reconnect, the `restoreSubscriptions` case set `action = recreateSession` when `recreateSubscription` failed, but then ran `c.setState(ctx, Connected)` and `action = none` unconditionally right after the loop. The unconditional `action = none` overrode the retry, so a subscription that could not be recreated (e.g. the server returns `StatusBadNodeIDUnknown` for a node that disappeared during the outage) was silently dropped and the client was left in `Connected` state with zero active subscriptions and a dead publish loop. No data was delivered again and no further reconnection was attempted.

This change marks the client `Connected` and clears the action only when every subscription was actually restored. If a subscription failed to recreate, `action` stays `recreateSession`, so the outer reconnect loop rebuilds the session and retries.

It also waits `ReconnectInterval` before retrying. Without the delay, a subscription that can never be restored (a permanently removed node) made the `recreateSession` -> `transferSubscriptions` -> `restoreSubscriptions` cycle hot-loop and hammer the server, since that path has no backoff of its own. The wait reuses the same interval as the `createSecureChannel` Dial loop and returns early if the context is cancelled.

The retry only helps if the subscription is still there to retry, and it was not. `recreateSubscription` forgot the subscription before creating its replacement, so a rejected `CreateSubscription` dropped it from `c.subs` for good, the next round had nothing to transfer, and the client came up `Connected` with zero subscriptions anyway. The last commit forgets the old id only once the replacement exists. `recreate_create` assigns the new id on success, so the old id captured by the caller is still the right key to forget, and a failure now leaves the subscription registered for the next attempt.

To make any of this testable, the `restoreSubscriptions` body moved out of the `monitor` switch into `(*Client).republishOrRecreateSubscriptions`, which returns the next reconnect action. Subscriptions already reach the client through `ClientInterface`, so the tests inject a stub server rather than needing a real one. `TestRepublishOrRecreateSubscriptions` covers nothing to restore, a successful recreate, a failed recreate, one of two subscriptions failing, a republish falling back to a recreate, and a failed create keeping the subscription registered. Reverting either fix breaks the corresponding cases.

Note this makes a subscription that can never be recreated retry forever at `ReconnectInterval` rather than being dropped once. That matches the `createSecureChannel` Dial loop, and it is the point of the change, but it is a behaviour change worth calling out.

Same class of bug as #854 / #855, on the `restoreSubscriptions` path instead of `restoreSession`.
