### PR TITLE
Bound array element count against remaining buffer in decodeSlice

### DIFF
--- a/ua/decode.go
+++ b/ua/decode.go
@@ -144,6 +144,17 @@ func decodeSlice(b []byte, val reflect.Value, name string) (int, error) {
 	}
 
 	pos := buf.Pos()
+
+	// The element count comes straight off the wire and the only prior check is
+	// n > math.MaxInt32, so a tiny message can still declare hundreds of millions
+	// of elements and force a huge MakeSlice before any element byte is read. Each
+	// element occupies at least one byte on the wire, so a count larger than the
+	// bytes remaining can never be satisfied. Reject it here to keep the allocation
+	// bounded by the actual input size.
+	if int(n) > buf.Len() {
+		return pos, errors.Errorf("array length %d exceeds remaining %d bytes", n, buf.Len())
+	}
+
 	// a is a slice of []*Foo
 	a := reflect.MakeSlice(val.Type(), int(n), int(n))
 	for i := 0; i < int(n); i++ {

--- a/ua/decode_test.go
+++ b/ua/decode_test.go
@@ -6,6 +6,7 @@ package ua
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -418,4 +419,42 @@ func TestFailDecodeArray(t *testing.T) {
 	var a [2]int32
 	_, err := Decode(b, &a)
 	require.Error(t, err, "was expecting error for tryig to decode a stream of bytes with length 3 into an array of size 2")
+}
+
+func TestDecodeSliceBoundsElementCount(t *testing.T) {
+	// A slice element occupies at least one byte on the wire, so a declared
+	// element count larger than the bytes left in the buffer is impossible and
+	// must not drive a MakeSlice of that size.
+	t.Run("oversized count errors without allocating", func(t *testing.T) {
+		// Declares 100,000,000 elements but carries only the 4-byte count.
+		// Without the bound this drove an ~800MB MakeSlice before failing; the
+		// guard must reject it up front, so allocation stays tiny.
+		b := []byte{0x00, 0xe1, 0xf5, 0x05}
+		v := &struct{ S []*A }{}
+
+		var m1, m2 runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&m1)
+		_, err := Decode(b, v)
+		runtime.ReadMemStats(&m2)
+
+		require.Error(t, err, "expected error for element count exceeding remaining bytes")
+		require.Less(t, m2.TotalAlloc-m1.TotalAlloc, uint64(1<<20),
+			"decode allocated too much for a 4-byte input; the element count was not bounded")
+	})
+
+	t.Run("valid small slice still decodes", func(t *testing.T) {
+		b := []byte{
+			// len = 2
+			0x02, 0x00, 0x00, 0x00,
+			// A{V:1}
+			0x01, 0x00, 0x00, 0x00,
+			// A{V:2}
+			0x02, 0x00, 0x00, 0x00,
+		}
+		v := &struct{ S []*A }{}
+		_, err := Decode(b, v)
+		require.NoError(t, err)
+		require.Equal(t, []*A{{V: 1}, {V: 2}}, v.S)
+	})
 }


### PR DESCRIPTION
I look at OPC-UA message parsing from a supply-chain-security angle, so this is a decoder-hardening fix on untrusted input.

`decodeSlice` in `ua/decode.go` reads the array element count as a uint32 straight off the wire. The only sanity check before it builds the slice is `n > math.MaxInt32`, which still allows counts up to ~2.1 billion. It then calls `reflect.MakeSlice(val.Type(), int(n), int(n))` and allocates the whole slice before reading a single element byte, with nothing tying the count to how much data is actually left in the message.

Because a slice element is always at least one byte on the wire, a count larger than the bytes remaining can never be satisfied. But nothing stops the allocation from running first. A 4-byte body that declares 100,000,000 elements makes the decoder allocate about 800 MB before it fails with EOF; a count near MaxInt32 pushes that into multi-GB / OOM territory. This is reachable through normal message types whose arrays have no generated Decode (for example `ReadRequest.NodesToRead`, a `[]*ReadValueID`), and it hits both a server decoding a client request and a client decoding a server/MITM response.

The fix adds one bound before `MakeSlice`: if the declared count is greater than the bytes remaining in the buffer, return an error instead of allocating. Since each element needs at least one byte, this can never reject a legitimate message, and the allocation is now capped by the actual input size.

I added a test in `ua/decode_test.go` covering both sides: a 4-byte input declaring a huge count now errors without a large allocation (it measures allocation and asserts it stays small, so it fails on the old code where ~800 MB is allocated), and a normal small slice still decodes to the expected values. `go test ./ua` passes. The one failing test I saw in the full run, `uacp.TestResolveEndpoint`, is a DNS-resolution test unrelated to this change and fails only because of NAT64 in my local network.
