### PR TITLE
Fix subscription reconnect and publish loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -475,7 +475,17 @@ func (c *Client) monitor(ctx context.Context) {
 						}
 						dlog.Printf("namespaces updated")
 
-						action = restoreSubscriptions
+						// Recover subscriptions via transferSubscriptions, exactly
+						// like recreateSession does. ActivateSession reactivated the
+						// same session, but after the secure channel was rebuilt real
+						// servers stop delivering notifications until the
+						// subscription is re-bound with TransferSubscriptions; a
+						// plain Republish is not enough and leaves the client
+						// Connected with a silently dead subscription.
+						// transferSubscriptions also populates
+						// subsToRepublish/subsToRecreate/availableSeqs and recreates
+						// subscriptions the server can no longer transfer.
+						action = transferSubscriptions
 
 					case recreateSession:
 						dlog.Printf("action: recreateSession")

--- a/client.go
+++ b/client.go
@@ -166,11 +166,21 @@ type Client struct {
 	// for all active subscriptions.
 	pendingAcks []*ua.SubscriptionAcknowledgement
 
-	// pausech pauses the subscription publish loop
-	pausech chan struct{}
+	// publishPaused is the single source of truth for whether the subscription
+	// publish loop should be running. pauseSubscriptions/resumeSubscriptions
+	// only ever store true/false here.
+	//
+	// It replaces the former pausech/resumech edge-triggered channels: both
+	// were read by the same select in monitorSubscriptions, so a resume racing
+	// a pause could be picked first and discarded, leaving the pause to park
+	// the loop forever. A level has no such race. See
+	// https://github.com/gopcua/opcua/issues/895.
+	publishPaused atomic.Bool
 
-	// resumech resumes subscription publish loop
-	resumech chan struct{}
+	// wakech nudges the publish loop to re-check publishPaused. It only carries
+	// a "something may have changed" hint, never state, so wake-ups are safe to
+	// coalesce or drop.
+	wakech chan struct{}
 
 	// mcancel stops subscription publish loop
 	mcancel func()
@@ -216,8 +226,7 @@ func NewClient(endpoint string, opts ...Option) (*Client, error) {
 		sechanErr:   make(chan error, 1),
 		subs:        make(map[uint32]*Subscription),
 		pendingAcks: make([]*ua.SubscriptionAcknowledgement, 0),
-		pausech:     make(chan struct{}, 2),
-		resumech:    make(chan struct{}, 2),
+		wakech:      make(chan struct{}, 1),
 		stateCh:     cfg.stateCh,
 		stateFunc:   cfg.stateFunc,
 	}

--- a/client_sub.go
+++ b/client_sub.go
@@ -48,7 +48,7 @@ func (c *Client) Subscribe(ctx context.Context, params *SubscriptionParameters, 
 	stats.Subscription().Add("Count", 1)
 
 	// start the publish loop if it isn't already running
-	c.resumech <- struct{}{}
+	c.resumeSubscriptions(ctx)
 
 	sub := &Subscription{
 		SubscriptionID:            res.SubscriptionID,
@@ -389,21 +389,28 @@ func (c *Client) notifySubscription(ctx context.Context, sub *Subscription, noti
 	}
 }
 
-// pauseSubscriptions suspends the publish loop by signalling the pausech.
+// pauseSubscriptions suspends the publish loop by setting the desired state
+// to paused and nudging the loop to notice.
 // It has no effect if the publish loop is already paused.
 func (c *Client) pauseSubscriptions(ctx context.Context) {
-	select {
-	case <-ctx.Done():
-	case c.pausech <- struct{}{}:
-	}
+	c.publishPaused.Store(true)
+	c.wake()
 }
 
-// resumeSubscriptions restarts the publish loop by signalling the resumech.
+// resumeSubscriptions restarts the publish loop by setting the desired state
+// to running and nudging the loop to notice.
 // It has no effect if the publish loop is not paused.
 func (c *Client) resumeSubscriptions(ctx context.Context) {
+	c.publishPaused.Store(false)
+	c.wake()
+}
+
+// wake nudges monitorSubscriptions to re-check publishPaused. The send is
+// non-blocking and best-effort: a wake-up already queued is enough.
+func (c *Client) wake() {
 	select {
-	case <-ctx.Done():
-	case c.resumech <- struct{}{}:
+	case c.wakech <- struct{}{}:
+	default:
 	}
 }
 
@@ -413,34 +420,30 @@ func (c *Client) monitorSubscriptions(ctx context.Context) {
 	dlog := debug.NewPrefixLogger("sub: ")
 	defer dlog.Print("done")
 
-publish:
 	for {
+		if c.publishPaused.Load() {
+			dlog.Print("pause")
+			select {
+			case <-ctx.Done():
+				dlog.Print("pause: ctx.Done()")
+				return
+
+			case <-c.wakech:
+				// Re-check publishPaused rather than assuming this wake-up
+				// means "resume". Trusting the state, not the signal, is what
+				// makes the loop immune to wake-ups being coalesced or dropped.
+				continue
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			dlog.Println("ctx.Done()")
 			return
 
-		case <-c.resumech:
-			dlog.Print("resume")
-			// ignore since not paused
-
-		case <-c.pausech:
-			dlog.Print("pause")
-			for {
-				select {
-				case <-ctx.Done():
-					dlog.Print("pause: ctx.Done()")
-					return
-
-				case <-c.resumech:
-					dlog.Print("pause: resume")
-					continue publish
-
-				case <-c.pausech:
-					dlog.Print("pause: pause")
-					// ignore since already paused
-				}
-			}
+		case <-c.wakech:
+			// state may have changed (e.g. paused again); re-check publishPaused.
+			continue
 
 		default:
 			// send publish request and handle response

--- a/client_sub_test.go
+++ b/client_sub_test.go
@@ -2,10 +2,12 @@ package opcua
 
 import (
 	"context"
+	"expvar"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gopcua/opcua/stats"
 	"github.com/gopcua/opcua/ua"
 	"github.com/stretchr/testify/require"
 )
@@ -245,4 +247,69 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 		require.Equal(t, recreateSession, action)
 		require.Equal(t, []uint32{6647}, c.SubscriptionIDs())
 	})
+}
+
+// errorCount reads the current value of the named counter in the global
+// stats.Error() expvar map, treating a missing counter as zero.
+func errorCount(key string) int64 {
+	v := stats.Error().Get(key)
+	if v == nil {
+		return 0
+	}
+	iv, ok := v.(*expvar.Int)
+	if !ok {
+		return 0
+	}
+	return iv.Value()
+}
+
+// TestMonitorSubscriptionsSurvivesPauseResumeRace guards against
+// https://github.com/gopcua/opcua/issues/895: pausech/resumech used to be two
+// buffered channels read by the same select in monitorSubscriptions. When a
+// pause and a resume were both pending -- e.g. Subscription.Cancel() followed
+// by Client.Subscribe() -- Go's select picked one at random; if the resume was
+// picked first it was discarded and the loop then parked on the pause forever.
+//
+// The level-based publishPaused plus a best-effort wake-up removes the race.
+// This test hammers pauseSubscriptions/resumeSubscriptions concurrently and
+// checks that a final resume always gets the loop running again.
+func TestMonitorSubscriptionsSurvivesPauseResumeRace(t *testing.T) {
+	c, err := NewClient("opc.tcp://example.com:4840")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.monitorSubscriptions(ctx)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	// c has no real connection, so a running loop reacts to being resumed by
+	// attempting exactly one PublishRequest, which fails immediately with
+	// StatusBadServerNotConnected (see sendWithTimeout) and re-pauses on its
+	// own. Counting this error proves the loop actually woke up and executed
+	// the publish path, rather than remaining parked forever.
+	const key = "ua.StatusBadServerNotConnected"
+	baseline := errorCount(key)
+
+	for i := 0; i < 200; i++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); c.pauseSubscriptions(ctx) }()
+		go func() { defer wg.Done(); c.resumeSubscriptions(ctx) }()
+		wg.Wait()
+
+		// Whatever order the two racing calls above landed in, make the
+		// desired end state explicit and unambiguous: the loop must run.
+		c.resumeSubscriptions(ctx)
+
+		require.Eventually(t, func() bool {
+			return errorCount(key) > baseline
+		}, time.Second, time.Millisecond, "iteration %d: publish loop appears stuck after a pause/resume race", i)
+		baseline = errorCount(key)
+	}
 }

--- a/client_sub_test.go
+++ b/client_sub_test.go
@@ -249,6 +249,58 @@ func TestRepublishOrRecreateSubscriptions(t *testing.T) {
 	})
 }
 
+// TestReconnectRecoversRegisteredSubscriptions guards against the reconnect
+// state machine (client.go) silently abandoning subscriptions.
+//
+// Both reconnect paths funnel their registered subscription ids through
+// transferSubscriptions into republishOrRecreateSubscriptions:
+//   - recreateSession builds a new session and always did so.
+//   - restoreSession reactivates the same session and now does too, because a
+//     Republish alone does not make servers resume delivery after the secure
+//     channel was rebuilt.
+//
+// If that step is handed nothing (as restoreSession used to do by jumping
+// straight to restoreSubscriptions) it returns action==none and activeSubs==0,
+// which marks the client Connected while the subscription is left registered
+// but untouched and the publish loop stays paused forever: the production hang
+// reported for short network blips.
+func TestReconnectRecoversRegisteredSubscriptions(t *testing.T) {
+	t.Run("empty input strands a registered subscription", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: recreateResponder(4711, ua.StatusOK)}
+		newTestSubscription(t, c, stub, 1)
+
+		// The regression: recovering with nothing to do leaves subscription 1
+		// registered under its old id, never republished or recreated, while
+		// the caller reads this as "everything recovered".
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), nil, nil, nil)
+
+		require.Equal(t, none, action)
+		require.Equal(t, 0, activeSubs)
+		require.Equal(t, []uint32{1}, c.SubscriptionIDs(), "subscription must not be silently abandoned")
+	})
+
+	t.Run("registered subscription ids are recovered", func(t *testing.T) {
+		c, err := NewClient("opc.tcp://example.com:4840")
+		require.NoError(t, err)
+
+		stub := &stubClient{send: recreateResponder(4711, ua.StatusOK)}
+		newTestSubscription(t, c, stub, 1)
+
+		// Fed the ids the way transferSubscriptions feeds them, the
+		// subscription is processed: republish fails (no session/channel) and
+		// falls back to recreate, so activeSubs > 0 and the reconnect loop
+		// resumes the publish loop.
+		action, activeSubs := c.republishOrRecreateSubscriptions(context.Background(), c.SubscriptionIDs(), nil, map[uint32][]uint32{})
+
+		require.Equal(t, none, action)
+		require.Greater(t, activeSubs, 0, "activeSubs must be > 0 so the publish loop is resumed")
+		require.Equal(t, []uint32{4711}, c.SubscriptionIDs(), "subscription must have been recreated, not abandoned")
+	})
+}
+
 // errorCount reads the current value of the named counter in the global
 // stats.Error() expvar map, treating a missing counter as zero.
 func errorCount(key string) int64 {


### PR DESCRIPTION
Confirmed working (logs anonymized from staging system):
```
# --- publish loop healthy before the outage ---
uasc 3/16: send *ua.PublishRequest with 110 bytes
uasc 3/16: recv *ua.PublishResponse
debug: publish: notif: 7

# --- server times out the in-flight publish; channel torn down ---
uasc 3/17: recv MSGF with 84 bytes
uasc 3/17: err: The operation timed out. StatusBadTimeout (0x800A0000)
debug: publish: error: ignoring: The operation timed out. StatusBadTimeout (0x800A0000)
debug: client: monitor: disconnected
debug: publish: eof: pausing publish loop
debug: sub: pause

# --- auto-reconnect: rebuild secure channel ---
debug: client: monitor: auto-reconnecting
debug: client: monitor: action: createSecureChannel
uasc 4/1: send *ua.OpenSecureChannelRequest
uasc 4/1: recv *ua.OpenSecureChannelResponse
debug: client: monitor: secure channel recreated

# --- same session is reactivated: this is the restoreSession path ---
debug: client: monitor: action: restoreSession
uasc 4/2: send *ua.ActivateSessionRequest
uasc 4/2: recv *ua.ActivateSessionResponse
debug: client: monitor: session restored
uasc 4/3: send *ua.ReadRequest            # UpdateNamespaces
uasc 4/3: recv *ua.ReadResponse
debug: client: monitor: namespaces updated

# --- THE FIX: restoreSession now routes through transferSubscriptions ---
gopcua reconnect: restoreSession OK -> transferSubscriptions (1 subscriptions: [6])
debug: client: monitor: action: transferSubscriptions
uasc 4/4: send *ua.TransferSubscriptionsRequest
uasc 4/4: recv *ua.TransferSubscriptionsResponse

debug: client: monitor: action: restoreSubscriptions
gopcua reconnect: restoreSubscriptions (republish=[6] recreate=[])
client_sub.go: republishing subscription 6
uasc 4/5: send *ua.RepublishRequest
uasc 4/5: err: The requested notification message is no longer available. StatusBadMessageNotAvailable (0x807B0000)
client_sub.go: Republishing subscription 6 OK

# --- connected AND publish loop resumed (was left paused before the fix) ---
state="Connected"
debug: client: monitor: resuming 1 subscriptions
gopcua reconnect: done, activeSubs=1 (publish loop RESUMED)
uasc 4/6: send *ua.PublishRequest

# --- subscription keeps delivering afterwards ---
uasc 4/6: recv *ua.PublishResponse   # SubscriptionID 6
uasc 4/7: send *ua.PublishRequest
uasc 4/7: recv *ua.PublishResponse   # SubscriptionID 6
```

Closes #895