### PR TITLE
treat a rejected monitored item as an item level result when recreating a subscription

### DIFF
--- a/client_sub_test.go
+++ b/client_sub_test.go
@@ -91,7 +91,8 @@ func recreateResponder(newSubID uint32, itemStatus ua.StatusCode) func(ua.Reques
 
 // rejectingRecreateResponder answers DeleteSubscriptions and then rejects
 // CreateSubscription with a service level status, so the recreate fails before
-// the replacement subscription exists.
+// the replacement subscription exists. A monitored item the server rejects is
+// not enough to fail a recreate, see recreate_monitoredItems.
 func rejectingRecreateResponder(status ua.StatusCode) func(ua.Request, func(ua.Response) error) error {
 	return func(req ua.Request, h func(ua.Response) error) error {
 		switch req.(type) {
@@ -172,9 +173,8 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 		require.Equal(t, []uint32{4711}, c.SubscriptionIDs())
 	})
 
-	// This is the #876 case. The server accepts the new subscription but
-	// rejects the monitored item because the node is gone from its address
-	// space, so recreateSubscription fails. The step has to hand
+	// This is the #876 case: the subscription cannot be brought back, here
+	// because the server refuses to create it. The step has to hand
 	// recreateSession back to the reconnect loop instead of none, otherwise
 	// the loop marks the client Connected with no live subscription and never
 	// tries again.
@@ -182,7 +182,7 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 		c, err := NewClient("opc.tcp://example.com:4840")
 		require.NoError(t, err)
 
-		stub := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		stub := &stubClient{send: rejectingRecreateResponder(ua.StatusBadTooManySubscriptions)}
 		newTestSubscription(t, c, stub, 6647)
 
 		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, []uint32{6647}, nil)
@@ -198,7 +198,7 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 		require.NoError(t, err)
 
 		good := &stubClient{send: recreateResponder(4711, ua.StatusOK)}
-		bad := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		bad := &stubClient{send: rejectingRecreateResponder(ua.StatusBadTooManySubscriptions)}
 		newTestSubscription(t, c, good, 1)
 		newTestSubscription(t, c, bad, 2)
 
@@ -214,7 +214,7 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 		c, err := NewClient("opc.tcp://example.com:4840")
 		require.NoError(t, err)
 
-		stub := &stubClient{send: recreateResponder(8581, ua.StatusBadNodeIDUnknown)}
+		stub := &stubClient{send: rejectingRecreateResponder(ua.StatusBadTooManySubscriptions)}
 		newTestSubscription(t, c, stub, 3)
 
 		action, _ := c.republishOrRecreateSubscriptions(context.Background(), []uint32{3}, nil, map[uint32][]uint32{3: {1}})

--- a/subscription.go
+++ b/subscription.go
@@ -3,6 +3,7 @@ package opcua
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -501,7 +502,10 @@ func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 		for i, item := range items {
 			result := res.Results[i]
 			if status := result.StatusCode; status != ua.StatusOK {
-				dlog.Printf("dropping monitored item %s: %v", monitoredNodeID(item), status)
+				// not dlog: losing a monitored item across a reconnect is
+				// data the caller stops receiving, so it has to be visible
+				// without debug logging turned on.
+				log.Printf("sub %d: dropping monitored item %s on recreate: %v", s.SubscriptionID, monitoredNodeID(item), status)
 				continue
 			}
 			restored[result.MonitoredItemID] = &monitoredItem{
@@ -517,7 +521,7 @@ func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 	s.itemsMu.Unlock()
 
 	if len(restored) != prevCount {
-		dlog.Printf("subscription recreated with %d of %d monitored items", len(restored), prevCount)
+		dlog.Printf("recreated with %d of %d monitored items", len(restored), prevCount)
 		return nil
 	}
 	dlog.Printf("subscription successfully recreated")

--- a/subscription.go
+++ b/subscription.go
@@ -453,6 +453,13 @@ func (s *Subscription) recreate_create(ctx context.Context) error {
 
 // recreate_monitoredItems restores monitored items after the recreated
 // subscription has been registered by the client.
+//
+// Part 4, 5.13.2 defines the status code of a MonitoredItemCreateResult as an
+// operation level result for that item: "Monitored Nodes can be removed from
+// the AddressSpace after the creation of a MonitoredItem. This does not affect
+// the validity of the MonitoredItem". An item the server rejects, e.g. with
+// Bad_NodeIdUnknown because the node is gone, therefore does not fail the
+// restore. It is dropped and logged and the remaining items are restored.
 func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 	dlog := debug.NewPrefixLogger("sub %d: recreate_monitoredItems: ", s.SubscriptionID)
 
@@ -462,8 +469,12 @@ func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 	for _, mi := range s.items {
 		itemsByTimestamps[mi.ts] = append(itemsByTimestamps[mi.ts], mi.req)
 	}
-	s.items = make(map[uint32]*monitoredItem, len(s.items))
+	prevCount := len(s.items)
 	s.itemsMu.Unlock()
+
+	// the previous items stay in place until every request has been answered so
+	// that a failed request leaves them for the next reconnect attempt to send.
+	restored := make(map[uint32]*monitoredItem, prevCount)
 
 	for ts, items := range itemsByTimestamps {
 		req := &ua.CreateMonitoredItemsRequest{
@@ -481,23 +492,43 @@ func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 			return err
 		}
 
-		for _, result := range res.Results {
-			if status := result.StatusCode; status != ua.StatusOK {
-				return status
-			}
+		// Part 4, 5.13.2.2: the size and order of the results match the size
+		// and order of itemsToCreate.
+		if len(res.Results) != len(items) {
+			return errors.Errorf("sub %d: got %d results for %d monitored items", s.SubscriptionID, len(res.Results), len(items))
 		}
 
-		s.itemsMu.Lock()
 		for i, item := range items {
-			s.items[res.Results[i].MonitoredItemID] = &monitoredItem{
+			result := res.Results[i]
+			if status := result.StatusCode; status != ua.StatusOK {
+				dlog.Printf("dropping monitored item %s: %v", monitoredNodeID(item), status)
+				continue
+			}
+			restored[result.MonitoredItemID] = &monitoredItem{
 				req: item,
-				res: res.Results[i],
+				res: result,
 				ts:  ts,
 			}
 		}
-		s.itemsMu.Unlock()
+	}
+
+	s.itemsMu.Lock()
+	s.items = restored
+	s.itemsMu.Unlock()
+
+	if len(restored) != prevCount {
+		dlog.Printf("subscription recreated with %d of %d monitored items", len(restored), prevCount)
+		return nil
 	}
 	dlog.Printf("subscription successfully recreated")
 
 	return nil
+}
+
+// monitoredNodeID returns the node id a monitored item watches for logging.
+func monitoredNodeID(item *ua.MonitoredItemCreateRequest) *ua.NodeID {
+	if item == nil || item.ItemToMonitor == nil {
+		return nil
+	}
+	return item.ItemToMonitor.NodeID
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -1,9 +1,11 @@
 package opcua
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gopcua/opcua/ua"
+	"github.com/stretchr/testify/require"
 )
 
 // Running tool: /Users/frank/sdk/go1.17.1/bin/go test -benchmem -run=^$ -bench ^BenchmarkUnmonitorItems$ github.com/gopcua/opcua
@@ -102,5 +104,119 @@ func BenchmarkUnmonitorItems(b *testing.B) {
 		}
 
 		b.Log("src", len(src)) // ensure src and dst are not GC'ed
+	})
+}
+
+// monitoredItemsResponder answers a CreateMonitoredItems request with a status
+// per node id, defaulting to StatusOK. Accepted items get sequential ids
+// starting at 100 so a dropped item cannot be mistaken for an accepted one.
+func monitoredItemsResponder(statusByNode map[string]ua.StatusCode) func(ua.Request, func(ua.Response) error) error {
+	return func(req ua.Request, h func(ua.Response) error) error {
+		r, ok := req.(*ua.CreateMonitoredItemsRequest)
+		if !ok {
+			return ua.StatusBadServiceUnsupported
+		}
+
+		res := &ua.CreateMonitoredItemsResponse{ResponseHeader: &ua.ResponseHeader{}}
+		var nextID uint32 = 100
+		for _, item := range r.ItemsToCreate {
+			status, ok := statusByNode[item.ItemToMonitor.NodeID.String()]
+			if !ok {
+				status = ua.StatusOK
+			}
+			result := &ua.MonitoredItemCreateResult{StatusCode: status}
+			if status == ua.StatusOK {
+				result.MonitoredItemID = nextID
+				nextID++
+			}
+			res.Results = append(res.Results, result)
+		}
+		return h(res)
+	}
+}
+
+// newSubscriptionWithItems builds an unregistered subscription monitoring the
+// given nodes, as it would look after a successful Monitor call.
+func newSubscriptionWithItems(stub *stubClient, nodes ...*ua.NodeID) *Subscription {
+	sub := &Subscription{
+		SubscriptionID: 1,
+		params:         &SubscriptionParameters{Interval: DefaultSubscriptionInterval},
+		items:          map[uint32]*monitoredItem{},
+		c:              stub,
+	}
+	for i, node := range nodes {
+		id := uint32(i + 1)
+		sub.items[id] = &monitoredItem{
+			req: NewMonitoredItemCreateRequestWithDefaults(node, ua.AttributeIDValue, id),
+			res: &ua.MonitoredItemCreateResult{MonitoredItemID: id},
+			ts:  ua.TimestampsToReturnBoth,
+		}
+	}
+	return sub
+}
+
+// TestRecreateMonitoredItems covers #886.
+//
+// Part 4, 5.13.2 makes the status of a MonitoredItemCreateResult an operation
+// level result for that item, so a node the server rejects must not take the
+// whole subscription down with it. recreate_monitoredItems used to clear
+// s.items up front and return the first bad status, which left the recreated
+// subscription registered but monitoring nothing.
+func TestRecreateMonitoredItems(t *testing.T) {
+	gone := ua.NewStringNodeID(2, "gone")
+	alive := ua.NewStringNodeID(2, "alive")
+
+	t.Run("keeps the items the server accepted", func(t *testing.T) {
+		stub := &stubClient{send: monitoredItemsResponder(map[string]ua.StatusCode{
+			gone.String(): ua.StatusBadNodeIDUnknown,
+		})}
+		sub := newSubscriptionWithItems(stub, gone, alive)
+
+		require.NoError(t, sub.recreate_monitoredItems(context.Background()))
+
+		require.Len(t, sub.items, 1)
+		for _, item := range sub.items {
+			require.Equal(t, alive.String(), item.req.ItemToMonitor.NodeID.String())
+			require.Equal(t, ua.StatusOK, item.res.StatusCode)
+		}
+	})
+
+	t.Run("every item rejected", func(t *testing.T) {
+		stub := &stubClient{send: monitoredItemsResponder(map[string]ua.StatusCode{
+			gone.String():  ua.StatusBadNodeIDUnknown,
+			alive.String(): ua.StatusBadNodeIDUnknown,
+		})}
+		sub := newSubscriptionWithItems(stub, gone, alive)
+
+		// the subscription itself is still valid, so the restore succeeds
+		require.NoError(t, sub.recreate_monitoredItems(context.Background()))
+		require.Empty(t, sub.items)
+	})
+
+	// A failed request tells us nothing about the items, so they have to stay
+	// in place for the next reconnect attempt to send.
+	t.Run("request error keeps the previous items", func(t *testing.T) {
+		stub := &stubClient{send: func(ua.Request, func(ua.Response) error) error {
+			return ua.StatusBadServerNotConnected
+		}}
+		sub := newSubscriptionWithItems(stub, gone, alive)
+
+		require.Equal(t, ua.StatusBadServerNotConnected, sub.recreate_monitoredItems(context.Background()))
+		require.Len(t, sub.items, 2)
+	})
+
+	// Part 4, 5.13.2.2: the results match the size and order of itemsToCreate.
+	// Indexing them against the requested items would panic otherwise.
+	t.Run("result count mismatch", func(t *testing.T) {
+		stub := &stubClient{send: func(req ua.Request, h func(ua.Response) error) error {
+			return h(&ua.CreateMonitoredItemsResponse{
+				ResponseHeader: &ua.ResponseHeader{},
+				Results:        []*ua.MonitoredItemCreateResult{{MonitoredItemID: 100}},
+			})
+		}}
+		sub := newSubscriptionWithItems(stub, gone, alive)
+
+		require.Error(t, sub.recreate_monitoredItems(context.Background()))
+		require.Len(t, sub.items, 2)
 	})
 }


### PR DESCRIPTION
Resolves #886. Stacked on #877, so please merge that one first. Only the last two commits belong to this PR.

`recreate_monitoredItems` cleared `s.items` before sending `CreateMonitoredItems` and only refilled it after a fully good response, returning the first bad `MonitoredItemCreateResult` status as the error for the whole restore. A single node that had gone from the server's address space therefore dropped every monitored item on the subscription, including the ones the server had just accepted. The recreated subscription stayed registered under its new id but monitored nothing, so it never delivered data again.

Part 4, 5.13.2 defines that status as an operation level result for that item: "Monitored Nodes can be removed from the AddressSpace after the creation of a MonitoredItem. This does not affect the validity of the MonitoredItem but a Bad_NodeIdUnknown shall be returned in the Publish response." UA-.NETStandard (`MonitoredItem.SetCreateResult`), node-opcua (`recreateSubscriptionAndMonitoredItem`) and open62541 (`ua_client_subscriptions.c`) all record it against the individual item and keep the subscription.

This change builds the restored item map locally and swaps it in at the end, so a failed request leaves the previous items in place for the next reconnect attempt to send. A rejected item is dropped and the rest are restored. Rejected items are not kept, because `s.items` is keyed by the server assigned `MonitoredItemID`, which is zero for a rejected item, so keeping them would collide and would hand `Unmonitor` and `ModifyMonitoredItems` an id the server does not have.

The drop is reported with `log.Printf`, not the debug logger. Losing a monitored item across a reconnect means the caller silently stops receiving that node, so it has to be visible without turning debug logging on. `sendRepublishRequests` already warns at that level for its retransmission buffer check.

It also guards the result count. The old code indexed `res.Results` against the requested items and would have panicked on a short response.

`TestRecreateMonitoredItems` covers four cases: accepted items survive alongside a rejected one, an all-rejected response still succeeds with an empty item set, a request error leaves the previous items in place, and a short result list returns an error instead of panicking. All four fail against the previous implementation.

The reconnect tests from #877 needed one adjustment. Their recreate failed on a rejected monitored item, which is exactly what no longer fails a recreate, so they now fail it at `CreateSubscription` instead. They still pin the state machine bug they were written for.

Together with #877 this closes the loop on #876: the reconnect loop retries instead of reporting `Connected` after a failed restore, the subscription survives to be retried, and a restore no longer throws away the monitored items that did come back.

Not covered here: `Monitor`, the initial create path, stores a rejected item under id 0, so two rejected items collide there. That is pre-existing and separate, happy to take it in a follow-up if you want it.
