### PR TITLE
server, subscription: renumber MonitoredItem service clauses to v1.05; correct CreateMonitoredItems cites

### DIFF
--- a/server/monitored_item_service.go
+++ b/server/monitored_item_service.go
@@ -13,7 +13,7 @@ import (
 
 // MonitoredItemService implements the MonitoredItem Service Set.
 //
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13
 type MonitoredItemService struct {
 	SubService *SubscriptionService
 	Mu         sync.Mutex
@@ -151,7 +151,12 @@ type MonitoredItem struct {
 	Mode ua.MonitoringMode
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.2
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.2
+// TODO: per-item results are never validated; every item is accepted with
+// StatusOK whether or not the node exists. Part 4 §5.13.2.4 (Table 65) defines
+// operation-level result codes such as Bad_NodeIdUnknown. Once implemented,
+// client failure-mode tests (e.g. a rejected item during subscription
+// recreation) could run against this server instead of an integration fixture.
 func (s *MonitoredItemService) CreateMonitoredItems(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.SubService.srv.cfg.logger != nil {
 		s.SubService.srv.cfg.logger.Debug("Handling %T", r)
@@ -245,7 +250,7 @@ func (s *MonitoredItemService) CreateMonitoredItems(sc *uasc.SecureChannel, r ua
 
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.3
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.3
 func (s *MonitoredItemService) ModifyMonitoredItems(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.SubService.srv.cfg.logger != nil {
 		s.SubService.srv.cfg.logger.Debug("Handling %T", r)
@@ -258,7 +263,7 @@ func (s *MonitoredItemService) ModifyMonitoredItems(sc *uasc.SecureChannel, r ua
 	return serviceUnsupported(req.RequestHeader), nil
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.4
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.4
 func (s *MonitoredItemService) SetMonitoringMode(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.SubService.srv.cfg.logger != nil {
 		s.SubService.srv.cfg.logger.Debug("Handling %T", r)
@@ -306,7 +311,7 @@ func (s *MonitoredItemService) SetMonitoringMode(sc *uasc.SecureChannel, r ua.Re
 
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.5
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.5
 func (s *MonitoredItemService) SetTriggering(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.SubService.srv.cfg.logger != nil {
 		s.SubService.srv.cfg.logger.Debug("Handling %T", r)
@@ -319,7 +324,7 @@ func (s *MonitoredItemService) SetTriggering(sc *uasc.SecureChannel, r ua.Reques
 	return serviceUnsupported(req.RequestHeader), nil
 }
 
-// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.6
+// https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.6
 func (s *MonitoredItemService) DeleteMonitoredItems(sc *uasc.SecureChannel, r ua.Request, reqID uint32) (ua.Response, error) {
 	if s.SubService.srv.cfg.logger != nil {
 		s.SubService.srv.cfg.logger.Debug("Handling %T", r)

--- a/subscription.go
+++ b/subscription.go
@@ -149,7 +149,7 @@ func (s *Subscription) Monitor(ctx context.Context, ts ua.TimestampsToReturn, it
 	stats.Subscription().Add("Monitor", 1)
 	stats.Subscription().Add("MonitoredItems", int64(len(items)))
 
-	// Part 4, 5.12.2.2 CreateMonitoredItems Service Parameters
+	// Part 4, 5.13.2.2 CreateMonitoredItems Service Parameters
 	req := &ua.CreateMonitoredItemsRequest{
 		SubscriptionID:     s.SubscriptionID,
 		TimestampsToReturn: ts,
@@ -302,7 +302,7 @@ func (s *Subscription) SetMonitoringMode(ctx context.Context, monitoringMode ua.
 func (s *Subscription) SetTriggering(ctx context.Context, triggeringItemID uint32, add, remove []uint32) (*ua.SetTriggeringResponse, error) {
 	stats.Subscription().Add("SetTriggering", 1)
 
-	// Part 4, 5.12.5.2 SetTriggering Service Parameters
+	// Part 4, 5.13.5.2 SetTriggering Service Parameters
 	req := &ua.SetTriggeringRequest{
 		SubscriptionID:   s.SubscriptionID,
 		TriggeringItemID: triggeringItemID,
@@ -455,12 +455,11 @@ func (s *Subscription) recreate_create(ctx context.Context) error {
 // recreate_monitoredItems restores monitored items after the recreated
 // subscription has been registered by the client.
 //
-// Part 4, 5.13.2 defines the status code of a MonitoredItemCreateResult as an
-// operation level result for that item: "Monitored Nodes can be removed from
-// the AddressSpace after the creation of a MonitoredItem. This does not affect
-// the validity of the MonitoredItem". An item the server rejects, e.g. with
-// Bad_NodeIdUnknown because the node is gone, therefore does not fail the
-// restore. It is dropped and logged and the remaining items are restored.
+// Part 4, 5.13.2.4 (Table 65) defines the status code of a
+// MonitoredItemCreateResult as an operation-level result for that item: an
+// item the server rejects, e.g. with Bad_NodeIdUnknown because the node is
+// gone, does not fail the restore. It is dropped and logged and the remaining
+// items are restored.
 func (s *Subscription) recreate_monitoredItems(ctx context.Context) error {
 	dlog := debug.NewPrefixLogger("sub %d: recreate_monitoredItems: ", s.SubscriptionID)
 


### PR DESCRIPTION
**Problem.** The MonitoredItem service set moved from 5.12 to 5.13 between OPC UA Part 4 v1.04 and v1.05, but the server and subscription code still carry the v1.04 numbers — and the create-monitored-items handler links to a v1.05 URL whose `5.12.2` still resolves to the *Call* service, not *CreateMonitoredItems*. Separately, the doc comment on `create_monitoredItems` quoted the 5.13.2 prose, which concerns a node removed from the address space *after* creation and reported via **Publish** — not the operation-level result code of a create for a node that is already gone.

**Shipping.**
- Renumber the MonitoredItem block (`5.12` / `5.12.2`–`5.12.6`) to `5.13` in `server/monitored_item_service.go` and `subscription.go`.
- Cite `Part 4 §5.13.2.4` (Table 65 — CreateMonitoredItems Operation Level Result Codes) in `create_monitoredItems`, replacing the trimmed 5.13.2 quote.
- Add a `TODO` to the change CreateMonitoredItems handler: per-item results are never validated, so a client cannot observe a rejected node as an operation-level status.

**Not shipping.** No behaviour change. Defining per-item status validation (the TODO) is follow-up work.

Co-Authored-By: Claude <noreply@anthropic.com>