### PR TITLE
monitor: extract testable request builders and document ClientHandle ownership

### DIFF
--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -7,6 +7,7 @@ import (
 
 func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequest {
 	request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
+	request.MonitoringMode = node.MonitoringMode
 
 	if node.MonitoringParameters != nil {
 		params := *node.MonitoringParameters

--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -8,9 +8,11 @@ import (
 func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequest {
 	request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
 
-	params := *node.MonitoringParameters
-	params.ClientHandle = handle
-	request.RequestedParameters = &params
+	if node.MonitoringParameters != nil {
+		params := *node.MonitoringParameters
+		params.ClientHandle = handle
+		request.RequestedParameters = &params
+	}
 
 	return request
 }

--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -17,3 +17,29 @@ func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequ
 
 	return request
 }
+
+func buildModifyRequests(nodes []Request, items []Item) []*ua.MonitoredItemModifyRequest {
+	requests := make([]*ua.MonitoredItemModifyRequest, 0)
+
+	for _, node := range nodes {
+		for _, item := range items {
+			if item.nodeID.String() != node.NodeID.String() {
+				continue
+			}
+
+			if node.MonitoringParameters == nil {
+				break
+			}
+
+			params := *node.MonitoringParameters
+			params.ClientHandle = item.handle
+			requests = append(requests, &ua.MonitoredItemModifyRequest{
+				MonitoredItemID:     item.id,
+				RequestedParameters: &params,
+			})
+			break
+		}
+	}
+
+	return requests
+}

--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -1,0 +1,16 @@
+package monitor
+
+import (
+	"github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/ua"
+)
+
+func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequest {
+	request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
+
+	params := *node.MonitoringParameters
+	params.ClientHandle = handle
+	request.RequestedParameters = &params
+
+	return request
+}

--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -5,10 +5,9 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
-// buildCreateRequest returns the create request for one node, with handle as
-// its ClientHandle. node.MonitoringParameters is copied, never written to.
-// The copy is shallow, so Filter stays shared with the caller; node.NodeID is
-// likewise retained by reference in the returned request.
+// buildCreateRequest builds a create request with the given handle. The
+// MonitoringParameters copy is shallow: Filter and node.NodeID stay aliased
+// with the caller's values.
 func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequest {
 	request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
 	request.MonitoringMode = node.MonitoringMode
@@ -22,10 +21,7 @@ func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequ
 	return request
 }
 
-// buildModifyRequests returns the modify requests for the given nodes, resolving
-// each node to its already-monitored item by NodeID. Nodes with nil
-// MonitoringParameters, and nodes matching no item, are skipped. A node matching
-// more than one item yields one request, naming the first match in items.
+// buildModifyRequests skips nodes with nil parameters or no matching item.
 func buildModifyRequests(nodes []Request, items []Item) []*ua.MonitoredItemModifyRequest {
 	requests := make([]*ua.MonitoredItemModifyRequest, 0)
 

--- a/monitor/builders.go
+++ b/monitor/builders.go
@@ -5,6 +5,10 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
+// buildCreateRequest returns the create request for one node, with handle as
+// its ClientHandle. node.MonitoringParameters is copied, never written to.
+// The copy is shallow, so Filter stays shared with the caller; node.NodeID is
+// likewise retained by reference in the returned request.
 func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequest {
 	request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
 	request.MonitoringMode = node.MonitoringMode
@@ -18,6 +22,10 @@ func buildCreateRequest(node Request, handle uint32) *ua.MonitoredItemCreateRequ
 	return request
 }
 
+// buildModifyRequests returns the modify requests for the given nodes, resolving
+// each node to its already-monitored item by NodeID. Nodes with nil
+// MonitoringParameters, and nodes matching no item, are skipped. A node matching
+// more than one item yields one request, naming the first match in items.
 func buildModifyRequests(nodes []Request, items []Item) []*ua.MonitoredItemModifyRequest {
 	requests := make([]*ua.MonitoredItemModifyRequest, 0)
 

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -1,0 +1,72 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/gopcua/opcua/ua"
+)
+
+func TestBuildCreateRequestKeepsCallerParameters(t *testing.T) {
+	filter := &ua.ExtensionObject{}
+	// Every value differs from the constructor's defaults (SamplingInterval 0,
+	// QueueSize 10, DiscardOldest true, Filter nil), so a request that ignored
+	// the caller cannot pass by coincidence.
+	caller := &ua.MonitoringParameters{
+		SamplingInterval: 250,
+		QueueSize:        42,
+		DiscardOldest:    false,
+		Filter:           filter,
+	}
+	node := Request{
+		NodeID:               ua.NewNumericNodeID(0, 2258),
+		MonitoringParameters: caller,
+	}
+
+	got := buildCreateRequest(node, 7).RequestedParameters
+
+	if got.SamplingInterval != 250 {
+		t.Errorf("SamplingInterval = %v, want 250", got.SamplingInterval)
+	}
+	if got.QueueSize != 42 {
+		t.Errorf("QueueSize = %d, want 42", got.QueueSize)
+	}
+	if got.DiscardOldest {
+		t.Error("DiscardOldest = true, want false")
+	}
+	if got.Filter != filter {
+		t.Errorf("Filter = %v, want the caller's filter", got.Filter)
+	}
+	if got.ClientHandle != 7 {
+		t.Errorf("ClientHandle = %d, want 7", got.ClientHandle)
+	}
+}
+
+// This test is a regression guard for issue #880, not a driver: it passes
+// against the first stub of buildCreateRequest and must keep passing.
+func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {
+	shared := &ua.MonitoringParameters{SamplingInterval: 100, QueueSize: 5}
+	before := *shared
+	node := Request{
+		NodeID:               ua.NewNumericNodeID(0, 2258),
+		MonitoringParameters: shared,
+	}
+
+	first := buildCreateRequest(node, 11)
+	second := buildCreateRequest(node, 12)
+
+	if *shared != before {
+		t.Errorf("caller's parameters = %+v, want them untouched at %+v", *shared, before)
+	}
+	if first.RequestedParameters == shared || second.RequestedParameters == shared {
+		t.Error("request aliases the caller's parameters, want a copy")
+	}
+	if first.RequestedParameters == second.RequestedParameters {
+		t.Error("both requests share one parameters struct, want one per call")
+	}
+	if first.RequestedParameters.ClientHandle != 11 {
+		t.Errorf("first ClientHandle = %d, want 11", first.RequestedParameters.ClientHandle)
+	}
+	if second.RequestedParameters.ClientHandle != 12 {
+		t.Errorf("second ClientHandle = %d, want 12", second.RequestedParameters.ClientHandle)
+	}
+}

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -41,6 +41,28 @@ func TestBuildCreateRequestKeepsCallerParameters(t *testing.T) {
 	}
 }
 
+func TestBuildCreateRequestWithNilParametersUsesDefaults(t *testing.T) {
+	node := Request{NodeID: ua.NewNumericNodeID(0, 2258)}
+
+	got := buildCreateRequest(node, 9).RequestedParameters
+
+	if got.ClientHandle != 9 {
+		t.Errorf("ClientHandle = %d, want 9", got.ClientHandle)
+	}
+	if got.QueueSize != 10 {
+		t.Errorf("QueueSize = %d, want the default 10", got.QueueSize)
+	}
+	if !got.DiscardOldest {
+		t.Error("DiscardOldest = false, want the default true")
+	}
+	if got.SamplingInterval != 0 {
+		t.Errorf("SamplingInterval = %v, want the default 0", got.SamplingInterval)
+	}
+	if got.Filter != nil {
+		t.Errorf("Filter = %v, want the default nil", got.Filter)
+	}
+}
+
 // This test is a regression guard for issue #880, not a driver: it passes
 // against the first stub of buildCreateRequest and must keep passing.
 func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -63,6 +63,19 @@ func TestBuildCreateRequestWithNilParametersUsesDefaults(t *testing.T) {
 	}
 }
 
+func TestBuildCreateRequestKeepsCallerMonitoringMode(t *testing.T) {
+	node := Request{
+		NodeID:         ua.NewNumericNodeID(0, 2258),
+		MonitoringMode: ua.MonitoringModeSampling,
+	}
+
+	got := buildCreateRequest(node, 3).MonitoringMode
+
+	if got != ua.MonitoringModeSampling {
+		t.Errorf("MonitoringMode = %v, want %v", got, ua.MonitoringModeSampling)
+	}
+}
+
 // This test is a regression guard for issue #880, not a driver: it passes
 // against the first stub of buildCreateRequest and must keep passing.
 func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -105,3 +105,128 @@ func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {
 		t.Errorf("second ClientHandle = %d, want 12", second.RequestedParameters.ClientHandle)
 	}
 }
+
+func TestBuildModifyRequestsStampsExistingHandleOnACopy(t *testing.T) {
+	nodeID := ua.NewNumericNodeID(0, 2258)
+	caller := &ua.MonitoringParameters{SamplingInterval: 500, QueueSize: 3}
+	before := *caller
+	items := []Item{{id: 77, nodeID: nodeID, handle: 55}}
+
+	got := buildModifyRequests([]Request{{NodeID: nodeID, MonitoringParameters: caller}}, items)
+
+	if len(got) != 1 {
+		t.Fatalf("built %d requests, want 1", len(got))
+	}
+	if got[0].MonitoredItemID != 77 {
+		t.Errorf("MonitoredItemID = %d, want 77", got[0].MonitoredItemID)
+	}
+	if got[0].RequestedParameters == caller {
+		t.Error("request aliases the caller's parameters, want a copy")
+	}
+	if *caller != before {
+		t.Errorf("caller's parameters = %+v, want them untouched at %+v", *caller, before)
+	}
+	if got[0].RequestedParameters.ClientHandle != 55 {
+		t.Errorf("ClientHandle = %d, want the item's existing handle 55", got[0].RequestedParameters.ClientHandle)
+	}
+	if got[0].RequestedParameters.SamplingInterval != 500 {
+		t.Errorf("SamplingInterval = %v, want 500", got[0].RequestedParameters.SamplingInterval)
+	}
+	if got[0].RequestedParameters.QueueSize != 3 {
+		t.Errorf("QueueSize = %d, want 3", got[0].RequestedParameters.QueueSize)
+	}
+}
+
+func TestBuildModifyRequestsSkipsNilParameters(t *testing.T) {
+	nodeID := ua.NewNumericNodeID(0, 2258)
+	items := []Item{{id: 77, nodeID: nodeID, handle: 55}}
+
+	got := buildModifyRequests([]Request{{NodeID: nodeID}}, items)
+
+	if len(got) != 0 {
+		t.Errorf("built %d requests, want none: a node with nil parameters has nothing to modify", len(got))
+	}
+}
+
+// The next two tests pin the control flow buildModifyRequests inherits from
+// ModifyMonitorItems. Both pass against the first stub and must keep passing:
+// they are the witness that moving the loop into a pure function changed no
+// behaviour.
+func TestBuildModifyRequestsSkipsNodesMatchingNoItem(t *testing.T) {
+	monitored := ua.NewNumericNodeID(0, 2258)
+	items := []Item{{id: 77, nodeID: monitored, handle: 55}}
+	unmonitored := Request{
+		NodeID:               ua.NewNumericNodeID(0, 2259),
+		MonitoringParameters: &ua.MonitoringParameters{SamplingInterval: 500},
+	}
+
+	got := buildModifyRequests([]Request{unmonitored}, items)
+
+	if len(got) != 0 {
+		t.Errorf("built %d requests, want none for an unmonitored node", len(got))
+	}
+}
+
+func TestBuildModifyRequestsBuildsOneRequestPerNode(t *testing.T) {
+	nodeID := ua.NewNumericNodeID(0, 2258)
+	// The same node monitored twice.
+	items := []Item{
+		{id: 77, nodeID: nodeID, handle: 55},
+		{id: 88, nodeID: nodeID, handle: 66},
+	}
+	node := Request{NodeID: nodeID, MonitoringParameters: &ua.MonitoringParameters{SamplingInterval: 500}}
+
+	got := buildModifyRequests([]Request{node}, items)
+
+	if len(got) != 1 {
+		t.Fatalf("built %d requests for one node matching two items, want 1", len(got))
+	}
+	if got[0].MonitoredItemID != 77 {
+		t.Errorf("MonitoredItemID = %d, want the first matching item 77", got[0].MonitoredItemID)
+	}
+	if got[0].RequestedParameters.ClientHandle != 55 {
+		t.Errorf("ClientHandle = %d, want the first matching item's handle 55", got[0].RequestedParameters.ClientHandle)
+	}
+}
+
+// TestBuildModifyRequestsStampsEachNodesOwnHandle requires two nodes in one call
+// to yield two requests, each carrying its own item's handle on its own copy of
+// its own parameters. One parameters struct shared by both requests would send
+// every item the last node's handle, which is the modify-side form of the defect
+// reported in issue #880; stopping after the first node would leave the second
+// node unmodified with no error.
+func TestBuildModifyRequestsStampsEachNodesOwnHandle(t *testing.T) {
+	first := ua.NewNumericNodeID(0, 2258)
+	second := ua.NewNumericNodeID(0, 2259)
+	items := []Item{
+		{id: 77, nodeID: first, handle: 55},
+		{id: 88, nodeID: second, handle: 66},
+	}
+	nodes := []Request{
+		{NodeID: first, MonitoringParameters: &ua.MonitoringParameters{SamplingInterval: 250}},
+		{NodeID: second, MonitoringParameters: &ua.MonitoringParameters{SamplingInterval: 500}},
+	}
+
+	got := buildModifyRequests(nodes, items)
+
+	if len(got) != 2 {
+		t.Fatalf("built %d requests for two monitored nodes, want 2", len(got))
+	}
+	if got[0].RequestedParameters == got[1].RequestedParameters {
+		t.Error("both requests share one parameters struct, want one per node")
+	}
+	if got[0].MonitoredItemID != 77 || got[0].RequestedParameters.ClientHandle != 55 {
+		t.Errorf("first request modifies item %d with handle %d, want item 77 with handle 55",
+			got[0].MonitoredItemID, got[0].RequestedParameters.ClientHandle)
+	}
+	if got[1].MonitoredItemID != 88 || got[1].RequestedParameters.ClientHandle != 66 {
+		t.Errorf("second request modifies item %d with handle %d, want item 88 with handle 66",
+			got[1].MonitoredItemID, got[1].RequestedParameters.ClientHandle)
+	}
+	if got[0].RequestedParameters.SamplingInterval != 250 {
+		t.Errorf("first SamplingInterval = %v, want 250", got[0].RequestedParameters.SamplingInterval)
+	}
+	if got[1].RequestedParameters.SamplingInterval != 500 {
+		t.Errorf("second SamplingInterval = %v, want 500", got[1].RequestedParameters.SamplingInterval)
+	}
+}

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -8,8 +8,7 @@ import (
 
 func TestBuildCreateRequestKeepsCallerParameters(t *testing.T) {
 	filter := &ua.ExtensionObject{}
-	// Every value differs from the constructor's defaults (SamplingInterval 0,
-	// QueueSize 10, DiscardOldest true, Filter nil), so a request that ignored
+	// All values differ from constructor defaults so a request that ignored
 	// the caller cannot pass by coincidence.
 	caller := &ua.MonitoringParameters{
 		SamplingInterval: 250,
@@ -76,11 +75,8 @@ func TestBuildCreateRequestKeepsCallerMonitoringMode(t *testing.T) {
 	}
 }
 
-// TestBuildCreateRequestDoesNotWriteCallerParameters is the guard against the
-// defect reported in issue #880: one Request used for two calls must leave the
-// caller's parameters as it found them and yield a fresh copy each time, since
-// two requests sharing one parameters struct would reach the wire carrying the
-// same handle.
+// TestBuildCreateRequestDoesNotWriteCallerParameters verifies that reusing one
+// Request produces a fresh copy each time, not a shared struct.
 func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {
 	shared := &ua.MonitoringParameters{SamplingInterval: 100, QueueSize: 5}
 	before := *shared
@@ -151,9 +147,8 @@ func TestBuildModifyRequestsSkipsNilParameters(t *testing.T) {
 	}
 }
 
-// TestBuildModifyRequestsSkipsNodesMatchingNoItem requires a node this
-// subscription does not monitor to produce no request at all, rather than one
-// naming item 0 with a zero handle.
+// TestBuildModifyRequestsSkipsNodesMatchingNoItem verifies that unmonitored
+// nodes produce no request.
 func TestBuildModifyRequestsSkipsNodesMatchingNoItem(t *testing.T) {
 	monitored := ua.NewNumericNodeID(0, 2258)
 	items := []Item{{id: 77, nodeID: monitored, handle: 55}}
@@ -169,13 +164,10 @@ func TestBuildModifyRequestsSkipsNodesMatchingNoItem(t *testing.T) {
 	}
 }
 
-// TestBuildModifyRequestsBuildsOneRequestPerNode requires one request per
-// Request value even where several monitored items carry the node's NodeID: the
-// search stops at the first match, so item 77 is modified and item 88 is left
-// alone.
+// TestBuildModifyRequestsBuildsOneRequestPerNode verifies one request per
+// Request even when multiple items share a NodeID.
 func TestBuildModifyRequestsBuildsOneRequestPerNode(t *testing.T) {
 	nodeID := ua.NewNumericNodeID(0, 2258)
-	// The same node monitored twice.
 	items := []Item{
 		{id: 77, nodeID: nodeID, handle: 55},
 		{id: 88, nodeID: nodeID, handle: 66},
@@ -195,12 +187,9 @@ func TestBuildModifyRequestsBuildsOneRequestPerNode(t *testing.T) {
 	}
 }
 
-// TestBuildModifyRequestsStampsEachNodesOwnHandle requires two nodes in one call
-// to yield two requests, each carrying its own item's handle on its own copy of
-// its own parameters. One parameters struct shared by both requests would send
-// every item the last node's handle, which is the modify-side form of the defect
-// reported in issue #880; stopping after the first node would leave the second
-// node unmodified with no error.
+// TestBuildModifyRequestsStampsEachNodesOwnHandle verifies that two nodes
+// produce two independent requests, each with its own handle and parameters
+// copy, and that both are modified.
 func TestBuildModifyRequestsStampsEachNodesOwnHandle(t *testing.T) {
 	first := ua.NewNumericNodeID(0, 2258)
 	second := ua.NewNumericNodeID(0, 2259)

--- a/monitor/builders_test.go
+++ b/monitor/builders_test.go
@@ -76,8 +76,11 @@ func TestBuildCreateRequestKeepsCallerMonitoringMode(t *testing.T) {
 	}
 }
 
-// This test is a regression guard for issue #880, not a driver: it passes
-// against the first stub of buildCreateRequest and must keep passing.
+// TestBuildCreateRequestDoesNotWriteCallerParameters is the guard against the
+// defect reported in issue #880: one Request used for two calls must leave the
+// caller's parameters as it found them and yield a fresh copy each time, since
+// two requests sharing one parameters struct would reach the wire carrying the
+// same handle.
 func TestBuildCreateRequestDoesNotWriteCallerParameters(t *testing.T) {
 	shared := &ua.MonitoringParameters{SamplingInterval: 100, QueueSize: 5}
 	before := *shared
@@ -148,10 +151,9 @@ func TestBuildModifyRequestsSkipsNilParameters(t *testing.T) {
 	}
 }
 
-// The next two tests pin the control flow buildModifyRequests inherits from
-// ModifyMonitorItems. Both pass against the first stub and must keep passing:
-// they are the witness that moving the loop into a pure function changed no
-// behaviour.
+// TestBuildModifyRequestsSkipsNodesMatchingNoItem requires a node this
+// subscription does not monitor to produce no request at all, rather than one
+// naming item 0 with a zero handle.
 func TestBuildModifyRequestsSkipsNodesMatchingNoItem(t *testing.T) {
 	monitored := ua.NewNumericNodeID(0, 2258)
 	items := []Item{{id: 77, nodeID: monitored, handle: 55}}
@@ -167,6 +169,10 @@ func TestBuildModifyRequestsSkipsNodesMatchingNoItem(t *testing.T) {
 	}
 }
 
+// TestBuildModifyRequestsBuildsOneRequestPerNode requires one request per
+// Request value even where several monitored items carry the node's NodeID: the
+// search stops at the first match, so item 77 is modified and item 88 is left
+// alone.
 func TestBuildModifyRequestsBuildsOneRequestPerNode(t *testing.T) {
 	nodeID := ua.NewNumericNodeID(0, 2258)
 	// The same node monitored twice.

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -1,3 +1,11 @@
+// Package monitor provides a high-level API for subscribing to OPC UA node
+// value changes.
+//
+// The subscription owns the ClientHandle of every monitored item: any value a
+// caller sets is ignored, and the subscription stamps its own handle on a
+// private copy, because handles are how incoming notifications are routed back
+// to nodes. Callers may therefore share one ua.MonitoringParameters across many
+// Requests.
 package monitor
 
 import (
@@ -98,8 +106,18 @@ func (m *Item) NodeID() *ua.NodeID {
 
 // Request is a struct to manage a request to monitor a node or modify a monitored node
 type Request struct {
-	NodeID               *ua.NodeID
-	MonitoringMode       ua.MonitoringMode
+	NodeID         *ua.NodeID
+	MonitoringMode ua.MonitoringMode
+
+	// MonitoringParameters carries the monitoring characteristics for this node.
+	// Any ClientHandle you set here is ignored: the subscription stamps its own
+	// handle on a private copy, so that incoming notifications can be routed
+	// back to the right node. Parameters are copied per node, so one instance
+	// may be shared across Requests.
+	//
+	// The copy is shallow. Filter is shared with the subscription and replayed
+	// on reconnect, so do not mutate the filter's contents after passing the
+	// Request. NodeID is likewise retained by reference.
 	MonitoringParameters *ua.MonitoringParameters
 }
 
@@ -322,6 +340,9 @@ func (s *Subscription) AddNodeIDs(ctx context.Context, nodes ...*ua.NodeID) erro
 }
 
 // AddMonitorItems adds nodes with monitoring parameters to the subscription
+//
+// ClientHandle in each Request's MonitoringParameters is assigned by the
+// subscription; any value set by the caller is ignored.
 func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([]Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -457,6 +478,9 @@ func (s *Subscription) RemoveMonitorItems(ctx context.Context, items ...Item) er
 }
 
 // ModifyMonitorItems modifies nodes with monitoring parameters to the subscription
+//
+// ClientHandle in each Request's MonitoringParameters is assigned by the
+// subscription; any value set by the caller is ignored.
 func (s *Subscription) ModifyMonitorItems(ctx context.Context, nodes ...Request) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -101,7 +101,6 @@ type Request struct {
 	NodeID               *ua.NodeID
 	MonitoringMode       ua.MonitoringMode
 	MonitoringParameters *ua.MonitoringParameters
-	handle               uint32
 }
 
 // Subscription is an instance of an active subscription.
@@ -334,23 +333,15 @@ func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([
 	}
 
 	toAdd := make([]*ua.MonitoredItemCreateRequest, 0)
+	allocated := make([]uint32, len(nodes))
 
 	// Add handles and make requests
 	for i, node := range nodes {
 		handle := atomic.AddUint32(&s.monitor.nextClientHandle, 1)
 		s.handles[handle] = nodes[i].NodeID
-		nodes[i].handle = handle
+		allocated[i] = handle
 
-		request := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDValue, handle)
-		request.MonitoringMode = node.MonitoringMode
-
-		if node.MonitoringParameters != nil {
-			// copy so each request owns its ClientHandle; sharing would map all items to the last node
-			params := *node.MonitoringParameters
-			params.ClientHandle = handle
-			request.RequestedParameters = &params
-		}
-		toAdd = append(toAdd, request)
+		toAdd = append(toAdd, buildCreateRequest(node, handle))
 	}
 	resp, err := s.sub.Monitor(ctx, ua.TimestampsToReturnBoth, toAdd...)
 	if err != nil {
@@ -373,12 +364,12 @@ func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([
 				Status: res.StatusCode,
 			})
 			// Clean up the handle for the failed item
-			delete(s.handles, nodes[i].handle)
+			delete(s.handles, allocated[i])
 			continue
 		}
 		mn := Item{
 			id:     res.MonitoredItemID,
-			handle: nodes[i].handle,
+			handle: allocated[i],
 			nodeID: toAdd[i].ItemToMonitor.NodeID,
 		}
 		s.itemLookup[res.MonitoredItemID] = mn
@@ -474,29 +465,12 @@ func (s *Subscription) ModifyMonitorItems(ctx context.Context, nodes ...Request)
 		return nil
 	}
 
-	toModify := make([]*ua.MonitoredItemModifyRequest, 0)
-
-	for _, node := range nodes {
-		for _, item := range s.itemLookup {
-			if item.nodeID.String() != node.NodeID.String() {
-				continue
-			}
-
-			if node.MonitoringParameters == nil {
-				break
-			}
-
-			// Copy so each request owns its parameters (see AddMonitorItems).
-			params := *node.MonitoringParameters
-			params.ClientHandle = item.handle
-			request := &ua.MonitoredItemModifyRequest{
-				MonitoredItemID:     item.id,
-				RequestedParameters: &params,
-			}
-			toModify = append(toModify, request)
-			break
-		}
+	items := make([]Item, 0, len(s.itemLookup))
+	for _, item := range s.itemLookup {
+		items = append(items, item)
 	}
+
+	toModify := buildModifyRequests(nodes, items)
 
 	resp, err := s.sub.ModifyMonitoredItems(ctx, ua.TimestampsToReturnBoth, toModify...)
 	if err != nil {

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -1,11 +1,8 @@
-// Package monitor provides a high-level API for subscribing to OPC UA node
-// value changes.
+// Package monitor provides an API for subscribing to OPC UA node value changes.
 //
-// The subscription owns the ClientHandle of every monitored item: any value a
-// caller sets is ignored, and the subscription stamps its own handle on a
-// private copy, because handles are how incoming notifications are routed back
-// to nodes. Callers may therefore share one ua.MonitoringParameters across many
-// Requests.
+// The subscription owns ClientHandles; it ignores caller values and uses them
+// to route notifications. Callers may share one ua.MonitoringParameters across
+// many Requests.
 package monitor
 
 import (
@@ -109,15 +106,12 @@ type Request struct {
 	NodeID         *ua.NodeID
 	MonitoringMode ua.MonitoringMode
 
-	// MonitoringParameters carries the monitoring characteristics for this node.
-	// Any ClientHandle you set here is ignored: the subscription stamps its own
-	// handle on a private copy, so that incoming notifications can be routed
-	// back to the right node. Parameters are copied per node, so one instance
-	// may be shared across Requests.
-	//
-	// The copy is shallow. Filter is shared with the subscription and replayed
-	// on reconnect, so do not mutate the filter's contents after passing the
-	// Request. NodeID is likewise retained by reference.
+	// MonitoringParameters holds this node's monitoring settings. Any
+	// ClientHandle you set is ignored: the subscription assigns its own on a
+	// private, shallow copy, so one instance may be shared across Requests.
+	// The copy leaves Filter and NodeID aliased with the caller; mutating
+	// either afterward is undefined, since Filter is replayed verbatim on
+	// reconnect.
 	MonitoringParameters *ua.MonitoringParameters
 }
 
@@ -339,10 +333,8 @@ func (s *Subscription) AddNodeIDs(ctx context.Context, nodes ...*ua.NodeID) erro
 	return err
 }
 
-// AddMonitorItems adds nodes with monitoring parameters to the subscription
-//
-// ClientHandle in each Request's MonitoringParameters is assigned by the
-// subscription; any value set by the caller is ignored.
+// AddMonitorItems adds monitored nodes. Any ClientHandle set in a Request is
+// ignored; the subscription assigns its own.
 func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([]Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -477,10 +469,8 @@ func (s *Subscription) RemoveMonitorItems(ctx context.Context, items ...Item) er
 	return nil
 }
 
-// ModifyMonitorItems modifies nodes with monitoring parameters to the subscription
-//
-// ClientHandle in each Request's MonitoringParameters is assigned by the
-// subscription; any value set by the caller is ignored.
+// ModifyMonitorItems modifies monitored nodes. Any ClientHandle set in a
+// Request is ignored; the subscription assigns its own.
 func (s *Subscription) ModifyMonitorItems(ctx context.Context, nodes ...Request) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -1,8 +1,9 @@
 // Package monitor provides an API for subscribing to OPC UA node value changes.
 //
-// The subscription owns ClientHandles; it ignores caller values and uses them
-// to route notifications. Callers may share one ua.MonitoringParameters across
-// many Requests.
+// The subscription owns ClientHandles: it ignores any value a caller sets and
+// assigns its own, which is how incoming notifications are matched back to
+// nodes. Callers may therefore share one ua.MonitoringParameters across many
+// Requests. See Part 4, 7.21.
 package monitor
 
 import (
@@ -107,8 +108,9 @@ type Request struct {
 	MonitoringMode ua.MonitoringMode
 
 	// MonitoringParameters holds this node's monitoring settings. Any
-	// ClientHandle you set is ignored: the subscription assigns its own on a
-	// private, shallow copy, so one instance may be shared across Requests.
+	// ClientHandle you set is ignored: Part 4, 7.21 scopes the handle to a
+	// single MonitoredItem, so the subscription assigns its own on a private,
+	// shallow copy and one instance may be shared across Requests.
 	// The copy leaves Filter and NodeID aliased with the caller; mutating
 	// either afterward is undefined, since Filter is replayed verbatim on
 	// reconnect.
@@ -334,7 +336,7 @@ func (s *Subscription) AddNodeIDs(ctx context.Context, nodes ...*ua.NodeID) erro
 }
 
 // AddMonitorItems adds monitored nodes. Any ClientHandle set in a Request is
-// ignored; the subscription assigns its own.
+// ignored; the subscription assigns its own. See Part 4, 7.21.
 func (s *Subscription) AddMonitorItems(ctx context.Context, nodes ...Request) ([]Item, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -470,7 +472,7 @@ func (s *Subscription) RemoveMonitorItems(ctx context.Context, items ...Item) er
 }
 
 // ModifyMonitorItems modifies monitored nodes. Any ClientHandle set in a
-// Request is ignored; the subscription assigns its own.
+// Request is ignored; the subscription assigns its own. See Part 4, 7.21.
 func (s *Subscription) ModifyMonitorItems(ctx context.Context, nodes ...Request) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
**Problem.** We keep splitting this codebase into pieces small enough to test on their own. `AddMonitorItems` and `ModifyMonitorItems` resist that: both build requests inline, so request construction cannot be tested without a live server. That is how #880 got in — a shared `*ua.MonitoringParameters` gave every item the last allocated handle. `Request.MonitoringParameters` also documents nothing about who owns the `ClientHandle` inside it.

**What we're shipping.**

- Extract `buildCreateRequest` and `buildModifyRequests` as unexported, test-reachable builders. Both call sites delegate to them, and the nil-parameter guards move inside.
- Add `monitor/builders_test.go` covering parameter copying, nil defaults, and unmatched nodes.
- Delete `Request.handle`. It wrote into the caller's variadic backing array, so sharing one `[]Request` across goroutines tripped the race detector.
- Document ClientHandle ownership: the subscription assigns its own on a shallow copy that leaves `Filter` and `NodeID` aliased with the caller's values.

**What we're NOT shipping.**

- No exported API change; no live-server coverage of the modify path, which the in-tree server answers with `Bad_ServiceUnsupported`.
- No unsettable `ClientHandle`. It is reachable through the generated `ua.MonitoringParameters`, so it needs a `monitor`-owned parameters type instead. Separate PR.
- No `Filter` deep copy; it stays shared.
- No defined pick when a node matches several monitored items; map order decides, as before.
- No changelog entry.