### PR TITLE
fix: NewPrefixLogger to honor a redirected Logger output

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -25,6 +25,13 @@ var Flags = os.Getenv("OPC_DEBUG")
 var Enable bool = FlagSet("debug")
 
 // Logger logs the debug messages when debug logging is enabled.
+//
+// It defaults to writing to os.Stderr but, since it is an exported
+// *log.Logger, applications can redirect it at runtime with
+// Logger.SetOutput(w) (or replace it entirely, e.g. Logger = log.New(...)),
+// for example to route opcua debug logs through the app's own logging
+// framework. NewPrefixLogger honors the same destination since it derives
+// its writer from Logger.Writer().
 var Logger = log.New(os.Stderr, "debug: ", 0)
 
 // PrefixLogger returns a new debug logger when debug logging is enabled.
@@ -33,7 +40,7 @@ func NewPrefixLogger(format string, args ...interface{}) *log.Logger {
 	if !Enable {
 		return log.New(io.Discard, "", 0)
 	}
-	return log.New(os.Stderr, "debug: "+fmt.Sprintf(format, args...), 0)
+	return log.New(Logger.Writer(), "debug: "+fmt.Sprintf(format, args...), 0)
 }
 
 // Printf logs the message with Logger.Printf() when debug logging is enabled.

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -1,0 +1,67 @@
+// Copyright 2018-2020 opcua authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package debug
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLoggerSetOutputRedirectsPrintf ensures that redirecting Logger's
+// output via the exported Logger.SetOutput reroutes Printf away from the
+// default os.Stderr destination, so that applications can capture/redirect
+// opcua debug logs into their own logging framework.
+func TestLoggerSetOutputRedirectsPrintf(t *testing.T) {
+	origEnable := Enable
+	origWriter := Logger.Writer()
+	t.Cleanup(func() {
+		Enable = origEnable
+		Logger.SetOutput(origWriter)
+	})
+
+	Enable = true
+
+	var buf bytes.Buffer
+	Logger.SetOutput(&buf)
+
+	Printf("hello %s", "world")
+
+	if got := buf.String(); !strings.Contains(got, "hello world") {
+		t.Fatalf("expected redirected output to contain log message, got %q", got)
+	}
+}
+
+// TestLoggerSetOutputRedirectsPrefixLogger ensures loggers returned by
+// NewPrefixLogger honor a redirected output set via Logger.SetOutput.
+func TestLoggerSetOutputRedirectsPrefixLogger(t *testing.T) {
+	origEnable := Enable
+	origWriter := Logger.Writer()
+	t.Cleanup(func() {
+		Enable = origEnable
+		Logger.SetOutput(origWriter)
+	})
+
+	Enable = true
+
+	var buf bytes.Buffer
+	Logger.SetOutput(&buf)
+
+	dlog := NewPrefixLogger("test: ")
+	dlog.Printf("prefixed message")
+
+	if got := buf.String(); !strings.Contains(got, "prefixed message") {
+		t.Fatalf("expected redirected output to contain prefixed message, got %q", got)
+	}
+}
+
+// TestLoggerDefaultsToStderr documents that, without calling SetOutput, the
+// default destination remains os.Stderr for backwards compatibility.
+func TestLoggerDefaultsToStderr(t *testing.T) {
+	if Logger.Writer() != os.Stderr {
+		t.Fatalf("expected default logger writer to be os.Stderr")
+	}
+}


### PR DESCRIPTION
NewPrefixLogger hardcoded os.Stderr instead of deriving its writer from the exported Logger, so prefixed loggers (e.g. the client's 'client: monitor: ' dlog) silently ignored any redirection of debug output, even though Logger is an exported *log.Logger and can already be redirected via Logger.SetOutput(w) or replaced entirely. Now NewPrefixLogger uses Logger.Writer(), so all debug output (Printf, ToJSON, and NewPrefixLogger loggers) consistently honors whatever destination Logger currently points to.

Specific use case for that is for our production setup and for debugging #895, where I needed to redirect to another log writer, i.e., syslog in my case to collect all log messages from the gopcua library.